### PR TITLE
feat: add aerogramme package

### DIFF
--- a/recipes/packages/aerogramme/0001-update-time-rs.patch
+++ b/recipes/packages/aerogramme/0001-update-time-rs.patch
@@ -1,0 +1,59 @@
+From ad754664a05808bdbb976906a86ad0b08f16eb32 Mon Sep 17 00:00:00 2001
+From: wxt <3264117476@qq.com>
+Date: Tue, 24 Sep 2024 20:38:19 +0800
+Subject: [PATCH] update time-rs
+
+---
+ Cargo.lock | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 0a159ae..cf6b1c4 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2468,6 +2468,12 @@ dependencies = [
+  "num-traits",
+ ]
+ 
++[[package]]
++name = "num-conv"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
++
+ [[package]]
+ name = "num-integer"
+ version = "0.1.45"
+@@ -3579,12 +3585,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "time"
+-version = "0.3.31"
++version = "0.3.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
++checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+ dependencies = [
+  "deranged",
+  "itoa",
++ "num-conv",
+  "powerfmt",
+  "serde",
+  "time-core",
+@@ -3599,10 +3606,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+ 
+ [[package]]
+ name = "time-macros"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
++checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+ dependencies = [
++ "num-conv",
+  "time-core",
+ ]
+ 
+-- 
+2.46.0
+

--- a/recipes/packages/aerogramme/recipe.nix
+++ b/recipes/packages/aerogramme/recipe.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  name = "aerogramme";
+  version = "0.3.0";
+  description = "Encrypted e-mail storage over Garage";
+  homePage = "https://aerogramme.deuxfleurs.fr/";
+  mainProgram = "aerogramme";
+  license = lib.licenses.eupl12;
+
+  source = {
+    git = "git:https://git.deuxfleurs.fr/Deuxfleurs/aerogramme?tag=0.3.0";
+    hash = "sha256-ER+P/XGqNzTLwDLK5EBZq/Dl29ZZKl2FdxDb+oLEJ8Y=";
+
+    patches = [
+      ./0001-update-time-rs.patch
+    ];
+  };
+
+  build.rustPackageBuilder = {
+    enable = true;
+    inputs = {
+      build = [
+        pkgs.pkg-config
+      ];
+      run = [
+        pkgs.openssl
+      ];
+    };
+    cargoHash = "sha256-GPj8qhfKgfAadQD9DJafN4ec8L6oY62PS/w/ljkPHpw=";
+  };
+
+  build.extraAttrs = {
+    # disable network tests as Nix sandbox breaks them
+    doCheck = false;
+
+    env = {
+      # get openssl-sys to use pkg-config
+      OPENSSL_NO_VENDOR = true;
+      RUSTC_BOOTSTRAP = true;
+    };
+  };
+
+  test.script = ''
+    aerogramme --version | grep -E "aerogramme [0-9]*\.[0-9]*\.[0-9]*"
+  '';
+}


### PR DESCRIPTION
Derived from the [Nixpkgs derivaiton](https://github.com/NixOS/nixpkgs/blob/46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9/pkgs/by-name/ae/aerogramme/package.nix).

Related: https://github.com/ngi-nix/forge/issues/143

~~**PS:** the upstream forge doesn't allow for downloading tarballs, so we can't use `fetchurl`. Since it's also a custom Forgejo forge, we can't use the current fetchers we have (also see https://github.com/ngi-nix/forge/issues/137). A workaround is to use `path`, which isn't really supposed to accept anything (we need to fix this), but it does.~~ We added `fetchgit` support.