### PR TITLE
fix: ignore non-NixOS configData paths on NixOS

### DIFF
--- a/forge/modules/apps/nixos/default.nix
+++ b/forge/modules/apps/nixos/default.nix
@@ -163,13 +163,23 @@
         {
           # modular services
           system = {
-            services = lib.mapAttrs (
-              name: value:
-              lib.recursiveUpdate (lib.removeAttrs value [ "passthru" ]) {
-                systemd.mainExecStart = lib.escapeShellArgs value.process.argv;
-                systemd.service.environment = value.passthru.raw.environment;
-              }
-            ) app.services;
+            services = lib.pipe app.services [
+              # NixOS already defines `configData."*".path`, but other runtimes
+              # don't do that. Since it's a read-only option, we can't just
+              # change its priority, so here we just filter out any non-NixOS
+              # declarations of that option.
+              # TODO: is there a more robust way of doing this?
+              # configData."*".path -> remove
+              (lib.filterAttrsRecursive (name: value: name != "path"))
+              # pass env vars to systemd; escape args
+              (lib.mapAttrs (
+                name: value:
+                lib.recursiveUpdate (lib.removeAttrs value [ "passthru" ]) {
+                  systemd.mainExecStart = lib.escapeShellArgs value.process.argv;
+                  systemd.service.environment = value.passthru.raw.environment;
+                }
+              ))
+            ];
           };
 
           environment.variables = lib.concatMapAttrs (_: value: value.passthru.raw.environment) app.services;


### PR DESCRIPTION
NixOS already defines `configData."*".path`, but other runtimes don't do that. Since it's a read-only option, we can't just change its priority, so here we just filter out any non-NixOS declarations of that option.

As such, this allows us to define `configData` in the app 's recipe without conflicts:

```shellSession
nix-repl> apps.tau-app.nixos.result.eval.config.system.services.tau-tower.configData."credstore/tau.PASSWORD"
{
  enable = true;
  name = "credstore/tau.PASSWORD";
  path = "/etc/system-services/tau-tower/credstore/tau.PASSWORD";
  source = "/etc/credstore/tau.PASSWORD";
  text = null;
}
```

```shellSession
nix-repl> apps.tau-app.container.result.nimi.eval.services.tau-tower.configData."credstore/tau.PASSWORD"
{
  enable = true;
  name = "credstore/tau.PASSWORD";
  path = "/etc/tau/password";
  source = "/etc/credstore/tau.PASSWORD";
  text = null;
}
```