### PR TITLE
feat: construct packagesFilter from forge options

### DIFF
--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -27,46 +27,6 @@ in
             packagesFilter = lib.mkOption {
               internal = true;
               type = lib.types.attrsOf (lib.types.listOf lib.types.str);
-              default = {
-                standardBuilder = [
-                  "packages.*.name"
-                  "packages.*.version"
-                  "packages.*.source.git"
-                  "packages.*.source.patches"
-                  "packages.*.build.standardBuilder.enable"
-                  "packages.*.build.standardBuilder.requirements.native"
-                  "packages.*.build.standardBuilder.requirements.build"
-                  "packages.*.test.script"
-                ];
-                pythonAppBuilder = [
-                  "packages.*.name"
-                  "packages.*.version"
-                  "packages.*.source.git"
-                  "packages.*.source.patches"
-                  "packages.*.build.pythonAppBuilder.enable"
-                  "packages.*.build.pythonAppBuilder.requirements.build-system"
-                  "packages.*.build.pythonAppBuilder.requirements.dependencies"
-                  "packages.*.build.pythonAppBuilder.requirements.optional-dependencies"
-                  "packages.*.build.pythonAppBuilder.importsCheck"
-                  "packages.*.build.pythonAppBuilder.relaxDeps"
-                  "packages.*.build.pythonAppBuilder.disabledTests"
-                  "packages.*.test.script"
-                ];
-                pythonPackageBuilder = [
-                  "packages.*.name"
-                  "packages.*.version"
-                  "packages.*.source.git"
-                  "packages.*.source.patches"
-                  "packages.*.build.pythonPackageBuilder.enable"
-                  "packages.*.build.pythonPackageBuilder.requirements.build-system"
-                  "packages.*.build.pythonPackageBuilder.requirements.dependencies"
-                  "packages.*.build.pythonPackageBuilder.requirements.optional-dependencies"
-                  "packages.*.build.pythonPackageBuilder.importsCheck"
-                  "packages.*.build.pythonPackageBuilder.relaxDeps"
-                  "packages.*.build.pythonPackageBuilder.disabledTests"
-                  "packages.*.test.script"
-                ];
-              };
               description = ''
                 Defines which configuration options are relevant for each builder type.
 

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -86,5 +86,37 @@
             "services"
           ] getOptions
         );
+
+      forge.packagesFilter =
+        let
+          optionNames = lib.attrNames forgeOptions.optionsNix;
+
+          # NOTE: don't forget to update these, if they change
+          commonOptions = [
+            "packages.*.name"
+            "packages.*.version"
+            "packages.*.source.git"
+            "packages.*.source.patches"
+            "packages.*.test.script"
+          ];
+
+          filterOptions = pred: lib.filter pred optionNames;
+
+          getOptions =
+            builderType:
+            let
+              pattern = "packages\\.\\*\\.build\\.${builderType}(\\..+)?";
+              matchedOptions = filterOptions (name: lib.match pattern name != null);
+              combinedOptions = commonOptions ++ matchedOptions;
+            in
+            lib.unique combinedOptions;
+        in
+        lib.mkDefault (
+          lib.genAttrs [
+            "standardBuilder"
+            "pythonAppBuilder"
+            "pythonPackageBuilder"
+          ] getOptions
+        );
     };
 }


### PR DESCRIPTION
Similar to appsFilter refactoring in #51, dynamically generate
packagesFilter from actual module options instead of hardcoded defaults.
