### PR TITLE
fix(ui): disable ambient search when Run modal is shown

### DIFF
--- a/ui/src/Main/Subscriptions.elm
+++ b/ui/src/Main/Subscriptions.elm
@@ -14,7 +14,16 @@ subscriptions : Model -> Sub Update
 subscriptions model =
     Sub.batch
         [ Navigation.onEvent Main.Ports.Navigation.onNavEvent Update_Navigation
-        , Browser.Events.onKeyDown decodeAmbientKeyPress
+        , case model.model_page of
+            Page_App pageApp ->
+                if pageApp.pageApp_route.routeApp_runShown then
+                    Sub.none
+
+                else
+                    Browser.Events.onKeyDown decodeAmbientKeyPress
+
+            _ ->
+                Browser.Events.onKeyDown decodeAmbientKeyPress
         , case model.model_page of
             Page_App pageApp ->
                 if pageApp.pageApp_route.routeApp_runShown then
@@ -63,9 +72,6 @@ decodeAmbientKeyPress =
                         [ "INPUT"
                         , "TEXTAREA"
                         , "SELECT"
-
-                        -- When run modal is open
-                        , "DIV"
                         ]
                 , hasModifier = modifier
                 }


### PR DESCRIPTION
I did it differently previously, which worked only when the DIV (modal) was in focus. but now it should work properly.

Open the Run modal on any application page and start typing some term, should not show the search bar. Close the Run modal and type stuff it should search.

Also Esc should work as well.