### PR TITLE
feat(deploy): add dedicated staging cachix instance for pull_requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # - name: Get more storage space
       #   uses: wimpysworld/nothing-but-nix@main
@@ -26,7 +26,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
 
-      - uses: cachix/cachix-action@v16
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ngi-forge
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,22 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
 
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+      - name: Setup Cachix (Staging)
+        if: github.event_name == 'pull_request'
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        with:
+          name: ngi-untrusted
+          extraPullNames: ngi-forge
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN_UNTRUSTED }}'
+
+      - name: Setup Cachix
+        if: github.event_name != 'pull_request'
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ngi-forge
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          extraPullNames: ngi-untrusted
+          useDaemon: false # IMPORTANT: Allows pushing substituted paths, see cachix action readme
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Run checks
         run: nix flake check --accept-flake-config

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -31,18 +31,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install nix
         uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
 
-      - uses: cachix/cachix-action@v16
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ngi-forge
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Encode version information
         run: |
@@ -66,10 +66,10 @@ jobs:
         run: nix build .#_forge-ui --accept-flake-config
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: "result"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
The purpose of this change is for prs from external forks to still leverage both caches while pushing to the untrusted one.

And cached derivations from untrusted cache will be copied to the trusted production cache after we merge the PR.

We have https://app.cachix.org/cache/ngi-untrusted for this purpose.