### PR TITLE
forge/modules/apps: add test.script

### DIFF
--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -43,6 +43,7 @@
 
       # All apps passthru attributes
       // (passthruAttr "programs")
+      // (passthruAttr "test")
       // (passthruAttr "container")
       // (passthruAttr "vm");
     };

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -97,22 +97,14 @@
     };
 
     # Test configuration
-    test = {
-      script = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Bash script to run application tests inside a NixOS machine.
-
-          The application's services are available in the machine.
-          Run with: nix build .#<app>.test
-        '';
-        example = lib.literalExpression ''
-          '''
-          curl -f http://localhost:5000/users
-          '''
-        '';
+    test = lib.mkOption {
+      type = lib.types.submodule {
+        imports = [ ./test ];
+        _module.args.app = config;
+        _module.args.pkgs = pkgs;
       };
+      default = { };
+      description = "Test configuration.";
     };
   };
 }

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -95,5 +95,24 @@
       default = { };
       description = "NixOS system configuration.";
     };
+
+    # Test configuration
+    test = {
+      script = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = ''
+          Bash script to run application tests inside a NixOS machine.
+
+          The application's services are available in the machine.
+          Run with: nix build .#<app>.test
+        '';
+        example = lib.literalExpression ''
+          '''
+          curl -f http://localhost:5000/users
+          '''
+        '';
+      };
+    };
   };
 }

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -72,21 +72,7 @@ in
               # finalApp parameter is currently not used in this function
               app: finalApp:
               { }
-              // lib.optionalAttrs (app.test.script != "") {
-                test = pkgs.testers.runNixOSTest {
-                  name = "${app.name}-test";
-                  nodes.machine = {
-                    imports = app.nixos.result.modules;
-                    system.stateVersion = "25.11";
-                    environment.systemPackages = app.programs.requirements;
-                  };
-                  testScript = ''
-                    machine.start()
-                    machine.wait_for_unit("multi-user.target")
-                    machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" app.test.script}")
-                  '';
-                };
-              }
+              // lib.optionalAttrs (app.test.script != "") { test = app.test.result.build; }
               // lib.optionalAttrs app.container.enable { container = app.container.result.imageBuilder; }
               // lib.optionalAttrs app.nixos.enable { vm = app.nixos.result.build; };
 

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -72,6 +72,21 @@ in
               # finalApp parameter is currently not used in this function
               app: finalApp:
               { }
+              // lib.optionalAttrs (app.test.script != "") {
+                test = pkgs.testers.runNixOSTest {
+                  name = "${app.name}-test";
+                  nodes.machine = {
+                    imports = app.nixos.result.modules;
+                    system.stateVersion = "25.11";
+                    environment.systemPackages = app.programs.requirements;
+                  };
+                  testScript = ''
+                    machine.start()
+                    machine.wait_for_unit("multi-user.target")
+                    machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" app.test.script}")
+                  '';
+                };
+              }
               // lib.optionalAttrs app.container.enable { container = app.container.result.imageBuilder; }
               // lib.optionalAttrs app.nixos.enable { vm = app.nixos.result.build; };
 

--- a/forge/modules/apps/nixos/default.nix
+++ b/forge/modules/apps/nixos/default.nix
@@ -95,6 +95,13 @@
     };
 
     result = {
+      modules = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = lib.types.listOf lib.types.anything;
+        description = "NixOS modules for the application's services and extra configuration.";
+      };
+
       eval = lib.mkOption {
         internal = true;
         readOnly = true;
@@ -123,6 +130,53 @@
   };
 
   config = {
+    result.modules = [
+      {
+        # modular services
+        system = {
+          services = lib.pipe app.services [
+            # NixOS already defines `configData."*".path`, but other runtimes
+            # don't do that. Since it's a read-only option, we can't just
+            # change its priority, so here we just filter out any non-NixOS
+            # declarations of that option.
+            # TODO: is there a more robust way of doing this?
+            # configData."*".path -> remove
+            (lib.filterAttrsRecursive (name: value: name != "path"))
+            (lib.mapAttrs (
+              _: service:
+              lib.recursiveUpdate service.result {
+                systemd.mainExecStart = lib.escapeShellArgs service.result.process.argv;
+                systemd.service = {
+                  environment = service.environment;
+                }
+                // lib.optionalAttrs (config.setup != "") {
+                  # make sure services run after setup is done
+                  after = [ "${app.name}-setup.service" ];
+                  requires = [ "${app.name}-setup.service" ];
+                };
+              }
+            ))
+          ];
+        };
+
+        environment.variables = lib.concatMapAttrs (_: value: value.environment) app.services;
+      }
+      (lib.mkIf (config.setup != "") {
+        systemd.services."${app.name}-setup" = {
+          description = "Setup service for ${app.name}.";
+          wantedBy = [ "multi-user.target" ];
+          before = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          script = config.setup;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+        };
+      })
+      config.extraConfig
+    ];
+
     result.eval = inputs.nixpkgs.lib.nixosSystem {
       inherit system;
       modules = [
@@ -160,51 +214,8 @@
 
           system.stateVersion = "25.11";
         }
-        {
-          # modular services
-          system = {
-            services = lib.pipe app.services [
-              # NixOS already defines `configData."*".path`, but other runtimes
-              # don't do that. Since it's a read-only option, we can't just
-              # change its priority, so here we just filter out any non-NixOS
-              # declarations of that option.
-              # TODO: is there a more robust way of doing this?
-              # configData."*".path -> remove
-              (lib.filterAttrsRecursive (name: value: name != "path"))
-              (lib.mapAttrs (
-                _: service:
-                lib.recursiveUpdate service.result {
-                  systemd.mainExecStart = lib.escapeShellArgs service.result.process.argv;
-                  systemd.service = {
-                    environment = service.environment;
-                  }
-                  // lib.optionalAttrs (config.setup != "") {
-                    # make sure services run after setup is done
-                    after = [ "${app.name}-setup.service" ];
-                    requires = [ "${app.name}-setup.service" ];
-                  };
-                }
-              ))
-            ];
-          };
-
-          environment.variables = lib.concatMapAttrs (_: value: value.environment) app.services;
-        }
-        (lib.mkIf (config.setup != "") {
-          systemd.services."${app.name}-setup" = {
-            description = "Setup service for ${app.name}.";
-            wantedBy = [ "multi-user.target" ];
-            before = [ "multi-user.target" ];
-            after = [ "network.target" ];
-            script = config.setup;
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = true;
-            };
-          };
-        })
-        config.extraConfig
-      ];
+      ]
+      ++ config.result.modules;
     };
   };
 }

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -17,7 +17,9 @@
 
     script = lib.mkOption {
       type = lib.types.str;
-      default = "";
+      default = ''
+        echo "Test script"
+      '';
       description = ''
         Bash script to run application tests inside a NixOS machine.
 

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -39,6 +39,9 @@
       default = ''
         machine.start()
         machine.wait_for_unit("multi-user.target")
+        ${lib.concatMapAttrsStringSep "\n" (
+          name: _: "machine.wait_for_unit(\"${name}.service\")"
+        ) app.services}
         machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
       '';
       description = "Python test script passed to the NixOS test driver.";

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+
+  app,
+  config,
+  pkgs,
+  ...
+}:
+{
+  options = {
+    script = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        Bash script to run application tests inside a NixOS machine.
+
+        The application's services are available in the machine.
+        Run with: nix build .#<app>.test
+      '';
+      example = lib.literalExpression ''
+        '''
+        curl -f http://localhost:5000/users
+        '''
+      '';
+    };
+
+    result = {
+      build = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = lib.types.package;
+        description = "NixOS test derivation.";
+      };
+
+      # HACK:
+      # Prevent toJSON from attempting to convert the `build` option,
+      # which won't work because it's a whole NixOS test evaluation.
+      __toString = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = with lib.types; functionTo str;
+        default = self: "nixos-test";
+      };
+    };
+  };
+
+  config = {
+    result.build = pkgs.testers.runNixOSTest {
+      name = "${app.name}-test";
+      nodes.machine = {
+        imports = app.nixos.result.modules;
+        system.stateVersion = "25.11";
+        environment.systemPackages = app.programs.requirements;
+      };
+      testScript = ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
+      '';
+    };
+  };
+}

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -8,6 +8,13 @@
 }:
 {
   options = {
+    requirements = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Additional packages required for running tests.";
+      example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
+    };
+
     script = lib.mkOption {
       type = lib.types.str;
       default = "";
@@ -50,7 +57,7 @@
       nodes.machine = {
         imports = app.nixos.result.modules;
         system.stateVersion = "25.11";
-        environment.systemPackages = app.programs.requirements;
+        environment.systemPackages = app.programs.requirements ++ config.requirements;
       };
       testScript = ''
         machine.start()

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -31,6 +31,17 @@
       '';
     };
 
+    testScript = lib.mkOption {
+      internal = true;
+      type = lib.types.str;
+      default = ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
+      '';
+      description = "Python test script passed to the NixOS test driver.";
+    };
+
     result = {
       build = lib.mkOption {
         internal = true;
@@ -59,11 +70,7 @@
         system.stateVersion = "25.11";
         environment.systemPackages = app.programs.requirements ++ config.requirements;
       };
-      testScript = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
-        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
-      '';
+      inherit (config) testScript;
     };
   };
 }

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -72,4 +72,15 @@
     docs = pkgs.mypkgs.python-web.meta.homepage;
     source = pkgs.mypkgs.python-web.meta.homepage;
   };
+
+  test.script = ''
+    curl -X POST localhost:5000/init
+
+    curl -X POST \
+      --header "Content-Type: application/json" \
+      --data '{"name":"username"}' \
+      localhost:5000/users
+
+    curl localhost:5000/users
+  '';
 }


### PR DESCRIPTION
To test: `nix build .#python-web-app.test`

Closes https://github.com/ngi-nix/forge/issues/107.

Model: `claude-4.6-opus-high`
Prompt:
> Add `test.script` to app recipes that will be executed in a NixOS machine for that service.  Refer to implementation for package recipes.
> Is it possible to make it use the nixos / container section of the app recipe?
