### PR TITLE
fix(ui): strip out trailing slash in urls on inital page load

### DIFF
--- a/ui/src/js/main.js
+++ b/ui/src/js/main.js
@@ -4,10 +4,23 @@ import { initClipboardListener } from "./Clipboard.js";
 
 const startingTheme = getInitialTheme();
 
+// work around github pages adding extra trailing slash
+if (
+  window.location.pathname.endsWith("/") &&
+  window.location.pathname !== "/"
+) {
+  const cleanUrl =
+    window.location.pathname.slice(0, -1) +
+    window.location.search +
+    window.location.hash;
+  window.history.replaceState(null, "", cleanUrl);
+}
+
+// init state
 const app = Elm.Main.init({
   node: document.getElementById("elm-main"),
   flags: {
-    href: location.href,
+    href: window.location.href,
     theme: startingTheme,
   },
 });


### PR DESCRIPTION
Github pages will always redirect to the url with the slash at the end, replace it on the client side to make our lives easier.

`https://ngi-nix.github.io/forge/` -> `https://ngi-nix.github.io/forge`

The purpose of this is to make `#resources` and other permalinks work as normal.