### PR TITLE
feat: add packages option to apps

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -29,6 +29,16 @@
       description = "Application usage description in markdown format.";
     };
 
+    # NOTE: ideally, this should either:
+    # 1. be automatically populated from submodules (services, programs, ...)
+    # 2. populate the submodules from this option (attrsOf packages)
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.attrs;
+      default = [ ];
+      description = "Forge packages used by the application.";
+      # TODO: assert that packages are internal to the forge?
+    };
+
     # Portable services configuration
     # https://nixos.org/manual/nixos/unstable/#modular-services
     services = lib.mkOption {
@@ -86,5 +96,36 @@
       default = { };
       description = "NixOS system configuration.";
     };
+  };
+
+  config = {
+    packages =
+      let
+        service-packages = lib.flatten (
+          lib.mapAttrsToList (name: value: value.passthru.raw.command) config.services
+        );
+
+        packages = service-packages ++ config.programs.requirements ++ config.container.requirements;
+      in
+      lib.pipe packages [
+        # NOTE: `unique` has an O(n^2) complexity
+        # - would that be an issue for our usecase?
+        # - could we perhaps do better?
+        (lib.unique)
+        (map (package: {
+          inherit (package)
+            pname
+            version
+            ;
+          meta = {
+            inherit (package.meta)
+              description
+              license
+              position
+              ;
+          };
+          storePath = package.outPath;
+        }))
+      ];
   };
 }


### PR DESCRIPTION
Consider the different designs, as a list of packages:

```nix
nix-repl> apps.python-web-app.packages
[
  «derivation /nix/store/j04zmb3dpw2bzi1ivhr7r2hyhc76l7lw-python-web-0.0.1.drv»
  «derivation /nix/store/iv358n7myrhqvfry1ly0x2fd670hbzkj-curl-8.17.0.drv»
]
```

As an attribute set of packages:

```nix
nix-repl> apps.python-web-app.packages
{
  container = [ ... ];
  programs = [ ... ];
  services = [ ... ];
}

nix-repl> :p apps.python-web-app.packages
{
  container = [
    «derivation /nix/store/j04zmb3dpw2bzi1ivhr7r2hyhc76l7lw-python-web-0.0.1.drv»
  ];
  programs = [
    «derivation /nix/store/iv358n7myrhqvfry1ly0x2fd670hbzkj-curl-8.17.0.drv»
  ];
  services = [
    «repeated»
  ];
}

nix-repl> :p apps.python-web-app.packages.services
[
  «derivation /nix/store/j04zmb3dpw2bzi1ivhr7r2hyhc76l7lw-python-web-0.0.1.drv»
]
```

@phanirithvij which approach do you think is better and would ease your work in the UI?

Related: https://github.com/ngi-nix/forge/issues/71