### PR TITLE
refactor: rename inputs and requirements options to packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Other packages built by Nix Forge can be referenced in recipes using `pkgs.mypkg
 ```nix
 {
   # Reference another Nix Forge package
-  inputs.run = [
+  packages.run = [
     pkgs.mypkgs.gdal  # Access gdal from Nix Forge
   ];
 }
@@ -114,15 +114,15 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.cmake
       pkgs.pkg-config
     ];
-    inputs.run = [
+    packages.run = [
       pkgs.openssl
       pkgs.zlib
     ];
-    inputs.check = [
+    packages.check = [
       pkgs.cunit
     ];
   };
@@ -244,13 +244,13 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.goPackageBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.pkg-config
     ];
-    inputs.run = [
+    packages.run = [
       pkgs.openssl
     ];
-    inputs.check = [
+    packages.check = [
       pkgs.gotestsum
     ];
     vendorHash = "sha256-...";
@@ -267,9 +267,9 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 
 **Inputs options**:
 
-- `inputs.build`: Build-time tools (pkg-config, installShellFiles)
-- `inputs.run`: CGO dependencies (openssl, sqlite)
-- `inputs.check`: Test tools (gotestsum)
+- `packages.build`: Build-time tools (pkg-config, installShellFiles)
+- `packages.run`: CGO dependencies (openssl, sqlite)
+- `packages.check`: Test tools (gotestsum)
 
 ### 5. rustPackageBuilder (Rust Crates)
 
@@ -279,15 +279,15 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 {
   build.rustPackageBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.pkg-config
       pkgs.rustPlatform.bindgenHook
     ];
-    inputs.run = [
+    packages.run = [
       pkgs.openssl
       pkgs.sqlite
     ];
-    inputs.check = [
+    packages.check = [
       pkgs.cargo-nextest
     ];
     cargoHash = "sha256-...";
@@ -304,9 +304,9 @@ error: flake does not provide attribute 'packages.x86_64-linux.<package-name>'
 
 **Inputs options**:
 
-- `inputs.build`: Build-time tools (pkg-config, bindgenHook)
-- `inputs.run`: Runtime dependencies (openssl, sqlite, etc.)
-- `inputs.check`: Test tools (cargo-nextest)
+- `packages.build`: Build-time tools (pkg-config, bindgenHook)
+- `packages.run`: Runtime dependencies (openssl, sqlite, etc.)
+- `packages.check`: Test tools (cargo-nextest)
 
 ## Source Configuration
 
@@ -360,7 +360,7 @@ source = {
 
 ```nix
 test = {
-  inputs = [ pkgs.curl ];  # Additional test dependencies
+  packages = [ pkgs.curl ];  # Additional test dependencies
   script = ''
     # Test commands
     $out/bin/program --version
@@ -380,7 +380,7 @@ test = {
 
 ```nix
 development = {
-  inputs = [ pkgs.gdb pkgs.valgrind ];  # Dev tools
+  packages = [ pkgs.gdb pkgs.valgrind ];  # Dev tools
   shellHook = ''
     echo "Development environment ready"
     echo "Source code: clone from ${source.git}"
@@ -508,7 +508,7 @@ Creates a shell bundle with all required packages available in PATH:
 ```nix
 programs = {
   components.default = {
-    requirements = [
+    packages = [
       pkgs.mypkgs.my-package  # Reference packages from forge
       pkgs.curl
       pkgs.jq
@@ -523,7 +523,7 @@ programs = {
 
 **Structure:**
 
-- `programs.components.<name>`: Named components with requirements
+- `programs.components.<name>`: Named components with packages
 - `programs.runtimes.shell.enable`: Enable shell bundle output
 
 **Access:** `nix shell .#<app>` or `nix build .#<app>`
@@ -537,7 +537,7 @@ container = {
   enable = true;  # Set to true to enable container image output
   tag = "latest";  # Optional, defaults to "latest"
 
-  requirements = [
+  packages = [
     pkgs.mypkgs.my-package  # Packages to include in /bin
   ];
 
@@ -649,7 +649,7 @@ Each app output type can be independently enabled or disabled:
   # Shell bundle with additional tools
   programs = {
     components.default = {
-      requirements = [
+      packages = [
         pkgs.mypkgs.python-web
         pkgs.curl
         pkgs.postgresql
@@ -665,7 +665,7 @@ Each app output type can be independently enabled or disabled:
   container = {
     enable = true;
     tag = "latest";
-    requirements = [ pkgs.mypkgs.python-web ];
+    packages = [ pkgs.mypkgs.python-web ];
     imageConfig = {
       Env = [ "PORT=5000" ];
       ExposedPorts = { "5000/tcp" = { }; };
@@ -716,8 +716,8 @@ ELSE IF has configure script OR uses CMake OR standard Makefile:
 
 ### 3. Dependency Resolution
 
-- **Build tools**: cmake, pkg-config, autoconf → `inputs.build`
-- **Libraries**: openssl, zlib, curl → `inputs.run`
+- **Build tools**: cmake, pkg-config, autoconf → `packages.build`
+- **Libraries**: openssl, zlib, curl → `packages.run`
 - **Python packages**: Use `pkgs.python3Packages.*`
 - **Unknown packages**: Use `pkgs.<package-name>`
 
@@ -768,11 +768,11 @@ source.hash = "";  # Leave empty initially
 
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.rustc
       pkgs.cargo
     ];
-    inputs.run = [ ];
+    packages.run = [ ];
   };
 
   test.script = ''
@@ -806,10 +806,10 @@ source.hash = "";  # Leave empty initially
 
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.which
     ];
-    inputs.run = [
+    packages.run = [
       pkgs.openssl
       pkgs.pcre
       pkgs.zlib
@@ -847,10 +847,10 @@ source.hash = "";  # Leave empty initially
 
   build.pythonAppBuilder = {
     enable = true;
-    inputs.build-system = [
+    packages.build-system = [
       pkgs.python3Packages.setuptools
     ];
-    inputs.dependencies = [
+    packages.dependencies = [
       pkgs.python3Packages.typing-extensions
       pkgs.python3Packages.mypy-extensions
     ];
@@ -887,10 +887,10 @@ source.hash = "";  # Leave empty initially
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs.build-system = [
+    packages.build-system = [
       pkgs.python3Packages.setuptools
     ];
-    inputs.dependencies = [
+    packages.dependencies = [
       pkgs.python3Packages.charset-normalizer
       pkgs.python3Packages.idna
       pkgs.python3Packages.urllib3
@@ -922,7 +922,7 @@ source.hash = "";  # Leave empty initially
 
 **Issue**: Missing dependency
 
-- **Solution**: Add to inputs.build or inputs.run
+- **Solution**: Add to packages.build or packages.run
 
 ## Naming Conventions
 
@@ -1033,9 +1033,9 @@ Check for submodules:
 
 **Dependency categories:**
 
-- **Build tools** (cmake, pkg-config, autoconf, meson, ninja) → `inputs.build`
-- **Libraries** (sqlite, gdal, openssl, zlib, postgresql) → `inputs.run`
-- **Test Tools** (cunit, pytest) → `inputs.check`
+- **Build tools** (cmake, pkg-config, autoconf, meson, ninja) → `packages.build`
+- **Libraries** (sqlite, gdal, openssl, zlib, postgresql) → `packages.run`
+- **Test Tools** (cunit, pytest) → `packages.check`
 - **Python packages** → `pkgs.python3Packages.<name>` in dependencies
 
 ### Step 5: Check for External/Vendored Dependencies
@@ -1060,7 +1060,7 @@ Nix builds in a sandbox without network access. You must:
 
 2. **Option 2:** Provide dependencies via nativeBuildInputs
    ```nix
-   inputs.build = [ pkgs.somelib ];
+   packages.build = [ pkgs.somelib ];
    ```
 
 3. **Option 3:** Patch build files to remove download steps
@@ -1164,7 +1164,7 @@ CMake Error at CMakeLists.txt:104 (INCLUDE):
 
 2. **Provide missing dependencies:**
    ```nix
-   inputs.run = [ pkgs.libgpkg ];  # If available in nixpkgs
+   packages.run = [ pkgs.libgpkg ];  # If available in nixpkgs
    ```
 
 3. **Patch CMakeLists.txt:**
@@ -1321,7 +1321,7 @@ START: What type of project is this?
 | wheel                              | `pkgs.python3Packages.wheel`              |
 | pytest                             | `pkgs.python3Packages.pytest` (test only) |
 
-### Build Tools (always in inputs.build)
+### Build Tools (always in packages.build)
 
 - `pkgs.cmake` - CMake build system
 - `pkgs.pkg-config` - Finding library dependencies
@@ -1384,7 +1384,7 @@ git add recipes/packages/<name>/recipe.nix
    ```
 
    Common fixes needed:
-   - Add missing dependencies to `inputs.build` or `inputs.run`
+   - Add missing dependencies to `packages.build` or `packages.run`
    - Set `sourceRoot` if CMakeLists.txt not in root
    - Patch build files to remove external downloads
    - Relax Python version constraints

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -60,7 +60,7 @@ in
               let
                 appDrv = pkgs.symlinkJoin {
                   name = "${app.name}";
-                  paths = lib.flatten (lib.mapAttrsToList (name: value: value.requirements) app.programs.components);
+                  paths = lib.flatten (lib.mapAttrsToList (name: value: value.packages) app.programs.components);
                 };
               in
               # Passthru

--- a/forge/modules/apps/programs/component.nix
+++ b/forge/modules/apps/programs/component.nix
@@ -4,7 +4,7 @@
 }:
 {
   options = {
-    requirements = lib.mkOption {
+    packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
     };

--- a/forge/modules/apps/programs/default.nix
+++ b/forge/modules/apps/programs/default.nix
@@ -15,7 +15,7 @@
       example = lib.literalExpression ''
         {
           default = {
-            requirements = [ pkgs.curl ];
+            packages = [ pkgs.curl ];
           };
         }
       '';

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -17,7 +17,7 @@
       description = "Tag of the generated container.";
     };
 
-    requirements = lib.mkOption {
+    packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
       description = "List of packages to add to the container's `/bin` directory.";
@@ -82,7 +82,7 @@
       settings.container = {
         copyToRoot = pkgs.buildEnv {
           name = "runtime-bins";
-          paths = config.requirements;
+          paths = config.packages;
           pathsToLink = [ "/bin" ];
         };
 

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -8,7 +8,7 @@
 }:
 {
   options = {
-    requirements = lib.mkOption {
+    packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
       description = "Additional packages required for running tests.";
@@ -75,11 +75,11 @@
         system.stateVersion = "25.11";
         environment.systemPackages =
           let
-            program-requirements = lib.flatten (
-              lib.mapAttrsToList (name: value: value.requirements) app.programs.components
+            program-packages = lib.flatten (
+              lib.mapAttrsToList (name: value: value.packages) app.programs.components
             );
           in
-          program-requirements ++ config.requirements;
+          program-packages ++ config.packages;
       };
       inherit (config) testScript;
     };

--- a/forge/modules/builders/go-builder.nix
+++ b/forge/modules/builders/go-builder.nix
@@ -29,7 +29,7 @@ in
                       Go module builder for applications and libraries.
 
                       Uses buildGoModule from nixpkgs under the hood.'';
-                    inputs = {
+                    packages = {
                       build = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -156,9 +156,9 @@ in
                         ldflags = pkg.build.goPackageBuilder.ldflags;
                         tags = pkg.build.goPackageBuilder.tags;
                         proxyVendor = pkg.build.goPackageBuilder.proxyVendor;
-                        nativeBuildInputs = pkg.build.goPackageBuilder.inputs.build;
-                        buildInputs = pkg.build.goPackageBuilder.inputs.run;
-                        nativeCheckInputs = pkg.build.goPackageBuilder.inputs.check;
+                        nativeBuildInputs = pkg.build.goPackageBuilder.packages.build;
+                        buildInputs = pkg.build.goPackageBuilder.packages.run;
+                        nativeCheckInputs = pkg.build.goPackageBuilder.packages.check;
                         passthru = sharedBuildAttrs.pkgPassthru pkg finalAttrs.finalPackage;
                         meta = sharedBuildAttrs.pkgMeta pkg;
                       }

--- a/forge/modules/builders/python-app-builder.nix
+++ b/forge/modules/builders/python-app-builder.nix
@@ -29,7 +29,7 @@ in
                       Python application builder for executable Python programs.
 
                       Uses buildPythonApplication which prevents the package from being used as a dependency'';
-                    inputs = {
+                    packages = {
                       build-system = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -124,9 +124,9 @@ in
                         format = "pyproject";
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        build-system = pkg.build.pythonAppBuilder.inputs.build-system;
-                        dependencies = pkg.build.pythonAppBuilder.inputs.dependencies;
-                        optional-dependencies = pkg.build.pythonAppBuilder.inputs.optional-dependencies;
+                        build-system = pkg.build.pythonAppBuilder.packages.build-system;
+                        dependencies = pkg.build.pythonAppBuilder.packages.dependencies;
+                        optional-dependencies = pkg.build.pythonAppBuilder.packages.optional-dependencies;
                         pythonImportsCheck = pkg.build.pythonAppBuilder.importsCheck;
                         pythonRelaxDeps = pkg.build.pythonAppBuilder.relaxDeps;
                         disabledTests = pkg.build.pythonAppBuilder.disabledTests;

--- a/forge/modules/builders/python-package-builder.nix
+++ b/forge/modules/builders/python-package-builder.nix
@@ -29,7 +29,7 @@ in
                       Python package builder for reusable Python libraries.
 
                       Uses buildPythonPackage which allows the package to be used as a dependency by other packages'';
-                    inputs = {
+                    packages = {
                       build-system = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -124,9 +124,9 @@ in
                         format = "pyproject";
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        build-system = pkg.build.pythonPackageBuilder.inputs.build-system;
-                        dependencies = pkg.build.pythonPackageBuilder.inputs.dependencies;
-                        optional-dependencies = pkg.build.pythonPackageBuilder.inputs.optional-dependencies;
+                        build-system = pkg.build.pythonPackageBuilder.packages.build-system;
+                        dependencies = pkg.build.pythonPackageBuilder.packages.dependencies;
+                        optional-dependencies = pkg.build.pythonPackageBuilder.packages.optional-dependencies;
                         pythonImportsCheck = pkg.build.pythonPackageBuilder.importsCheck;
                         pythonRelaxDeps = pkg.build.pythonPackageBuilder.relaxDeps;
                         disabledTests = pkg.build.pythonPackageBuilder.disabledTests;

--- a/forge/modules/builders/rust-package-builder/builder-options.nix
+++ b/forge/modules/builders/rust-package-builder/builder-options.nix
@@ -12,7 +12,7 @@
 
       Uses rustPlatform.buildRustPackage'';
 
-    inputs = {
+    packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];

--- a/forge/modules/builders/rust-package-builder/default.nix
+++ b/forge/modules/builders/rust-package-builder/default.nix
@@ -39,9 +39,9 @@ in
                   src = sharedBuildAttrs.pkgSource pkg;
                   patches = pkg.source.patches or [ ];
 
-                  nativeBuildInputs = pkg.build.rustPackageBuilder.inputs.build;
-                  buildInputs = pkg.build.rustPackageBuilder.inputs.run;
-                  nativeCheckInputs = pkg.build.rustPackageBuilder.inputs.check;
+                  nativeBuildInputs = pkg.build.rustPackageBuilder.packages.build;
+                  buildInputs = pkg.build.rustPackageBuilder.packages.run;
+                  nativeCheckInputs = pkg.build.rustPackageBuilder.packages.check;
 
                   cargoHash = pkg.build.rustPackageBuilder.cargoHash;
                   cargoBuildFlags = pkg.build.rustPackageBuilder.cargoBuildFlags;

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -117,7 +117,7 @@ in
           pkgPassthru = pkg: finalPkg: {
             test = pkgs.testers.runCommand {
               name = "${pkg.name}-test";
-              buildInputs = [ finalPkg ] ++ pkg.test.inputs;
+              buildInputs = [ finalPkg ] ++ pkg.test.packages;
               script = pkg.test.script + "\ntouch $out";
             };
             devenv = pkgs.mkShell {
@@ -126,7 +126,7 @@ in
               inputsFrom = [
                 finalPkg
               ];
-              packages = pkg.development.inputs;
+              packages = pkg.development.packages;
               shellHook = pkg.development.shellHook;
             };
           };

--- a/forge/modules/builders/standard-builder.nix
+++ b/forge/modules/builders/standard-builder.nix
@@ -29,7 +29,7 @@ in
                       Standard builder for autotools, CMake, or Makefile-based projects.
 
                       Automatically handles configure, build, and install phases'';
-                    inputs = {
+                    packages = {
                       build = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
                         default = [ ];
@@ -86,9 +86,9 @@ in
                         version = pkg.version;
                         src = sharedBuildAttrs.pkgSource pkg;
                         patches = pkg.source.patches;
-                        nativeBuildInputs = pkg.build.standardBuilder.inputs.build;
-                        buildInputs = pkg.build.standardBuilder.inputs.run;
-                        nativeCheckInputs = pkg.build.standardBuilder.inputs.check;
+                        nativeBuildInputs = pkg.build.standardBuilder.packages.build;
+                        buildInputs = pkg.build.standardBuilder.packages.run;
+                        nativeCheckInputs = pkg.build.standardBuilder.packages.check;
                         passthru = sharedBuildAttrs.pkgPassthru pkg finalAttrs.finalPackage;
                         meta = sharedBuildAttrs.pkgMeta pkg;
                       }

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -177,7 +177,7 @@ in
 
                         # Test configuration
                         test = {
-                          inputs = lib.mkOption {
+                          packages = lib.mkOption {
                             type = lib.types.listOf lib.types.package;
                             default = [ ];
                             description = "Additional packages required for running tests.";
@@ -204,7 +204,7 @@ in
 
                         # Development configuration
                         development = {
-                          inputs = lib.mkOption {
+                          packages = lib.mkOption {
                             type = lib.types.listOf lib.types.package;
                             default = [ ];
                             description = ''

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -50,7 +50,7 @@
 
   programs = {
     components.default = {
-      requirements = [
+      packages = [
         pkgs.curl
       ];
     };
@@ -70,9 +70,9 @@
     runtimes = {
       container = {
         enable = true;
-        requirements = [ pkgs.mypkgs.python-web ];
+        packages = [ pkgs.mypkgs.python-web ];
         # Alternatively, we can re-use attributes with `config`:
-        #requirements = [ config.services.python-web.command ];
+        #packages = [ config.services.python-web.command ];
         composeFile = ./compose.yaml;
       };
 

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -44,7 +44,7 @@
 
   programs = {
     components.default = {
-      requirements = [
+      packages = [
         pkgs.mypkgs.tau-radio
       ];
     };
@@ -65,7 +65,7 @@
     runtimes = {
       container = {
         enable = true;
-        requirements = [
+        packages = [
           pkgs.mypkgs.tau-tower
         ];
         composeFile = ./compose.yaml;

--- a/recipes/packages/aerogramme/recipe.nix
+++ b/recipes/packages/aerogramme/recipe.nix
@@ -24,7 +24,7 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    inputs = {
+    packages = {
       build = [
         pkgs.pkg-config
       ];

--- a/recipes/packages/helium/recipe.nix
+++ b/recipes/packages/helium/recipe.nix
@@ -20,7 +20,7 @@
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs = {
+    packages = {
       build-system = [
         pkgs.python3Packages.setuptools
       ];

--- a/recipes/packages/python-web/recipe.nix
+++ b/recipes/packages/python-web/recipe.nix
@@ -20,10 +20,10 @@
 
   build.pythonAppBuilder = {
     enable = true;
-    inputs.build-system = [
+    packages.build-system = [
       pkgs.python3Packages.setuptools
     ];
-    inputs.dependencies = [
+    packages.dependencies = [
       pkgs.python3Packages.flask
       pkgs.python3Packages.psycopg2
     ];

--- a/recipes/packages/requests/recipe.nix
+++ b/recipes/packages/requests/recipe.nix
@@ -20,7 +20,7 @@
 
   build.pythonPackageBuilder = {
     enable = true;
-    inputs = {
+    packages = {
       build-system = [
         pkgs.python3Packages.setuptools
       ];

--- a/recipes/packages/tau-radio/recipe.nix
+++ b/recipes/packages/tau-radio/recipe.nix
@@ -20,7 +20,7 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    inputs = {
+    packages = {
       build = with pkgs; [
         pkg-config
         rustPlatform.bindgenHook

--- a/recipes/packages/tau-tower/recipe.nix
+++ b/recipes/packages/tau-tower/recipe.nix
@@ -20,7 +20,7 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    inputs = {
+    packages = {
       build = with pkgs; [
         perl
         pkg-config

--- a/recipes/packages/tslib/recipe.nix
+++ b/recipes/packages/tslib/recipe.nix
@@ -20,7 +20,7 @@ rec {
 
   build.standardBuilder = {
     enable = true;
-    inputs.build = [
+    packages.build = [
       pkgs.cmake
     ];
   };

--- a/templates/provider/recipes/apps/hello-app/recipe.nix
+++ b/templates/provider/recipes/apps/hello-app/recipe.nix
@@ -11,7 +11,7 @@
 
   programs = {
     components.default = {
-      requirements = [
+      packages = [
         pkgs.mypkgs.hello-nix
       ];
     };
@@ -25,7 +25,7 @@
     runtimes = {
       container = {
         enable = true;
-        requirements = [ pkgs.mypkgs.hello-nix ];
+        packages = [ pkgs.mypkgs.hello-nix ];
         imageConfig.CMD = [
           "hello"
         ];

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -38,7 +38,7 @@ type alias AppName =
 
 
 type alias AppProgramsComponents =
-    { requirements : List String
+    { packages : List String
     }
 
 


### PR DESCRIPTION
`packages` options is more intuitive and makes a sense for both
packages and apps.
