### PR TITLE
fix(ui): inconsitent nav bar icons

### DIFF
--- a/ui/src/Main/View.elm
+++ b/ui/src/Main/View.elm
@@ -42,17 +42,9 @@ view model =
                 , style "flex-direction" "row"
                 , style "justify-content" "space-evenly"
                 ]
-                ((case model.model_page of
-                    Page_RecipeOptions _ ->
-                        []
-
-                    _ ->
-                        [ li [ class "nav-item me-3" ] [ viewRecipeOptionsLink ]
-                        ]
-                 )
-                    ++ [ model |> viewThemeToggle
-                       ]
-                )
+                [ li [ class "nav-item me-3" ] [ viewRecipeOptionsLink ]
+                , model |> viewThemeToggle
+                ]
             ]
         , div []
             (model.model_errors


### PR DESCRIPTION
Navbar should always look the same, we shouldn't conditionally hide things.

The current behavior, is when you click on the options link on the top right it will disappear in the options page.