### PR TITLE
fix: exclude non-recipe files when loading recipes

### DIFF
--- a/forge/flake-module.nix
+++ b/forge/flake-module.nix
@@ -37,8 +37,12 @@
               # self.outPath gives us the flake root directory
               dirPath = self.outPath + "/${dir}";
 
-              # Use bundled import-tree from nix-forge inputs
-              recipeFiles = (inputs.import-tree.withLib lib).leafs dirPath;
+              recipeFiles = lib.pipe dirPath [
+                # Use bundled import-tree from nix-forge inputs
+                (inputs.import-tree.withLib lib).leafs
+                # Exclude non-recipe files
+                (lib.filter (file: lib.hasSuffix "/recipe.nix" file))
+              ];
 
               # Extend pkgs with mypkgs containing all Nix Forge packages
               # This allows recipes to reference other packages via mypkgs


### PR DESCRIPTION
Currently, any file sitting in the recipe directory will be attempted to be loaded as if it's a recipe, resulting in errors.

It's more robust to only load files which we're certain are recipes.