### PR TITLE
chore: remove nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,6 @@
 {
   description = "NGI Forge";
 
-  nixConfig = {
-    extra-substituters = [ "" ];
-    extra-trusted-public-keys = [ "" ];
-  };
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
We [removed substitutors from `nixConfig`](https://github.com/ngi-nix/forge/commit/b276062d56af9a3a3c17c6208cc54f65ce0a56c9) a while back, but it itself still persists, which does not serve any current purpose than make any nix command needlessly longer:

```shellSession
$ nix fmt
do you want to allow configuration setting 'extra-substituters' to be
set to '' (y/N)?
do you want to permanently mark this value as untrusted (y/N)?
warning: ignoring untrusted flake configuration setting
'extra-substituters'.
Pass '--accept-flake-config' to trust it
do you want to allow configuration setting 'extra-trusted-public-keys'
to be set to '' (y/N)?
do you want to permanently mark this value as untrusted (y/N)?
warning: ignoring untrusted flake configuration setting
'extra-trusted-public-keys'.
Pass '--accept-flake-config' to trust it
```