### PR TITLE
feat: add preStart option to nimi services

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776191855,
-        "narHash": "sha256-F+dH5LUBY27zIfA6aPQ5jGQSVMoy+4fiuv2oIKdlVcE=",
+        "lastModified": 1776448905,
+        "narHash": "sha256-Lmazo4/snwAsqWhGD9IQyPXrf5sbvzKslIqZ4IcuUp0=",
         "owner": "ngi-nix",
         "repo": "nimi",
-        "rev": "6ab31237f98bd39e2659a24db12316a37d560d32",
+        "rev": "258fd20856c128040b2932a89ed3b22fa5d613e8",
         "type": "github"
       },
       "original": {

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -1,4 +1,5 @@
 {
+  name,
   inputs,
   pkgs,
 
@@ -27,6 +28,21 @@
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = "Environment variables.";
+    };
+
+    preStart = lib.mkOption {
+      description = ''
+        Script to run before each start of this service.
+
+        Runs before every start attempt, including restarts.
+        If the script exits with a non-zero status, the service
+        is considered failed and the restart policy applies.
+
+        Set to `null` to disable.
+      '';
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      apply = self: if self != null then pkgs.writeShellScript "${name}-pre-start" self else null;
     };
   };
 }

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -39,6 +39,7 @@
                 in
                 [ command ] ++ service.argv;
               configData = service.configData;
+              preStart = service.preStart;
             };
           }
         ) self;


### PR DESCRIPTION
Closes https://github.com/ngi-nix/forge/issues/292

Example:

```nix
  services = {
    components = {
      python-web = {
        command = pkgs.mypkgs.python-web;
        preStart = ''
          echo Hello!
        '';
      };
    };
  };
```

```shellSession
$ podman run --rm -it localhost/python-web-app:latest
[2026-04-20T07:43:03Z INFO  nimi::cli] Launching process manager...
[2026-04-20T07:43:03Z INFO  nimi::process_manager] Starting process manager...
[2026-04-20T07:43:03Z INFO  python-web] Running pre-start script (/nix/store/r5g4iblynwr3rnzn17x9jji5qwh2k6nh-python-web-pre-start)
[2026-04-20T07:43:03Z DEBUG python-web] Hello!
[2026-04-20T07:43:03Z DEBUG python-web]  * Serving Flask app 'python_web.app'
[2026-04-20T07:43:03Z DEBUG python-web]  * Debug mode: off
[2026-04-20T07:43:03Z ERROR python-web] WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
[2026-04-20T07:43:03Z ERROR python-web]  * Running on all addresses (0.0.0.0)
[2026-04-20T07:43:03Z ERROR python-web]  * Running on http://127.0.0.1:5000
[2026-04-20T07:43:03Z ERROR python-web]  * Running on http://192.168.1.100:5000
[2026-04-20T07:43:03Z ERROR python-web] Press CTRL+C to quit
```