### PR TITLE
feat: make app recipes overridable

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  extendModules,
 
   inputs,
   nimi,
@@ -111,6 +112,24 @@
       };
       default = { };
       description = "Test configuration.";
+    };
+
+    result = {
+      extend = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        default = module: (extendModules { modules = [ module ]; }).config;
+      };
+
+      # HACK:
+      # Prevent toJSON from attempting to convert the `eval` option,
+      # which won't work because it's a whole NixOS evaluation.
+      __toString = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = with lib.types; functionTo str;
+        default = self: "nixos-vm-config";
+      };
     };
   };
 }

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -68,13 +68,23 @@ in
                 passthru = appPassthru app appDrv;
               });
 
-            appPassthru =
-              # finalApp parameter is currently not used in this function
-              app: finalApp:
-              { }
+            mkPassthru =
+              app:
+              {
+                config = app;
+                extend =
+                  module:
+                  let
+                    appExtended = app.result.extend module;
+                  in
+                  shellBundle appExtended;
+              }
               // lib.optionalAttrs (app.test.script != "") { test = app.test.result.build; }
               // lib.optionalAttrs app.container.enable { container = app.container.result.imageBuilder; }
               // lib.optionalAttrs app.nixos.enable { vm = app.nixos.result.build; };
+
+            # finalApp parameter is currently not used in this function
+            appPassthru = app: finalApp: mkPassthru app;
 
             allApps = lib.listToAttrs (
               map (app: {

--- a/forge/modules/apps/nixos/default.nix
+++ b/forge/modules/apps/nixos/default.nix
@@ -34,7 +34,7 @@
     };
 
     extraConfig = lib.mkOption {
-      type = with lib.types; lazyAttrsOf (either attrs anything);
+      type = with lib.types; deferredModule;
       default = { };
       description = ''
         NixOS system configuration


### PR DESCRIPTION
With this, we can extend apps and override any recipe attributes:

```nix
nix-repl> original = packages.x86_64-linux.python-web-app

nix-repl> original.config.nixos.enable
true

nix-repl> pkgs = import inputs.nixpkgs {}

nix-repl> modified = original.extend { nixos.enable = pkgs.lib.mkForce false; }

nix-repl> modified.vm
error: attribute 'vm' missing
       at «string»:1:1:
            1| modified.vm
             | ^
```

Supersedes https://github.com/ngi-nix/forge/pull/201 Closes https://github.com/ngi-nix/forge/pull/201
Related https://github.com/ngi-nix/forge/issues/75
Closes https://github.com/ngi-nix/forge/issues/227