### PR TITLE
feat: add grants option to apps

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -28,6 +28,11 @@
       default = "";
       description = "Application usage description in markdown format.";
     };
+    grants = lib.mkOption {
+      type = lib.types.submodule ./ngi/grants.nix;
+      default = { };
+      description = "NGI grants supporting this project.";
+    };
 
     # Portable services configuration
     # https://nixos.org/manual/nixos/unstable/#modular-services

--- a/forge/modules/apps/ngi/grants.nix
+++ b/forge/modules/apps/ngi/grants.nix
@@ -1,0 +1,31 @@
+/**
+  Funding that software authors receive from NLnet to support various software projects.
+  Each subgrant comes from a fund, which is in turn bound to a grant agreement with the European commission.
+
+  We track: `Commons`, `Core`, `Entrust` and `Review`.
+  While the first three are current fund themes, `Review` encompasses all non-current NGI funds (e.g. Assure, Discovery, PET, ...).
+
+  See [NLnet - Thematics Funds](https://nlnet.nl/themes/) for more information.
+*/
+{
+  lib,
+  ...
+}:
+{
+  options =
+    lib.genAttrs
+      [
+        "Commons"
+        "Core"
+        "Entrust"
+        "Review"
+      ]
+      (
+        name:
+        lib.mkOption {
+          description = "subgrants under the ${name} fund";
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+        }
+      );
+}


### PR DESCRIPTION
```nix
nix-repl> :p apps.python-web-app.grants
{
  Commons = [ ];
  Core = [ ];
  Entrust = [ "Test" ];
  Review = [ ];
}
```

The grants submodule has been taken [from NGIpkgs](https://github.com/ngi-nix/ngipkgs/blob/52ddbe1df9ecf65366fe12e525a2db0285466d81/maintainers/types/subgrant.nix).

Related: https://github.com/ngi-nix/forge/issues/72
Closes: https://github.com/ngi-nix/forge/issues/119