### PR TITLE
options: remove redundant name option for nixos and containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,6 @@ Builds a single OCI-compliant container image:
 ```nix
 container = {
   enable = true;  # Set to true to enable container image output
-  name = "my-app";
   tag = "latest";  # Optional, defaults to "latest"
 
   requirements = [
@@ -418,7 +417,6 @@ Builds a complete NixOS virtual machine:
 ```nix
 nixos = {
   enable = true;  # Set to true to enable VM output
-  name = "my-vm";
 
   # NixOS system configuration
   # See: https://search.nixos.org/options
@@ -507,7 +505,6 @@ Each app output type can be independently enabled or disabled:
   # Container image
   container = {
     enable = true;
-    name = "python-web";
     tag = "latest";
     requirements = [ pkgs.mypkgs.python-web ];
     imageConfig = {
@@ -520,7 +517,6 @@ Each app output type can be independently enabled or disabled:
   # VM with PostgreSQL
   nixos = {
     enable = true;
-    name = "python-web";
     extraConfig = {
       services.postgresql = {
         enable = true;

--- a/forge/modules/apps/container/default.nix
+++ b/forge/modules/apps/container/default.nix
@@ -11,12 +11,6 @@
   options = {
     enable = lib.mkEnableOption "container image output";
 
-    name = lib.mkOption {
-      type = lib.types.str;
-      default = "container";
-      description = "Name of the generated container.";
-    };
-
     tag = lib.mkOption {
       type = lib.types.str;
       default = "latest";
@@ -151,7 +145,7 @@
       cat > $out/bin/build-oci <<EOF
       #!${pkgs.runtimeShell}
       ${config.result.recipe.copyTo}/bin/copy-to \
-        oci-archive:${config.name}.tar:${config.name}:${config.tag}
+        oci-archive:${app.name}.tar:${app.name}:${config.tag}
       EOF
 
       chmod +x $out/bin/build-oci

--- a/forge/modules/apps/nixos/default.nix
+++ b/forge/modules/apps/nixos/default.nix
@@ -11,12 +11,6 @@
   options = {
     enable = lib.mkEnableOption "NixOS/VM output";
 
-    name = lib.mkOption {
-      type = lib.types.str;
-      default = "nixos-vm";
-      description = "Hostname for the VM.";
-    };
-
     # TODO:
     # - wire this up with nimi
     # - maybe rename to `nimi` or `nimi-settings`?
@@ -159,7 +153,7 @@
           };
 
           networking = {
-            hostName = config.name;
+            hostName = app.name;
             useDHCP = lib.mkForce true;
             firewall.enable = lib.mkForce false;
           };
@@ -186,8 +180,8 @@
                   }
                   // lib.optionalAttrs (config.setup != "") {
                     # make sure services run after setup is done
-                    after = [ "${config.name}-setup.service" ];
-                    requires = [ "${config.name}-setup.service" ];
+                    after = [ "${app.name}-setup.service" ];
+                    requires = [ "${app.name}-setup.service" ];
                   };
                 }
               ))
@@ -197,8 +191,8 @@
           environment.variables = lib.concatMapAttrs (_: value: value.environment) app.services;
         }
         (lib.mkIf (config.setup != "") {
-          systemd.services."${config.name}-setup" = {
-            description = "Setup service for ${config.name}.";
+          systemd.services."${app.name}-setup" = {
+            description = "Setup service for ${app.name}.";
             wantedBy = [ "multi-user.target" ];
             before = [ "multi-user.target" ];
             after = [ "network.target" ];

--- a/recipes/apps/hello-app/recipe.nix
+++ b/recipes/apps/hello-app/recipe.nix
@@ -27,7 +27,6 @@
 
   container = {
     enable = true;
-    name = "hello";
     tag = "latest";
     requirements = [ pkgs.mypkgs.hello ];
     # Alternatively, we can re-use attributes with `config`:

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -44,7 +44,6 @@
 
   container = {
     enable = true;
-    name = "python-web";
     requirements = [ pkgs.mypkgs.python-web ];
     # Alternatively, we can re-use attributes with `config`:
     #requirements = [ config.services.python-web.command ];
@@ -53,7 +52,6 @@
 
   nixos = {
     enable = true;
-    name = "python-web";
     extraConfig = {
       # database service
       services.postgresql.enable = true;

--- a/templates/example/recipes/apps/hello-app/recipe.nix
+++ b/templates/example/recipes/apps/hello-app/recipe.nix
@@ -18,7 +18,6 @@
 
   container = {
     enable = true;
-    name = "hello";
     requirements = [ pkgs.mypkgs.hello-nix ];
     imageConfig.CMD = [
       "hello"
@@ -28,7 +27,6 @@
 
   nixos = {
     enable = true;
-    name = "hello";
     extraConfig = {
       environment.systemPackages = [
         pkgs.mypkgs.hello-nix

--- a/ui/src/Main/View/Instructions.elm
+++ b/ui/src/Main/View/Instructions.elm
@@ -273,11 +273,8 @@ viewVMInstructions model pageApp =
         flakes =
             model.model_preferences.pref_flakes
 
-        -- In nixpkgs nixos/modules/virtualisation/qemu-vm.nix, look for mainProgram
-        -- And in nixos/modules/system/activation/top-level.nix, look for hostName
-        -- Assume we always set hostname to be without -app suffix
-        serviceName =
-            String.dropRight 4 pageApp.pageApp_app.app_name
+        app_name =
+            pageApp.pageApp_app.app_name
     in
     div []
         [ p [ style "margin-bottom" "0em" ] [ text "Run application services in a NixOS VM." ]
@@ -288,7 +285,7 @@ viewVMInstructions model pageApp =
                     [ "nix run "
                     , model.model_config.config_repository
                     , "#"
-                    , pageApp.pageApp_app.app_name
+                    , app_name
                     , ".vm"
                     ]
 
@@ -299,11 +296,11 @@ viewVMInstructions model pageApp =
                         , nixShellForgeInput model
                         , "  -E '(import <forge> {})"
                         , "."
-                        , pageApp.pageApp_app.app_name
+                        , app_name
                         , ".vm"
                         , "' "
                         ]
                     , ""
-                    , "./result/bin/run-" ++ serviceName ++ "-vm"
+                    , "./result/bin/run-" ++ app_name ++ "-vm"
                     ]
         ]


### PR DESCRIPTION
`name` option for nixos and containers is redundant, can cause issues
and can be confusing. Top level app `name` should be used instead.
