### PR TITLE
feat: make nixos vm overridable

### DIFF
--- a/forge/modules/apps/nixos/default.nix
+++ b/forge/modules/apps/nixos/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   inputs,
+  extendModules,
 
   app,
   config,
@@ -34,7 +35,7 @@
     };
 
     extraConfig = lib.mkOption {
-      type = with lib.types; lazyAttrsOf (either attrs anything);
+      type = with lib.types; deferredModule;
       default = { };
       description = ''
         NixOS system configuration
@@ -106,7 +107,17 @@
         internal = true;
         readOnly = true;
         type = lib.types.package;
-        default = config.result.eval.config.system.build.vm;
+        default =
+          let
+            mkVm =
+              appConfig:
+              appConfig.result.eval.config.system.build.vm
+              // {
+                eval = appConfig.result.eval;
+                extend = module: mkVm (extendModules { modules = [ { extraConfig = module; } ]; }).config;
+              };
+          in
+          mkVm config;
         description = "NixOS Virtual Machine.";
       };
 


### PR DESCRIPTION
```nix
nix-repl> original = packages.x86_64-linux.python-web-app

nix-repl> original.vm.eval.config.services.postgresql.enable
true

nix-repl> pkgs = import inputs.nixpkgs {}

nix-repl> modified = original.vm.extend { services.postgresql.enable = pkgs.lib.mkForce false; }

nix-repl> modified.eval.config.services.postgresql.enable
false
```

Related: https://github.com/ngi-nix/forge/issues/75