### PR TITLE
fix(dev): set default baseurl in html

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -59,7 +59,7 @@ jobs:
             deploy_root="/$repo_name/"
           fi
           sed -i "s|:baseUrl|$deploy_root|g" ui/src/Main/Route.elm
-          sed -i "s|:baseUrl|$deploy_root|g" ui/src/index.html
+          sed -i "s|<base href=\"/\"|<base href=\"$deploy_root\"|g" ui/src/index.html
 
       - name: Build UI
         run: nix build .#_forge-ui --accept-flake-config

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8">
 		<title>NGI Nix Forge</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<base href=":baseUrl">
+		<base href="/">
 		<link rel="stylesheet" href="css/bootstrap.min.css">
 		<link rel="stylesheet" href="css/main.css">
 		<script src="js/Elm.js" type="text/javascript" defer></script>


### PR DESCRIPTION
I was able to run local dev setup fine after #92, even with the invalid base tag but noticed today if I visit an app page directly then it fails due to it being treated as empty and thus the same as the window location.

This should fix it.