### PR TITLE
Package helium with LLM (split docs)

### DIFF
--- a/recipes/packages/helium/recipe.nix
+++ b/recipes/packages/helium/recipe.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "helium";
+  version = "7.0.0";
+  description = "Lighter browser automation based on Selenium.";
+  homePage = "https://github.com/mherrmann/helium";
+  mainProgram = "";
+  license = lib.licenses.mit;
+
+  source = {
+    git = "github:mherrmann/helium/v7.0.0";
+    hash = "sha256-SGLxP2OOzosLpZn/DgIJN3BnbUeg8cXE1HhKBF4EpyM=";
+  };
+
+  build.pythonPackageBuilder = {
+    enable = true;
+    requirements = {
+      build-system = [
+        pkgs.python3Packages.setuptools
+      ];
+      dependencies = [
+        pkgs.python3Packages.selenium
+      ];
+    };
+    importsCheck = [
+      "helium"
+    ];
+  };
+
+  test.script = ''
+    python -c "import helium; print(helium.__doc__)"
+  '';
+}


### PR DESCRIPTION
Testing LLM documentation from https://github.com/ngi-nix/forge/pull/122.

- **model:** `MiniMax M2.5 (Free)`
- **context:** 42,000 tokens
- **prompt:** `Package https://github.com/mherrmann/helium`
- **notes:** the model needed some intervention to `git add` recipe file, even though it read `.agent-docs/workflow.md`, which tells it that adding to git is critical