### PR TITLE
recipes: remove programs configuration from python-web-app

### DIFF
--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -30,6 +30,8 @@
     ```
     curl localhost:5000/users
     ```
+
+    _Available in: container, vm._
   '';
 
   links = {
@@ -47,16 +49,6 @@
       "Example 1"
       "Example 2"
     ];
-  };
-
-  programs = {
-    packages = [
-      pkgs.curl
-    ];
-
-    runtimes.shell = {
-      enable = true;
-    };
   };
 
   services = {


### PR DESCRIPTION
programs configuration didn't contain any python-web program.
