### PR TITLE
ui: fix container run command

### DIFF
--- a/ui/src/Main/View/Instructions.elm
+++ b/ui/src/Main/View/Instructions.elm
@@ -90,12 +90,13 @@ viewPageAppInstructions model pageApp =
                                         , codeBlock Update_CopyCode <|
                                             String.join "\n"
                                                 [ String.concat
-                                                    [ "nix run "
+                                                    [ "nix build "
                                                     , model.model_config.config_repository
                                                     , "#"
                                                     , pageApp.pageApp_app.app_name
                                                     , ".container"
                                                     ]
+                                                , "./result/bin/build-oci"
                                                 , ""
                                                 , "podman load < *.tar"
                                                 , ""


### PR DESCRIPTION
Use build instead of run otherwise we can't run the last step which is
`podman-compose --profile services --file $(pwd)/result/compose.yaml up`
because there is no `result` directory.
