### PR TITLE
ui: remove app usage instructions title

### DIFF
--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -94,7 +94,6 @@ viewPageAppUsage _ pageApp =
     if not (String.isEmpty pageApp.pageApp_app.app_usage) then
         div [ id "usage", class "mt-4" ]
             [ hr [] []
-            , h4 [ class "mb-3" ] [ text "Usage Instructions" ]
             , div [ class "markdown-content" ]
                 (pageApp.pageApp_app.app_usage
                     |> Markdown.render


### PR DESCRIPTION
App usage instructions title can conflicts with titles provided by
instructions itself (see for example in https://pr-260--ngi-forge-pr-preview.netlify.app/app/tau).
