### PR TITLE
chore: remove package image output

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -50,7 +50,6 @@ jobs:
         working-directory: /tmp/template-test
         run: |
           nix build .#hello-nix --accept-flake-config
-          nix build .#hello-nix.image --accept-flake-config
 
       - name: Build hello-app
         working-directory: /tmp/template-test

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ graph TB
         PO4[Nix Package]
         PO1[Development Environment]
         PO2[Shell Environment]
-        PO3[Container Image]
     end
 
     APP[Application Recipe<br/>recipe.nix]
@@ -52,14 +51,13 @@ graph TB
     end
 
     SW1 & SW2 & SW3 & NIXPKGS--> PKG
-    PKG --> PO1 & PO2 & PO3 & PO4
+    PKG --> PO1 & PO2 & PO4
 
     PO4 & NIXPKGS --> APP
     APP --> AO1
     APP --> AO2
     APP --> AO3
 
-    PO3 --> REG
     AO2 --> REG
 
     AO1 --> SHELL

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -38,7 +38,6 @@
       // allPackages
 
       # All packages passthru attributes
-      // (passthruAttr "image")
       // (passthruAttr "devenv")
       // (passthruAttr "test")
 

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -53,16 +53,6 @@ in
               buildInputs = [ finalPkg ] ++ pkg.test.requirements;
               script = pkg.test.script + "\ntouch $out";
             };
-            image = pkgs.dockerTools.buildImage {
-              name = "${pkg.name}";
-              tag = pkg.version;
-              copyToRoot = [
-                finalPkg
-              ];
-              config = {
-                Entrypoint = [ "${pkgs.bashInteractive}/bin/bash" ];
-              };
-            };
             devenv = pkgs.mkShell {
               env.DEVENV_PACKAGE_NAME = "${pkg.name}";
               env.DEVENV_PACKAGE_SOURCE = "${finalPkg.src}";


### PR DESCRIPTION
Image output is not relevant for NGI Nix Forge user. We want to provide
higher level software components (apps) to the end user.
