### PR TITLE
feat: add links to apps

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -28,6 +28,11 @@
       default = "";
       description = "Application usage description in markdown format.";
     };
+    links = lib.mkOption {
+      type = lib.types.submodule ./links.nix;
+      default = { };
+      description = "Links related to this project";
+    };
     grants = lib.mkOption {
       type = lib.types.submodule ./ngi/grants.nix;
       default = { };

--- a/forge/modules/apps/links.nix
+++ b/forge/modules/apps/links.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  ...
+}:
+let
+  link-submodule = lib.types.submodule (
+    { name, ... }:
+    {
+      options = {
+        text = lib.mkOption {
+          description = "link text";
+          type = lib.types.str;
+          default = name;
+        };
+        description = lib.mkOption {
+          description = "long-form description of the linked resource";
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+        };
+        url = lib.mkOption {
+          # basic check for the URI syntax
+          # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+          type = lib.types.strMatching "[a-zA-Z][a-zA-Z0-9+\-.]*://[^ \t\n]+";
+          description = "URL of the linked resource";
+        };
+      };
+    }
+  );
+
+  # - `links.website = "https://foobar.com";`
+  # - `links.website = { text = "Homepage"; url = "https://foobar.com"; };`
+  link = lib.types.coercedTo lib.types.str (url: { inherit url; }) link-submodule;
+in
+{
+  options = {
+    website = lib.mkOption {
+      type = lib.types.nullOr link;
+      description = "Project website.";
+      default = null;
+    };
+    source = lib.mkOption {
+      type = lib.types.nullOr link;
+      description = "Project source code.";
+      default = null;
+    };
+    docs = lib.mkOption {
+      type = lib.types.nullOr link;
+      description = "Project documentation.";
+      default = null;
+    };
+  };
+}


### PR DESCRIPTION
```nix
{
  links.website = "https://foobar.com";
  links.docs = "this is not right";
}
```

```nix
nix-repl> :p apps.python-web-app.links
{
  docs = {
    description = null;
    text = "docs";
    url = «error: A definition for option `perSystem.x86_64-linux.forge.apps."[definition 1-entry 2]".links.docs.url' is not of type `string matching the pattern [a-zA-Z][a-zA-Z0-9+-.]*://[^
]+'. Definition values:
- In `/nix/store/5azs2aal0cfzl77g1dflzsg4y4n2ah3c-source/flake.nix, via option perSystem': "this is not right"»;
  };
  website = {
    description = null;
    text = "website";
    url = "https://foobar.com";
  };
}
```

Related: https://github.com/ngi-nix/forge/issues/73