### PR TITLE
fix(ui): show placeholder icon to improve loading

### DIFF
--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -52,7 +52,8 @@ viewPageAppHeader _ pageApp =
             ]
             [ img
                 [ src (getAppIconPath pageApp.pageApp_route.routeApp_name)
-                , class "app-header-icon"
+                , class "item-header-icon"
+                , attribute "loading" "lazy"
                 , attribute "alt" (pageApp.pageApp_route.routeApp_name ++ " icon")
                 ]
                 []

--- a/ui/src/Main/View/Page/Apps.elm
+++ b/ui/src/Main/View/Page/Apps.elm
@@ -75,7 +75,8 @@ viewPageAppsApp _ app =
             ]
             [ img
                 [ src (getAppIconPath app.app_name)
-                , class "app-card-icon"
+                , class "item-card-icon"
+                , attribute "loading" "lazy"
                 , attribute "alt" (app.app_name ++ " icon")
                 ]
                 []

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -115,6 +115,10 @@ body {
   height: 48px;
   object-fit: contain;
   flex-shrink: 0;
+  background-color: transparent;
+  border-radius: 8px;
+  color: transparent; /* Hide alt text before image loads on firefox */
+  font-size: 0;
 }
 
 .item-header-icon {
@@ -122,6 +126,10 @@ body {
   height: 64px;
   object-fit: contain;
   flex-shrink: 0;
+  background-color: transparent;
+  border-radius: 12px;
+  color: transparent; /* Hide alt text before image loads on firefox */
+  font-size: 0;
 }
 
 /* Hide the annoying border around search bar that bootstrap adds */


### PR DESCRIPTION
It adds a transparent placeholder and hides the alt text on firefox, so the initial home page load looks a bit better.