### PR TITLE
fix: add real recipe path in json config

### DIFF
--- a/forge/flake-module.nix
+++ b/forge/flake-module.nix
@@ -44,7 +44,10 @@
                 (lib.filter (file: lib.hasSuffix "/recipe.nix" file))
               ];
             in
-            recipeFiles;
+            map (file: (_: {
+              imports = [ file ];
+              recipePath = lib.removePrefix (self.outPath + "/") file;
+            })) recipeFiles;
 
         # Load package and app recipes from configured directories
         packageRecipes = loadRecipes config.forge.recipeDirs.packages;

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -84,6 +84,13 @@
       description = "Test configuration.";
     };
 
+    recipePath = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      internal = true;
+      description = "Path to the recipe.nix file relative to the flake root. Set automatically by the recipe loader.";
+    };
+
     result = {
       extend = lib.mkOption {
         internal = true;

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -246,6 +246,13 @@ in
                             '';
                           };
                         };
+
+                        recipePath = lib.mkOption {
+                          type = lib.types.str;
+                          default = "";
+                          internal = true;
+                          description = "Path to the recipe.nix file relative to the flake root. Set automatically by the recipe loader.";
+                        };
                       };
                     }
                   ];

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -13,20 +13,25 @@ type alias App =
     , app_services : AppServices
     , app_ngi : Ngi
     , app_links : AppLinks
+    , app_recipePath : String
     }
 
 
 decodeApp : Decoder App
 decodeApp =
-    Decode.map8 App
-        (Decode.field "name" Decode.string)
-        (Decode.field "displayName" Decode.string)
-        (Decode.field "description" Decode.string)
-        (Decode.field "usage" Decode.string)
-        (Decode.field "programs" decodeAppPrograms)
-        (Decode.field "services" decodeAppServices)
-        (Decode.field "ngi" decodeNgi)
-        (Decode.field "links" decodeAppLinks)
+    Decode.map2 (\app recipePath -> { app | app_recipePath = recipePath })
+        (Decode.map8 App
+            (Decode.field "name" Decode.string)
+            (Decode.field "displayName" Decode.string)
+            (Decode.field "description" Decode.string)
+            (Decode.field "usage" Decode.string)
+            (Decode.field "programs" decodeAppPrograms)
+            (Decode.field "services" decodeAppServices)
+            (Decode.field "ngi" decodeNgi)
+            (Decode.field "links" decodeAppLinks)
+            |> Decode.map (\f -> f "")
+        )
+        (Decode.field "recipePath" Decode.string)
 
 
 type alias AppName =

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -2,6 +2,7 @@ module Main.Config.App exposing (..)
 
 import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
+import Main.Helpers.Json.Decode as Decode
 
 
 type alias App =
@@ -19,19 +20,16 @@ type alias App =
 
 decodeApp : Decoder App
 decodeApp =
-    Decode.map2 (\app recipePath -> { app | app_recipePath = recipePath })
-        (Decode.map8 App
-            (Decode.field "name" Decode.string)
-            (Decode.field "displayName" Decode.string)
-            (Decode.field "description" Decode.string)
-            (Decode.field "usage" Decode.string)
-            (Decode.field "programs" decodeAppPrograms)
-            (Decode.field "services" decodeAppServices)
-            (Decode.field "ngi" decodeNgi)
-            (Decode.field "links" decodeAppLinks)
-            |> Decode.map (\f -> f "")
-        )
-        (Decode.field "recipePath" Decode.string)
+    App
+        |> Decode.flipMap (Decode.field "name" Decode.string)
+        |> Decode.andMap (Decode.field "displayName" Decode.string)
+        |> Decode.andMap (Decode.field "description" Decode.string)
+        |> Decode.andMap (Decode.field "usage" Decode.string)
+        |> Decode.andMap (Decode.field "programs" decodeAppPrograms)
+        |> Decode.andMap (Decode.field "services" decodeAppServices)
+        |> Decode.andMap (Decode.field "ngi" decodeNgi)
+        |> Decode.andMap (Decode.field "links" decodeAppLinks)
+        |> Decode.andMap (Decode.field "recipePath" Decode.string)
 
 
 type alias AppName =

--- a/ui/src/Main/Config/Package.elm
+++ b/ui/src/Main/Config/Package.elm
@@ -12,12 +12,13 @@ type alias Package =
     , package_mainProgram : String
     , package_license : PackageLicense
     , package_source : PackageSource
+    , package_recipePath : String
     }
 
 
 decodePackage : Decoder Package
 decodePackage =
-    Decode.map7 Package
+    Decode.map8 Package
         (Decode.field "name" Decode.string)
         (Decode.field "description" Decode.string)
         (Decode.field "version" Decode.string)
@@ -25,6 +26,7 @@ decodePackage =
         (Decode.field "mainProgram" Decode.string)
         (Decode.field "license" decodeLicense)
         (Decode.field "source" decodeSource)
+        (Decode.field "recipePath" Decode.string)
 
 
 type alias PackageName =

--- a/ui/src/Main/Helpers/Json/Decode.elm
+++ b/ui/src/Main/Helpers/Json/Decode.elm
@@ -1,0 +1,13 @@
+module Main.Helpers.Json.Decode exposing (..)
+
+import Json.Decode as Decode exposing (Decoder)
+
+
+flipMap : Decoder a -> (a -> value) -> Decoder value
+flipMap x f =
+    Decode.map f x
+
+
+andMap : Decoder a -> Decoder (a -> b) -> Decoder b
+andMap =
+    Decode.map2 (|>)

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -165,9 +165,7 @@ showAppRecipeLink model app =
     String.join "/"
         [ model.model_config.config_repository |> showNixUrl
         , "blob/" ++ commit
-        , model.model_config.config_recipe.configRecipe_apps
-        , app.app_name
-        , "recipe.nix"
+        , app.app_recipePath
         ]
 
 

--- a/ui/src/Main/View/Page/Packages.elm
+++ b/ui/src/Main/View/Page/Packages.elm
@@ -120,7 +120,5 @@ showPackageRecipeLink model package =
     String.join "/"
         [ model.model_config.config_repository |> showNixUrl
         , "blob/" ++ commit
-        , model.model_config.config_recipe.configRecipe_packages
-        , package.package_name
-        , "recipe.nix"
+        , package.package_recipePath
         ]


### PR DESCRIPTION
We assumed that recipe directory name is equal to package/app name which
is might not be true. This change is adding recipe path based on real
location of recipe.
