### PR TITLE
+dev/compatibility(nixpkgs): update path to the portable service infrastructure

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,11 +180,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1775294664,
+        "narHash": "sha256-xA9GUXyFT0OHCWzgikiTQaQquyaZUP06h9ltfOnXPNc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "1baf57f3a0a12a99c1f1e74134e3df09c6ef7bfb",
         "type": "github"
       },
       "original": {

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -7,10 +7,7 @@
 }:
 {
   imports = [
-    # configData
-    (lib.modules.importApply (
-      inputs.nixpkgs + "/nixos/modules/system/service/portable/config-data.nix"
-    ) { inherit pkgs; })
+    (lib.modules.importApply (inputs.nixpkgs + "/lib/services/config-data.nix") { inherit pkgs; })
   ];
 
   options = {


### PR DESCRIPTION
`inputs.nixpkgs` is here updated to the latest commit of the PR introducing the change:
https://github.com/NixOS/nixpkgs/pull/506519

### Checked
- [X]  `nix -L build -f. python-web-app.vm`
- [X] `nix -L build .#_forge-ui`
- [X] `nix flake check`

### Relations
- Stacked on: https://github.com/ngi-nix/forge/pull/208