### PR TITLE
dev: clean up message when entering development environment

### DIFF
--- a/flake/develop.nix
+++ b/flake/develop.nix
@@ -35,10 +35,14 @@
             PATH="$PWD/bin:$PATH"
             {
             echo
-            echo "$(tput rev)QuickStart$(tput sgr0): run the dev-ui command"
-            echo "to get a development Web server with live reload."
-            echo "Interrupt by sending SIGINT with Ctrl-C"
-            echo "$(tput rev)Documentation$(tput sgr0): browse docs/manuals/contributor/ for more."
+            echo "Run"
+            echo
+            echo "  \$ dev-ui"
+            echo
+            echo "command to get a development web server with live reload."
+            echo "Interrupt by sending SIGINT with Ctrl-C."
+            echo
+            echo "Browse docs/manuals/contributor/ for more information."
             echo
             }
           '';


### PR DESCRIPTION
Now:

```bash
nix develop
```
```
Run

  $ dev-ui

command to get a development web server with live reload.
Interrupt by sending SIGINT with Ctrl-C.

Browse docs/manuals/contributor/ for more information.
```