### PR TITLE
feat: add more package builder conditions

### DIFF
--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -258,28 +258,41 @@ in
 
             # Collect assertions from packages
             assertions = lib.flatten (
-              map (pkg: [
-                {
-                  condition = !(pkg.source.git == null && pkg.source.url == null && pkg.source.path == null);
-                  message = ''
-                    Package '${pkg.name}': one of sources options must be defined.
-                    Available options: source.git, source.url, or source.path.
-                  '';
-                }
-                (
-                  let
-                    builders = lib.filterAttrs (name: _: lib.hasSuffix "Builder" name) pkg.build;
-                    builderNames = map (name: "build." + name) (lib.attrNames builders);
-                  in
+              map (
+                pkg:
+                let
+                  builders = lib.filterAttrs (name: _: lib.hasSuffix "Builder" name) pkg.build;
+                  builderNames = map (name: "build." + name) (lib.attrNames builders);
+
+                  enabledBuilders = lib.filterAttrs (_: b: b.enable) builders;
+                  enabledBuilderNames = map (name: "build." + name) (lib.attrNames enabledBuilders);
+
+                  enabledBuildersCount = lib.length enabledBuilderNames;
+                in
+                [
                   {
-                    condition = lib.any (b: b.enable) (lib.attrValues builders);
+                    condition = !(pkg.source.git == null && pkg.source.url == null && pkg.source.path == null);
+                    message = ''
+                      Package '${pkg.name}': one of sources options must be defined.
+                      Available options: source.git, source.url, or source.path.
+                    '';
+                  }
+                  {
+                    condition = !(enabledBuildersCount != 1);
+                    message = ''
+                      Package '${pkg.name}': only one builder can be enabled at a time.
+                      Enabled options: ${lib.concatStringsSep ", " enabledBuilderNames}.
+                    '';
+                  }
+                  {
+                    condition = !(enabledBuildersCount == 0);
                     message = ''
                       Package '${pkg.name}': one of builder options must be enabled.
                       Available options: ${lib.concatStringsSep ", " builderNames}.
                     '';
                   }
-                )
-              ]) cfg
+                ]
+              ) cfg
             );
 
             # Evaluation check: show warnings first, then throw on failed assertions


### PR DESCRIPTION
Currently, we can't handle multiple builders enabled at the same time. The module system detects and fails when this is the case, but the error message it prints isn't very clear:

```shellSession
       error: The option `perSystem.x86_64-linux.packages.hello' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `/nix/store/sc8dgdrkll1ck36lswj8ka59y7jqgf6v-source/forge/modules/builders/python-package-builder.nix': <derivation python3.13-hello-2.12.1>
       - In `/nix/store/sc8dgdrkll1ck36lswj8ka59y7jqgf6v-source/forge/modules/builders/standard-builder.nix': <derivation hello-2.12.1>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

With the new condition, this becomes:

```shellSession
       error:
       Failed assertions:
       - Package 'hello': Only one builder must be enabled at a time.
       Enabled options: build.pythonPackageBuilder, build.standardBuilder.
``` 

We also refactor the existing condition for no builders set.