### PR TITLE
Add tau app

### DIFF
--- a/recipes/apps/tau-app/compose.yaml
+++ b/recipes/apps/tau-app/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  tau-tower:
+    image: localhost/tau-tower:latest
+    ports:
+      - "3001:3001"
+      - "3002:3002"
+    volumes:
+      - ./config.toml:/etc/tau/tower.toml
+      - ./password:/etc/credstore/tau.PASSWORD
+    profiles:
+      - services

--- a/recipes/apps/tau-app/config.toml
+++ b/recipes/apps/tau-app/config.toml
@@ -1,0 +1,6 @@
+ip = "127.0.0.1"
+listen_port = 3001
+mount = "tau.ogg"
+mount_port = 3002
+password = "@password@"
+username = "alice"

--- a/recipes/apps/tau-app/password
+++ b/recipes/apps/tau-app/password
@@ -1,0 +1,1 @@
+superSecretPassword

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  name = "tau-app";
+  description = "Web radio streaming system - tau-tower server and tau-radio client";
+
+  usage = ''
+    ## Tau Radio Streaming System
+
+    This app provides both the tau-tower server and tau-radio client.
+
+    ### tau-tower (Server)
+    Run as a service to broadcast audio to clients:
+    - Listens on port 3001 by default
+    - Broadcasts on port 3002 by default
+    - Configuration: ~/.config/tau/config.toml
+
+    ### tau-radio (Client)
+    Capture audio from your device and stream to tau-tower:
+    ```
+    tau-radio --username <user> --password <pass> --host <server-ip>
+    ```
+
+    ### Default Ports
+    - Server listen: 3001
+    - Broadcast: 3002
+  '';
+
+  programs = {
+    components.default = {
+      requirements = [
+        pkgs.mypkgs.tau-radio
+        pkgs.mypkgs.tau-tower
+      ];
+    };
+
+    runtimes.shell = {
+      enable = true;
+    };
+  };
+
+  services = {
+    components.tau-tower = {
+      command = pkgs.mypkgs.tau-tower;
+
+      configData."tau/tower.toml" = {
+        source = "/etc/tau/tower.toml";
+        path = "tau/tower.toml";
+      };
+
+      configData."credstore/tau.PASSWORD" = {
+        source = "/etc/credstore/tau.PASSWORD";
+        path = "tau/PASSWORD";
+      };
+    };
+
+    runtimes = {
+      container = {
+        enable = true;
+        requirements = [
+          pkgs.mypkgs.tau-tower
+          pkgs.bash
+          pkgs.coreutils
+          pkgs.gnused
+        ];
+        # NOTE: `tau` expects its config to be under `XDG_CONFIG_HOME/tau`
+        imageConfig.WorkingDir = "/tau";
+        imageConfig.Env = [ "XDG_CONFIG_HOME=/" ];
+        setup =
+          let
+            configFile = "/etc/tau/tower.toml";
+            passwordFile = "/etc/credstore/tau.PASSWORD";
+          in
+          ''
+            install -Dm600 "${configFile}" /tau/tower.toml
+            sed -i "s/@password@/$(cat "${passwordFile}")/" /tau/tower.toml
+          '';
+        composeFile = ./compose.yaml;
+      };
+
+      nixos = {
+        enable = true;
+        extraConfig =
+          let
+            configFile = "/etc/system-services/tau-tower/tau/tower.toml";
+            passwordFile = "/etc/system-services/tau-tower/credstore/tau.PASSWORD";
+          in
+          {
+            # WARN: !!! Don't use in production !!!
+            #
+            # This will copy your secrets to the Nix store, which is world-readable.
+            #
+            # Instead, manually put your secret files in the systemd credentials
+            # store (e.g. `/etc/credstore/`, `/run/credstore/`, ...).
+            #
+            # For more information on this topic, see:
+            # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#ImportCredential=GLOB
+            environment.etc."credstore/tau.PASSWORD".source = ./password;
+
+            environment.etc."tau/tower.toml".source = ./config.toml;
+
+            systemd.services.tau-tower = {
+              description = "Tau Webradio Server";
+              serviceConfig = {
+                DynamicUser = true;
+                User = "tau-tower";
+                Group = "tau-tower";
+                Restart = "on-failure";
+                RestartSec = 5;
+                StateDirectory = "tau-tower";
+                LoadCredential = [
+                  "password_file:${passwordFile}"
+                ];
+              };
+              unitConfig = {
+                StartLimitBurst = 5;
+                StartLimitInterval = 100;
+              };
+              wantedBy = [ "multi-user.target" ];
+              after = [ "network.target" ];
+              environment.XDG_CONFIG_HOME = "/var/lib/tau-tower";
+              preStart = ''
+                install -Dm600 ${configFile} $XDG_CONFIG_HOME/tau/tower.toml
+                sed -i "s/@password@/$(cat $CREDENTIALS_DIRECTORY/password_file)/" $XDG_CONFIG_HOME/tau/tower.toml
+              '';
+              postStop = ''
+                rm -f $XDG_CONFIG_HOME/tau/tower.toml
+              '';
+            };
+
+            environment.systemPackages = [
+              pkgs.mypkgs.tau-radio
+              pkgs.mypkgs.tau-tower
+            ];
+          };
+        vm.forwardPorts = [
+          "3001:3001"
+          "3002:3002"
+        ];
+      };
+    };
+  };
+
+}


### PR DESCRIPTION
Requires https://github.com/ngi-nix/forge/pull/132

```shellSession
$ nix run .#tau-app.container
$ podman load < tau-tower.tar
$ podman compose -f recipes/apps/tau-app/compose.yaml --profile services up --force-recreate
```

```shellSession
[tau-tower] | [2026-03-26T08:10:32Z INFO  nimi::cli] Launching process manager...
[tau-tower] | [2026-03-26T08:10:32Z INFO  nimi::process_manager] Starting process manager...
[tau-tower] | [2026-03-26T08:10:32Z INFO  nimi::process_manager] Running startup binary (/nix/store/01vqdp8pzspgqbbm91g8mp3nfci5lll6-setup)...
[tau-tower] | [2026-03-26T08:10:32Z DEBUG tau-tower] Broadcasting on:
[tau-tower] | [2026-03-26T08:10:32Z DEBUG tau-tower]    http://127.0.0.1:3002/tau.ogg
```

```shellSession
$ nix run .#tau-app.vm
```

```shellSession
[root@tau-tower:~]# systemctl status tau-tower.service
● tau-tower.service - Tau Webradio Server
     Loaded: loaded (/etc/systemd/system/tau-tower.service; enabled; preset: ignored)
     Active: active (running) since Thu 2026-03-26 08:13:33 UTC; 20s ago
 Invocation: 99de702582504ad1a7fc91f2f47044ec
    Process: 737 ExecStartPre=/nix/store/i7msxjcmd2h7gwl4aa3pl4ih7fvxfc76-unit-script-tau-tower-pre-start/bin/tau-tower-pre-start (code=exited, status=0/SUCCESS)
   Main PID: 751 (tau-tower)
         IP: 0B in, 0B out
         IO: 0B read, 4K written
      Tasks: 5 (limit: 2341)
     Memory: 4.5M (peak: 4.9M)
        CPU: 55ms
     CGroup: /system.slice/tau-tower.service
             └─751 /nix/store/aviinfg7ixyqw69zf4k11m4hgv1618sn-tau-tower-0.2.2-beta-unstable-2026-03-14/bin/tau-tower

Mar 26 08:13:33 tau-tower systemd[1]: Starting Tau Webradio Server...
Mar 26 08:13:33 tau-tower systemd[1]: Started Tau Webradio Server.
Mar 26 08:13:33 tau-tower tau-tower[751]: Broadcasting on:
Mar 26 08:13:33 tau-tower tau-tower[751]:         http://127.0.0.1:3002/tau.ogg
```