### PR TITLE
+user/reproducibility(templates/example): use `follows` to `ngi-forge`'s `inputs`

### DIFF
--- a/templates/example/flake.nix
+++ b/templates/example/flake.nix
@@ -9,18 +9,12 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.follows = "nix-forge/nixpkgs";
+    flake-parts.follows = "nix-forge/flake-parts";
     nix-forge.url = "github:ngi-nix/forge";
-    elm2nix = {
-      url = "github:dwayne/elm2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    nix-utils = {
-      url = "github:imincik/nix-utils";
-      flake = false;
-    };
-    nimi.url = "github:weyl-ai/nimi";
+    elm2nix.follows = "nix-forge/elm2nix";
+    nix-utils.follows = "nix-forge/nix-utils";
+    nimi.follows = "nix-forge/nimi";
   };
 
   outputs =


### PR DESCRIPTION

Otherwise `nix flake` pulls the latest version of each `inputs`, which may not be compatible with each others or with nix-forge.
This happened here: https://github.com/ngi-nix/forge/pull/207

An alternative would be to reuse `ngi-forge/flake.lock` in the CI.
But using `follows` in the Nix template makes it work directly for users with only `nix flake init`,
and will nudge them to maintain known-to-work versions across `nix flake update`,
because they would have to knowingly decide
to change `inputs` in their `flake.nix` to deviate from `ngi-forge/flake.lock`.