### PR TITLE
fix: avoid conflicts with nimi service wrapper

### DIFF
--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -86,6 +86,8 @@
 
   config = {
     result.modules = {
+      settings.binName = "${app.name}-service";
+
       settings.container = {
         copyToRoot = pkgs.buildEnv {
           name = "runtime-bins";

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -106,6 +106,7 @@
       inputs.nimi.nixosModules.default
       {
         nimi = lib.mapAttrs (serviceName: service: {
+          settings.binName = "${serviceName}-service";
           services.${serviceName} = {
             imports = [
               service.result


### PR DESCRIPTION
Nimi process manager generates a wrapper binary for each service it
manages. By default this binary is named after the service (e.g. mox),
which conflicts with actual binary (e.g. mox) which might be already on
PATH.

Setting `settings.binName = "${serviceName}-service"` renames the nimi
wrapper to <service-name>-service, avoiding the conflict.
