### PR TITLE
fix: add all issues and prs to project via github actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,7 +1,9 @@
 name: "User Story"
 description: "Create a User Story."
 title: "US: <USER STORY TITLE>"
-projects: ["Nix@NGI"]
+# NOTE: only one repository can have auto added to project in github free plan
+# we instead add this via github actions.
+# projects: ["Nix@NGI"]
 labels: ["User story", "nix-forge"]
 body:
   - type: "textarea"

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,22 @@
+name: Auto-Add to Project
+on:
+  issues:
+    types: [opened, reopened]
+  # NOTE: Security wise this is unsafe if we were running some build script
+  # The user submitting the PR can modify the code and during the build step dump and capture the secrets
+  # BUT in this case there are no build steps, the only way is to modify this workflow file.
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
+  # state that the workflow will not run on the merge commit but the base branch, i.e. the modifications to this file are not run.
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue/pr to project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/ngi-nix/projects/8
+          # need to a token with project permissions
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
I went to https://github.com/orgs/ngi-nix/projects/8/workflows/35134378

Then EDIT, and only one repository can be specified.

If I want to add another such rule, then it is saying not possible to do so in free plan.

<img width="1320" height="290" alt="image" src="https://github.com/user-attachments/assets/13b28b81-41dd-4747-845f-e84fe27ae066" />

So I have found this alternative way of adding the issues to the project using github actions.