### PR TITLE
forge: use nimi process manager for nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,18 +94,21 @@
     "nimi": {
       "inputs": {
         "nix2container": "nix2container",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1774008115,
-        "narHash": "sha256-hq30WyJ3AsrUOS5yWaXDmLM34YblRadQTidfUzTKZxw=",
-        "owner": "weyl-ai",
+        "lastModified": 1776159258,
+        "narHash": "sha256-QtbbkPw4LJ1IQyogfyt9wx9xpaam5uQcX9ff11sAVcE=",
+        "owner": "ngi-nix",
         "repo": "nimi",
-        "rev": "d47f6d735b768d234d19c27d540c3e6fb4d450a3",
+        "rev": "68e2a43c984e77e74d2f005fab9c1ff01e9478c4",
         "type": "github"
       },
       "original": {
-        "owner": "weyl-ai",
+        "owner": "ngi-nix",
+        "ref": "nixpkgs-update-portable-lib",
         "repo": "nimi",
         "type": "github"
       }
@@ -149,11 +152,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1775294664,
+        "narHash": "sha256-xA9GUXyFT0OHCWzgikiTQaQquyaZUP06h9ltfOnXPNc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "1baf57f3a0a12a99c1f1e74134e3df09c6ef7bfb",
         "type": "github"
       },
       "original": {
@@ -178,22 +181,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1775294664,
-        "narHash": "sha256-xA9GUXyFT0OHCWzgikiTQaQquyaZUP06h9ltfOnXPNc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1baf57f3a0a12a99c1f1e74134e3df09c6ef7bfb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devshell": "devshell",
@@ -202,7 +189,7 @@
         "import-tree": "import-tree",
         "nimi": "nimi",
         "nix-utils": "nix-utils",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    nimi.url = "github:weyl-ai/nimi";
+    nimi = {
+      url = "github:ngi-nix/nimi/nixpkgs-update-portable-lib";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -11,22 +11,6 @@
   options = {
     enable = lib.mkEnableOption "NixOS/VM output";
 
-    # TODO:
-    # - wire this up with nimi
-    # - maybe rename to `nimi` or `nimi-settings`?
-    settings = lib.mkOption {
-      type = lib.types.attrsOf lib.types.anything;
-      default = { };
-      description = "Nimi settings for the NixOS configuration.";
-      example = lib.literalExpression ''
-        {
-          restart.mode = "always";
-          restart.time = 1000;
-          logging.enable = true;
-        }
-      '';
-    };
-
     setup = lib.mkOption {
       type = lib.types.str;
       default = "";

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -131,33 +131,29 @@
 
   config = {
     result.modules = [
+      # nimi NixOS module — runs services via nimi process manager
+      inputs.nimi.nixosModules.default
       {
-        # modular services
-        system = {
-          services = lib.pipe app.services.components [
-            # NixOS already defines `configData."*".path`, but other runtimes
-            # don't do that. Since it's a read-only option, we can't just
-            # change its priority, so here we just filter out any non-NixOS
-            # declarations of that option.
-            # TODO: is there a more robust way of doing this?
-            # configData."*".path -> remove
-            (lib.filterAttrsRecursive (name: value: name != "path"))
-            (lib.mapAttrs (
-              _: service:
-              lib.recursiveUpdate service.result {
-                systemd.mainExecStart = lib.escapeShellArgs service.result.process.argv;
-                systemd.service = {
-                  environment = service.environment;
+        nimi = lib.mapAttrs (
+          serviceName: service:
+          {
+            services.${serviceName} = {
+              imports = [
+                service.result
+                {
+                  options.nimi = lib.mkOption {
+                    type = with lib.types; lazyAttrsOf (attrsOf anything);
+                    default = { };
+                    description = ''
+                      Let the modular service know that it's evaluated for nimi,
+                      by testing `options ? nimi`.
+                    '';
+                  };
                 }
-                // lib.optionalAttrs (config.setup != "") {
-                  # make sure services run after setup is done
-                  after = [ "${app.name}-setup.service" ];
-                  requires = [ "${app.name}-setup.service" ];
-                };
-              }
-            ))
-          ];
-        };
+              ];
+            };
+          }
+        ) app.services.components;
 
         environment.variables = lib.concatMapAttrs (_: value: value.environment) app.services.components;
       }

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -96,13 +96,15 @@
   };
 
   test.script = ''
-    curl -X POST localhost:5000/init
+    curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
 
-    curl -X POST \
+    $curl -X POST localhost:5000/init
+
+    $curl -X POST \
       --header "Content-Type: application/json" \
       --data '{"name":"username"}' \
       localhost:5000/users
 
-    curl localhost:5000/users
+    $curl localhost:5000/users
   '';
 }


### PR DESCRIPTION
Use the same application service process manager for containers and
NixOS.

We need to use branch from our nimi fork due to portable services modules location incompatibility between our nixpkgs version and version used by Nimi. 
