### PR TITLE
feat: introduce git fetcher schemas

### DIFF
--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -26,6 +26,8 @@ in
                     forges = {
                       # forge = fetchFunction
                       codeberg = pkgs.fetchFromCodeberg;
+                      forgejo = pkgs.fetchFromForgejo;
+                      gitea = pkgs.fetchFromGitea;
                       github = pkgs.fetchFromGitHub;
                       gitlab = pkgs.fetchFromGitLab;
                     };


### PR DESCRIPTION
Example:

```nix
{
  source = {
    git = "codeberg:jpt/django-honeypot/1.3.0";
    # git = "gitea:codeberg.org/jpt/django-honeypot/1.3.0";
    # git = "forgejo:codeberg.org/jpt/django-honeypot/1.3.0";
    hash = "sha256-8j1/p+GD8ac+y/TT2K6SvJAYogAX3QC12LExt/nJeYk=";
  };
}
```

Depends on https://github.com/ngi-nix/forge/pull/165
Closes https://github.com/ngi-nix/forge/issues/139