### PR TITLE
feat(ui): add license to package information

### DIFF
--- a/ui/src/Main/Helpers/Html.elm
+++ b/ui/src/Main/Helpers/Html.elm
@@ -32,3 +32,18 @@ onClick : update -> Attribute update
 onClick update =
     Html.Events.preventDefaultOn "click"
         (Json.Decode.succeed ( update, True ))
+
+
+{-| Stop a click event from bubbling up to a parent element.
+Use this on external links nested inside an `onClick` parent.
+
+-}
+onClickStopPropagation : Attribute Update
+onClickStopPropagation =
+    Html.Events.custom "click"
+        (Json.Decode.succeed
+            { message = Update_NoOp
+            , stopPropagation = True
+            , preventDefault = False
+            }
+        )

--- a/ui/src/Main/View/Page/Packages.elm
+++ b/ui/src/Main/View/Page/Packages.elm
@@ -95,8 +95,14 @@ viewPagePackagesItem model pagePackages package =
             , div []
                 (package.package_description |> Markdown.render)
             ]
-        , div []
+        , div [ class "d-flex gap-3" ]
             [ a
+                [ href package.package_license.license_url
+                , target "_blank"
+                , rel "noopener"
+                ]
+                [ text package.package_license.license_spdxId ]
+            , a
                 [ href <| showPackageRecipeLink model package
                 , target "_blank"
                 , rel "noopener"

--- a/ui/src/Main/View/Page/Packages.elm
+++ b/ui/src/Main/View/Page/Packages.elm
@@ -100,12 +100,14 @@ viewPagePackagesItem model pagePackages package =
                 [ href package.package_license.license_url
                 , target "_blank"
                 , rel "noopener"
+                , onClickStopPropagation
                 ]
                 [ text package.package_license.license_spdxId ]
             , a
                 [ href <| showPackageRecipeLink model package
                 , target "_blank"
                 , rel "noopener"
+                , onClickStopPropagation
                 ]
                 [ text "Forge Recipe" ]
             ]


### PR DESCRIPTION
This PR is also fixing links opening in package details.

External links (license and Forge Recipe) nested inside the package list
item's `onClick` handler were being intercepted by the parent's
`preventDefaultOn` "click", preventing them from opening.

This change is adding `onClickStopPropagation` helper that stops click
propagation on the inner links so they open correctly in a new tab.