### PR TITLE
fix: don't warn missing hash when using path

### DIFF
--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -252,7 +252,7 @@ in
             warnings = lib.flatten (
               map (pkg: [
                 {
-                  condition = pkg.source.hash == "";
+                  condition = pkg.source.hash == "" && pkg.source.path == null;
                   message = ''
                     Package '${pkg.name}': source.hash is empty.
                     Correct hash will be printed in the error message when package is built.


### PR DESCRIPTION
becuase we're not hashing local sources.