### PR TITLE
refactor: rename inputs back to requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Other packages built by Nix Forge can be referenced in recipes using `pkgs.mypkg
 ```nix
 {
   # Reference another Nix Forge package
-  inputs.run = [
+  requirements.run = [
     pkgs.mypkgs.gdal  # Access gdal from Nix Forge
   ];
 }
@@ -114,15 +114,15 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    requirements.build = [
       pkgs.cmake
       pkgs.pkg-config
     ];
-    inputs.run = [
+    requirements.run = [
       pkgs.openssl
       pkgs.zlib
     ];
-    inputs.check = [
+    requirements.check = [
       pkgs.cunit
     ];
   };
@@ -244,13 +244,13 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.goPackageBuilder = {
     enable = true;
-    inputs.build = [
+    requirements.build = [
       pkgs.pkg-config
     ];
-    inputs.run = [
+    requirements.run = [
       pkgs.openssl
     ];
-    inputs.check = [
+    requirements.check = [
       pkgs.gotestsum
     ];
     vendorHash = "sha256-...";
@@ -267,9 +267,9 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 
 **Inputs options**:
 
-- `inputs.build`: Build-time tools (pkg-config, installShellFiles)
-- `inputs.run`: CGO dependencies (openssl, sqlite)
-- `inputs.check`: Test tools (gotestsum)
+- `requirements.build`: Build-time tools (pkg-config, installShellFiles)
+- `requirements.run`: CGO dependencies (openssl, sqlite)
+- `requirements.check`: Test tools (gotestsum)
 
 ### 5. rustPackageBuilder (Rust Crates)
 
@@ -279,15 +279,15 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.rustPackageBuilder = {
     enable = true;
-    inputs.build = [
+    requirements.build = [
       pkgs.pkg-config
       pkgs.rustPlatform.bindgenHook
     ];
-    inputs.run = [
+    requirements.run = [
       pkgs.openssl
       pkgs.sqlite
     ];
-    inputs.check = [
+    requirements.check = [
       pkgs.cargo-nextest
     ];
     cargoHash = "sha256-...";
@@ -304,9 +304,9 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 
 **Inputs options**:
 
-- `inputs.build`: Build-time tools (pkg-config, bindgenHook)
-- `inputs.run`: Runtime dependencies (openssl, sqlite, etc.)
-- `inputs.check`: Test tools (cargo-nextest)
+- `requirements.build`: Build-time tools (pkg-config, bindgenHook)
+- `requirements.run`: Runtime dependencies (openssl, sqlite, etc.)
+- `requirements.check`: Test tools (cargo-nextest)
 
 ## Source Configuration
 
@@ -360,7 +360,7 @@ source = {
 
 ```nix
 test = {
-  inputs = [ pkgs.curl ];  # Additional test dependencies
+  requirements = [ pkgs.curl ];  # Additional test dependencies
   script = ''
     # Test commands
     $out/bin/program --version
@@ -380,7 +380,7 @@ test = {
 
 ```nix
 development = {
-  inputs = [ pkgs.gdb pkgs.valgrind ];  # Dev tools
+  requirements = [ pkgs.gdb pkgs.valgrind ];  # Dev tools
   shellHook = ''
     echo "Development environment ready"
     echo "Source code: clone from ${source.git}"
@@ -715,8 +715,8 @@ ELSE IF has configure script OR uses CMake OR standard Makefile:
 
 ### 3. Dependency Resolution
 
-- **Build tools**: cmake, pkg-config, autoconf → `inputs.build`
-- **Libraries**: openssl, zlib, curl → `inputs.run`
+- **Build tools**: cmake, pkg-config, autoconf → `requirements.build`
+- **Libraries**: openssl, zlib, curl → `requirements.run`
 - **Python packages**: Use `pkgs.python3Packages.*`
 - **Unknown packages**: Use `pkgs.<package-name>`
 
@@ -767,11 +767,11 @@ source.hash = "";  # Leave empty initially
 
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    requirements.build = [
       pkgs.rustc
       pkgs.cargo
     ];
-    inputs.run = [ ];
+    requirements.run = [ ];
   };
 
   test.script = ''
@@ -805,10 +805,10 @@ source.hash = "";  # Leave empty initially
 
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    requirements.build = [
       pkgs.which
     ];
-    inputs.run = [
+    requirements.run = [
       pkgs.openssl
       pkgs.pcre
       pkgs.zlib
@@ -846,10 +846,10 @@ source.hash = "";  # Leave empty initially
 
   build.pythonAppBuilder = {
     enable = true;
-    inputs.build-system = [
+    requirements.build-system = [
       pkgs.python3Packages.setuptools
     ];
-    inputs.dependencies = [
+    requirements.dependencies = [
       pkgs.python3Packages.typing-extensions
       pkgs.python3Packages.mypy-extensions
     ];
@@ -886,10 +886,10 @@ source.hash = "";  # Leave empty initially
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs.build-system = [
+    requirements.build-system = [
       pkgs.python3Packages.setuptools
     ];
-    inputs.dependencies = [
+    requirements.dependencies = [
       pkgs.python3Packages.charset-normalizer
       pkgs.python3Packages.idna
       pkgs.python3Packages.urllib3
@@ -921,7 +921,7 @@ source.hash = "";  # Leave empty initially
 
 **Issue**: Missing dependency
 
-- **Solution**: Add to inputs.build or inputs.run
+- **Solution**: Add to requirements.build or requirements.run
 
 ## Naming Conventions
 
@@ -1032,9 +1032,9 @@ Check for submodules:
 
 **Dependency categories:**
 
-- **Build tools** (cmake, pkg-config, autoconf, meson, ninja) → `inputs.build`
-- **Libraries** (sqlite, gdal, openssl, zlib, postgresql) → `inputs.run`
-- **Test Tools** (cunit, pytest) → `inputs.check`
+- **Build tools** (cmake, pkg-config, autoconf, meson, ninja) → `requirements.build`
+- **Libraries** (sqlite, gdal, openssl, zlib, postgresql) → `requirements.run`
+- **Test Tools** (cunit, pytest) → `requirements.check`
 - **Python packages** → `pkgs.python3Packages.<name>` in dependencies
 
 ### Step 5: Check for External/Vendored Dependencies
@@ -1059,7 +1059,7 @@ Nix builds in a sandbox without network access. You must:
 
 2. **Option 2:** Provide dependencies via nativeBuildInputs
    ```nix
-   inputs.build = [ pkgs.somelib ];
+   requirements.build = [ pkgs.somelib ];
    ```
 
 3. **Option 3:** Patch build files to remove download steps
@@ -1163,7 +1163,7 @@ CMake Error at CMakeLists.txt:104 (INCLUDE):
 
 2. **Provide missing dependencies:**
    ```nix
-   inputs.run = [ pkgs.libgpkg ];  # If available in nixpkgs
+   requirements.run = [ pkgs.libgpkg ];  # If available in nixpkgs
    ```
 
 3. **Patch CMakeLists.txt:**
@@ -1320,7 +1320,7 @@ START: What type of project is this?
 | wheel                              | `pkgs.python3Packages.wheel`              |
 | pytest                             | `pkgs.python3Packages.pytest` (test only) |
 
-### Build Tools (always in inputs.build)
+### Build Tools (always in requirements.build)
 
 - `pkgs.cmake` - CMake build system
 - `pkgs.pkg-config` - Finding library dependencies
@@ -1383,7 +1383,7 @@ git add recipes/packages/<name>/recipe.nix
    ```
 
    Common fixes needed:
-   - Add missing dependencies to `inputs.build` or `inputs.run`
+   - Add missing dependencies to `requirements.build` or `requirements.run`
    - Set `sourceRoot` if CMakeLists.txt not in root
    - Patch build files to remove external downloads
    - Relax Python version constraints

--- a/forge/modules/builders/go-builder.nix
+++ b/forge/modules/builders/go-builder.nix
@@ -29,7 +29,7 @@ in
                       Go module builder for applications and libraries.
 
                       Uses buildGoModule from nixpkgs under the hood.'';
-                    inputs = {
+                    requirements = {
                       build = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -156,9 +156,9 @@ in
                         ldflags = pkg.build.goPackageBuilder.ldflags;
                         tags = pkg.build.goPackageBuilder.tags;
                         proxyVendor = pkg.build.goPackageBuilder.proxyVendor;
-                        nativeBuildInputs = pkg.build.goPackageBuilder.inputs.build;
-                        buildInputs = pkg.build.goPackageBuilder.inputs.run;
-                        nativeCheckInputs = pkg.build.goPackageBuilder.inputs.check;
+                        nativeBuildInputs = pkg.build.goPackageBuilder.requirements.build;
+                        buildInputs = pkg.build.goPackageBuilder.requirements.run;
+                        nativeCheckInputs = pkg.build.goPackageBuilder.requirements.check;
                         passthru = sharedBuildAttrs.pkgPassthru pkg finalAttrs.finalPackage;
                         meta = sharedBuildAttrs.pkgMeta pkg;
                       }

--- a/forge/modules/builders/python-app-builder.nix
+++ b/forge/modules/builders/python-app-builder.nix
@@ -29,7 +29,7 @@ in
                       Python application builder for executable Python programs.
 
                       Uses buildPythonApplication which prevents the package from being used as a dependency'';
-                    inputs = {
+                    requirements = {
                       build-system = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -124,9 +124,9 @@ in
                         format = "pyproject";
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        build-system = pkg.build.pythonAppBuilder.inputs.build-system;
-                        dependencies = pkg.build.pythonAppBuilder.inputs.dependencies;
-                        optional-dependencies = pkg.build.pythonAppBuilder.inputs.optional-dependencies;
+                        build-system = pkg.build.pythonAppBuilder.requirements.build-system;
+                        dependencies = pkg.build.pythonAppBuilder.requirements.dependencies;
+                        optional-dependencies = pkg.build.pythonAppBuilder.requirements.optional-dependencies;
                         pythonImportsCheck = pkg.build.pythonAppBuilder.importsCheck;
                         pythonRelaxDeps = pkg.build.pythonAppBuilder.relaxDeps;
                         disabledTests = pkg.build.pythonAppBuilder.disabledTests;

--- a/forge/modules/builders/python-package-builder.nix
+++ b/forge/modules/builders/python-package-builder.nix
@@ -29,7 +29,7 @@ in
                       Python package builder for reusable Python libraries.
 
                       Uses buildPythonPackage which allows the package to be used as a dependency by other packages'';
-                    inputs = {
+                    requirements = {
                       build-system = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -124,9 +124,9 @@ in
                         format = "pyproject";
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        build-system = pkg.build.pythonPackageBuilder.inputs.build-system;
-                        dependencies = pkg.build.pythonPackageBuilder.inputs.dependencies;
-                        optional-dependencies = pkg.build.pythonPackageBuilder.inputs.optional-dependencies;
+                        build-system = pkg.build.pythonPackageBuilder.requirements.build-system;
+                        dependencies = pkg.build.pythonPackageBuilder.requirements.dependencies;
+                        optional-dependencies = pkg.build.pythonPackageBuilder.requirements.optional-dependencies;
                         pythonImportsCheck = pkg.build.pythonPackageBuilder.importsCheck;
                         pythonRelaxDeps = pkg.build.pythonPackageBuilder.relaxDeps;
                         disabledTests = pkg.build.pythonPackageBuilder.disabledTests;

--- a/forge/modules/builders/rust-package-builder/builder-options.nix
+++ b/forge/modules/builders/rust-package-builder/builder-options.nix
@@ -12,7 +12,7 @@
 
       Uses rustPlatform.buildRustPackage'';
 
-    inputs = {
+    requirements = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];

--- a/forge/modules/builders/rust-package-builder/default.nix
+++ b/forge/modules/builders/rust-package-builder/default.nix
@@ -39,9 +39,9 @@ in
                   src = sharedBuildAttrs.pkgSource pkg;
                   patches = pkg.source.patches or [ ];
 
-                  nativeBuildInputs = pkg.build.rustPackageBuilder.inputs.build;
-                  buildInputs = pkg.build.rustPackageBuilder.inputs.run;
-                  nativeCheckInputs = pkg.build.rustPackageBuilder.inputs.check;
+                  nativeBuildInputs = pkg.build.rustPackageBuilder.requirements.build;
+                  buildInputs = pkg.build.rustPackageBuilder.requirements.run;
+                  nativeCheckInputs = pkg.build.rustPackageBuilder.requirements.check;
 
                   cargoHash = pkg.build.rustPackageBuilder.cargoHash;
                   cargoBuildFlags = pkg.build.rustPackageBuilder.cargoBuildFlags;

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -117,7 +117,7 @@ in
           pkgPassthru = pkg: finalPkg: {
             test = pkgs.testers.runCommand {
               name = "${pkg.name}-test";
-              buildInputs = [ finalPkg ] ++ pkg.test.inputs;
+              buildInputs = [ finalPkg ] ++ pkg.test.requirements;
               script = pkg.test.script + "\ntouch $out";
             };
             devenv = pkgs.mkShell {
@@ -126,7 +126,7 @@ in
               inputsFrom = [
                 finalPkg
               ];
-              packages = pkg.development.inputs;
+              packages = pkg.development.requirements;
               shellHook = pkg.development.shellHook;
             };
           };

--- a/forge/modules/builders/standard-builder.nix
+++ b/forge/modules/builders/standard-builder.nix
@@ -29,7 +29,7 @@ in
                       Standard builder for autotools, CMake, or Makefile-based projects.
 
                       Automatically handles configure, build, and install phases'';
-                    inputs = {
+                    requirements = {
                       build = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -86,9 +86,9 @@ in
                         version = pkg.version;
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        nativeBuildInputs = pkg.build.standardBuilder.inputs.build;
-                        buildInputs = pkg.build.standardBuilder.inputs.run;
-                        nativeCheckInputs = pkg.build.standardBuilder.inputs.check;
+                        nativeBuildInputs = pkg.build.standardBuilder.requirements.build;
+                        buildInputs = pkg.build.standardBuilder.requirements.run;
+                        nativeCheckInputs = pkg.build.standardBuilder.requirements.check;
                         passthru = sharedBuildAttrs.pkgPassthru pkg finalAttrs.finalPackage;
                         meta = sharedBuildAttrs.pkgMeta pkg;
                       }

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -177,7 +177,7 @@ in
 
                         # Test configuration
                         test = {
-                          inputs = lib.mkOption {
+                          requirements = lib.mkOption {
                             type = lib.types.listOf lib.types.package;
                             default = [ ];
                             description = "Additional packages required for running tests.";
@@ -204,7 +204,7 @@ in
 
                         # Development configuration
                         development = {
-                          inputs = lib.mkOption {
+                          requirements = lib.mkOption {
                             type = lib.types.listOf lib.types.package;
                             default = [ ];
                             description = ''

--- a/recipes/packages/helium/recipe.nix
+++ b/recipes/packages/helium/recipe.nix
@@ -20,7 +20,7 @@
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs = {
+    requirements = {
       build-system = [
         pkgs.python3Packages.setuptools
       ];

--- a/recipes/packages/requests/recipe.nix
+++ b/recipes/packages/requests/recipe.nix
@@ -20,7 +20,7 @@
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs = {
+    requirements = {
       build-system = [
         pkgs.python3Packages.setuptools
       ];

--- a/recipes/packages/tau-radio/recipe.nix
+++ b/recipes/packages/tau-radio/recipe.nix
@@ -20,7 +20,7 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    inputs = {
+    requirements = {
       build = with pkgs; [
         pkg-config
         rustPlatform.bindgenHook

--- a/recipes/packages/tau-tower/recipe.nix
+++ b/recipes/packages/tau-tower/recipe.nix
@@ -20,7 +20,7 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    inputs = {
+    requirements = {
       build = with pkgs; [
         perl
         pkg-config


### PR DESCRIPTION
1. `inputs` doesn't look that more intuitive than `requirements`,
especially for `development` and `test` options.

2. It is not consistent with apps options where we still use
requirements (and renaming them to inputs is not suitable).

