### PR TITLE
Add application displayName option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,7 @@ build.extraAttrs = {
 ```nix
 {
   name = "app-name";
+  displayName = "Human Readable Name";  # Optional: defaults to name if not set
   description = "Application description.";
   usage = ''
     Usage instructions in markdown format.
@@ -467,6 +468,7 @@ Apps can optionally specify a custom icon in SVG format. When creating app recip
 ```nix
 {
   name = "my-app";
+  displayName = "My Application";
   description = "My application";
   icon = ./logo.svg;  # Found in repository root
 
@@ -623,6 +625,7 @@ Each app output type can be independently enabled or disabled:
 
 {
   name = "python-web-app";
+  displayName = "Python Web Example";
   description = "Simple web application with database backend.";
   usage = ''
     This is a simple example app which provides a web API.

--- a/flake/develop/commands/dev/dev-ui/build_app_resources.py
+++ b/flake/develop/commands/dev/dev-ui/build_app_resources.py
@@ -72,9 +72,7 @@ def populate_resources_dir():
             if not app_name:
                 continue
 
-            # Remove '-app' suffix for directory name
-            app_dir_name = app_name[:-4] if app_name.endswith("-app") else app_name
-            app_dir: Path = apps_dir / app_dir_name
+            app_dir: Path = apps_dir / app_name
             app_dir.mkdir(parents=True, exist_ok=True)
 
             app_icon: str = app.get("icon")

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -16,6 +16,11 @@
       type = lib.types.str;
       default = "my-application";
     };
+    displayName = lib.mkOption {
+      type = lib.types.str;
+      default = config.name;
+      description = "Human readable application name. Defaults to `name` if not set.";
+    };
     description = lib.mkOption {
       type = lib.types.str;
       default = "";

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -45,13 +45,9 @@
         ${lib.concatStringsSep "\n" (
           map (
             app:
-            let
-              # Remove -app suffix for directory name
-              appDir = lib.removeSuffix "-app" app.name;
-            in
             ''
-              mkdir -p $out/${appDir}
-              ${if app.icon or null != null then "cp ${app.icon} $out/${appDir}/icon.svg" else ""}
+              mkdir -p $out/${app.name}
+              ${if app.icon or null != null then "cp ${app.icon} $out/${app.name}/icon.svg" else ""}
             ''
           ) config.forge.apps
         )}

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -7,6 +7,7 @@
 
 {
   name = "python-web-app";
+  displayName = "Python Web Example";
   description = "Example web API with database backend.";
   usage = ''
     This is a simple example application that provides a web API for

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -7,6 +7,7 @@
 
 {
   name = "tau-app";
+  displayName = "Tau";
   description = "Web radio streaming system.";
 
   usage = ''

--- a/ui/package.nix
+++ b/ui/package.nix
@@ -60,20 +60,17 @@ symlinkJoin {
 
     # Process each app: copy icons and create HTML routes
     for app in $(${jq}/bin/jq '.apps.[].name' -r forge-config.json); do
-      # Remove -app suffix for directory name
-      app_dir="''${app%-app}"
-
       # Copy custom icon if it exists, otherwise use default
-      mkdir -p "resources/apps/$app_dir"
-      if [ -f "${appIcons}/$app_dir/icon.svg" ]; then
-        cp "${appIcons}/$app_dir/icon.svg" "resources/apps/$app_dir/icon.svg"
+      mkdir -p "resources/apps/$app"
+      if [ -f "${appIcons}/$app/icon.svg" ]; then
+        cp "${appIcons}/$app/icon.svg" "resources/apps/$app/icon.svg"
       else
-        cp ${defaultIcon} "resources/apps/$app_dir/icon.svg"
+        cp ${defaultIcon} "resources/apps/$app/icon.svg"
       fi
 
       # Create SPA routing for this app (github pages workaround)
-      mkdir -p "app/$app_dir"
-      ln -s $out/index.html "app/$app_dir/index.html"
+      mkdir -p "app/$app"
+      ln -s $out/index.html "app/$app/index.html"
     done
 
     for page in apps packages recipe recipe/options; do

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -2,11 +2,11 @@ module Main.Config.App exposing (..)
 
 import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
-import Main.Helpers.String exposing (..)
 
 
 type alias App =
     { app_name : AppName
+    , app_displayName : String
     , app_description : String
     , app_usage : String
     , app_programs : AppPrograms
@@ -16,15 +16,11 @@ type alias App =
     }
 
 
-app_output : App -> String
-app_output app =
-    app.app_name ++ "-app"
-
-
 decodeApp : Decoder App
 decodeApp =
-    Decode.map7 App
-        (Decode.field "name" (Decode.string |> Decode.map (stripSuffix "-app")))
+    Decode.map8 App
+        (Decode.field "name" Decode.string)
+        (Decode.field "displayName" Decode.string)
         (Decode.field "description" Decode.string)
         (Decode.field "usage" Decode.string)
         (Decode.field "programs" decodeAppPrograms)

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -54,14 +54,14 @@ viewPageAppHeader _ pageApp =
                 [ src (getAppIconPath pageApp.pageApp_route.routeApp_name)
                 , class "item-header-icon"
                 , attribute "loading" "lazy"
-                , attribute "alt" (pageApp.pageApp_route.routeApp_name ++ " icon")
+                , attribute "alt" (pageApp.pageApp_app.app_displayName ++ " icon")
                 ]
                 []
             , h2
                 [ class "mb-0 fw-bold"
                 , style "margin" "0"
                 ]
-                [ text pageApp.pageApp_route.routeApp_name
+                [ text pageApp.pageApp_app.app_displayName
                 ]
             ]
         , button
@@ -166,7 +166,7 @@ showAppRecipeLink model app =
         [ model.model_config.config_repository |> showNixUrl
         , "blob/" ++ commit
         , model.model_config.config_recipe.configRecipe_apps
-        , app |> app_output
+        , app.app_name
         , "recipe.nix"
         ]
 

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -44,7 +44,7 @@ viewPageAppRun model pageApp =
                     ]
                     [ div [ class "modal-content" ]
                         [ div [ class "modal-header" ]
-                            [ h5 [ class "modal-title" ] [ text ("Run " ++ pageApp.pageApp_route.routeApp_name) ]
+                            [ h5 [ class "modal-title" ] [ text ("Run " ++ pageApp.pageApp_app.app_displayName) ]
                             , button
                                 [ class "btn-close"
                                 , onClick (Update_RouteWithoutHistory onClickRoute)
@@ -261,7 +261,7 @@ viewPageAppRunShell model pageApp =
                         [ "nix shell "
                         , showForgeInputFlakes model
                         , "#"
-                        , pageApp.pageApp_app |> app_output
+                        , pageApp.pageApp_app.app_name
                         ]
 
                     PreferencesInstall_NixTraditional ->
@@ -269,7 +269,7 @@ viewPageAppRunShell model pageApp =
                         , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
                         , "  -p '(import <forge> {})"
                         , "."
-                        , pageApp.pageApp_app |> app_output
+                        , pageApp.pageApp_app.app_name
                         , "' "
                         ]
                 )
@@ -289,7 +289,7 @@ viewPageAppRunContainer model pageApp =
                             [ "nix build "
                             , showForgeInputFlakes model
                             , "#"
-                            , pageApp.pageApp_app |> app_output
+                            , pageApp.pageApp_app.app_name
                             , ".container"
                             ]
 
@@ -299,14 +299,14 @@ viewPageAppRunContainer model pageApp =
                             , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
                             , "  -E '(import <forge> {})"
                             , "."
-                            , pageApp.pageApp_app |> app_output
+                            , pageApp.pageApp_app.app_name
                             , ".container"
                             , "' "
                             ]
                 , ""
                 , "./result/bin/build-oci-image"
                 , ""
-                , "podman load < " ++ (pageApp.pageApp_app |> app_output) ++ ".tar"
+                , "podman load < " ++ pageApp.pageApp_app.app_name ++ ".tar"
                 , "podman-compose --profile services --file $(pwd)/result/compose.yaml up"
                 ]
         ]
@@ -324,7 +324,7 @@ viewPageAppRunVM model pageApp =
                         [ "nix run "
                         , showForgeInputFlakes model
                         , "#"
-                        , pageApp.pageApp_app |> app_output
+                        , pageApp.pageApp_app.app_name
                         , ".vm"
                         ]
 
@@ -335,12 +335,12 @@ viewPageAppRunVM model pageApp =
                             , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
                             , "  -E '(import <forge> {})"
                             , "."
-                            , pageApp.pageApp_app |> app_output
+                            , pageApp.pageApp_app.app_name
                             , ".vm"
                             , "' "
                             ]
                         , ""
-                        , "./result/bin/run-" ++ (pageApp.pageApp_app |> app_output) ++ "-vm"
+                        , "./result/bin/run-" ++ pageApp.pageApp_app.app_name ++ "-vm"
                         ]
         ]
 

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -44,7 +44,7 @@ viewPageAppRun model pageApp =
                     ]
                     [ div [ class "modal-content" ]
                         [ div [ class "modal-header" ]
-                            [ h5 [ class "modal-title" ] [ text ("Run " ++ pageApp.pageApp_app.app_displayName) ]
+                            [ h5 [ class "modal-title" ] [ text pageApp.pageApp_app.app_displayName ]
                             , button
                                 [ class "btn-close"
                                 , onClick (Update_RouteWithoutHistory onClickRoute)

--- a/ui/src/Main/View/Page/Apps.elm
+++ b/ui/src/Main/View/Page/Apps.elm
@@ -64,10 +64,10 @@ viewPageAppsApp _ _ app =
                 [ src (getAppIconPath app.app_name)
                 , class "item-card-icon"
                 , attribute "loading" "lazy"
-                , attribute "alt" (app.app_name ++ " icon")
+                , attribute "alt" (app.app_displayName ++ " icon")
                 ]
                 []
-            , h5 [ class "mb-10" ] [ text app.app_name ]
+            , h5 [ class "mb-10" ] [ text app.app_displayName ]
             ]
         , p
             [ class "mb-1"


### PR DESCRIPTION
This PR is adding `displayName` option for apps and is using it as a human name in UI. Application `name` is used in URL and commands. PR also removes `-app` workarounds in UI.

- **feat: add displayName configuration option for apps**
- **feat(ui): use displayName for app title**
- **ui: clean up Run instructions window title**
- **recipes: use displayName for python-web and tau apps**


Closes #252 #253
