### PR TITLE
unfeat(forge): remove app.*.packages option

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -34,16 +34,6 @@
       description = "NGI grants supporting this project.";
     };
 
-    # NOTE: ideally, this should either:
-    # 1. be automatically populated from submodules (services, programs, ...)
-    # 2. populate the submodules from this option (attrsOf packages)
-    packages = lib.mkOption {
-      type = lib.types.listOf lib.types.attrs;
-      default = [ ];
-      description = "Forge packages used by the application.";
-      # TODO: assert that packages are internal to the forge?
-    };
-
     # Portable services configuration
     # https://nixos.org/manual/nixos/unstable/#modular-services
     services = lib.mkOption {
@@ -104,34 +94,5 @@
       default = { };
       description = "NixOS system configuration.";
     };
-  };
-
-  config = {
-    packages =
-      let
-        service-packages = lib.flatten (lib.mapAttrsToList (name: value: value.command) config.services);
-
-        packages = service-packages ++ config.programs.requirements ++ config.container.requirements;
-      in
-      lib.pipe packages [
-        # NOTE: `unique` has an O(n^2) complexity
-        # - would that be an issue for our usecase?
-        # - could we perhaps do better?
-        (lib.unique)
-        (map (package: {
-          inherit (package)
-            pname
-            version
-            ;
-          meta = {
-            inherit (package.meta)
-              description
-              license
-              position
-              ;
-          };
-          storePath = package.outPath;
-        }))
-      ];
   };
 }


### PR DESCRIPTION
Manual linking of packages to application is not a good idea.

Revert of https://github.com/ngi-nix/forge/commit/f4822bc40d91ef71d861a27a6746e0e00fef8490 .
