### PR TITLE
refactor(ui): rename programs to shell

### DIFF
--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -77,7 +77,7 @@ decodeAppNixosVm =
 
 
 type AppOutput
-    = AppOutput_Programs
+    = AppOutput_Shell
     | AppOutput_Container
     | AppOutput_VM
 
@@ -85,8 +85,8 @@ type AppOutput
 showAppOutput : AppOutput -> String
 showAppOutput r =
     case r of
-        AppOutput_Programs ->
-            "Programs"
+        AppOutput_Shell ->
+            "Shell"
 
         AppOutput_Container ->
             "Container"

--- a/ui/src/Main/Route.elm
+++ b/ui/src/Main/Route.elm
@@ -94,8 +94,8 @@ fromAppUrl url =
                                     |> Maybe.map
                                         (\( output, _ ) ->
                                             case output of
-                                                "programs" ->
-                                                    AppOutput_Programs
+                                                "shell" ->
+                                                    AppOutput_Shell
 
                                                 "container" ->
                                                     AppOutput_Container
@@ -104,7 +104,7 @@ fromAppUrl url =
                                                     AppOutput_VM
 
                                                 _ ->
-                                                    AppOutput_Programs
+                                                    AppOutput_Shell
                                         )
                             }
                         )
@@ -147,8 +147,8 @@ toAppUrl route =
 
                         Just output ->
                             case output of
-                                AppOutput_Programs ->
-                                    [ "programs" ]
+                                AppOutput_Shell ->
+                                    [ "shell" ]
 
                                 AppOutput_Container ->
                                     [ "container" ]

--- a/ui/src/Main/Update.elm
+++ b/ui/src/Main/Update.elm
@@ -165,7 +165,7 @@ updateRoute route model =
                                             { routeApp
                                                 | routeApp_runOutput =
                                                     [ if app.app_programs.enable then
-                                                        [ AppOutput_Programs ]
+                                                        [ AppOutput_Shell ]
 
                                                       else
                                                         []
@@ -191,7 +191,7 @@ updateRoute route model =
                             let
                                 appHasRequestedOutput =
                                     case output of
-                                        AppOutput_Programs ->
+                                        AppOutput_Shell ->
                                             app.app_programs.enable
 
                                         AppOutput_Container ->

--- a/ui/src/Main/View.elm
+++ b/ui/src/Main/View.elm
@@ -202,7 +202,7 @@ viewPageSearchApp model app =
             [ small []
                 (List.concat
                     [ if app.app_programs.enable then
-                        [ span [ class "badge bg-secondary me-1" ] [ text "programs" ] ]
+                        [ span [ class "badge bg-secondary me-1" ] [ text "shell" ] ]
 
                       else
                         []
@@ -329,7 +329,7 @@ viewPageAppRunOuputs model pageApp =
         enabled : AppOutput -> Bool
         enabled tab =
             case tab of
-                AppOutput_Programs ->
+                AppOutput_Shell ->
                     pageApp.pageApp_app.app_programs.enable
 
                 AppOutput_Container ->
@@ -339,7 +339,7 @@ viewPageAppRunOuputs model pageApp =
                     pageApp.pageApp_app.app_vm.enable
     in
     ul [ class "nav nav-pills mb-4" ]
-        ([ AppOutput_Programs
+        ([ AppOutput_Shell
          , AppOutput_Container
          , AppOutput_VM
          ]

--- a/ui/src/Main/View/Instructions.elm
+++ b/ui/src/Main/View/Instructions.elm
@@ -73,7 +73,7 @@ viewPageAppInstructions model pageApp =
                 Just output ->
                     div []
                         [ case output of
-                            AppOutput_Programs ->
+                            AppOutput_Shell ->
                                 if pageApp.pageApp_app.app_programs.enable then
                                     div []
                                         [ p [ style "margin-bottom" "0em" ] [ text "Create and enter a shell environment for (CLI, GUI) programs." ]


### PR DESCRIPTION
# Rationale

We configure programs in the application recipe and run them in the
shell environment. This is now consistent with services - we configure
services in the recipe and run them in container or VM.
