### PR TITLE
ui: remove substituters configuration instruction

### DIFF
--- a/ui/src/Main/View/Instructions.elm
+++ b/ui/src/Main/View/Instructions.elm
@@ -49,13 +49,6 @@ viewInstructionsNixInstall _ =
                 , codeBlock Update_CopyCode <|
                     String.join "\n"
                         [ "export NIX_CONFIG='accept-flake-config = true'" ]
-                , p [ class "mt-3 mb-1" ]
-                    [ text "3. Configure substitutors (optional, highly recommended)" ]
-                , codeBlock Update_CopyCode <|
-                    String.join "\n"
-                        [ "export NIX_CONFIG='substituters = https://cache.nixos.org/ https://ngi.cachix.org/"
-                        , "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ngi.cachix.org-1:n+CAL72ROC3qQuLxIHpV+Tw5t42WhXmMhprAGkRSrOw='"
-                        ]
                 ]
             ]
         ]


### PR DESCRIPTION
Remove substituters configuration from Nix installation instructions.

This step is required only for old, non-Flake CLI which we currently
don't have implemented. With Flakes and new CLI, substiters are
configured in flake.nix and this configuration is enabled by previous

`export NIX_CONFIG='accept-flake-config = true'`

instruction.
