### PR TITLE
feat: add tests for application containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
-        run: nix flake check --accept-flake-config
+        run: nix flake check --accept-flake-config --option sandbox relaxed
 
   lint:
     name: Run format checks

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -43,8 +43,9 @@
 
       # All apps passthru attributes
       // (passthruAttr "programs")
-      // (passthruAttr "test")
       // (passthruAttr "container")
-      // (passthruAttr "vm");
+      // (passthruAttr "vm")
+      // (passthruAttr "test")
+      // (passthruAttr "test-container");
     };
 }

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -101,7 +101,12 @@ in
                   vm = app.services.runtimes.nixos.result.build;
                 };
               }
-              // lib.optionalAttrs (app.test.script != "") { test = app.test.result.build; };
+              // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.test.script != "") {
+                test = app.test.result.build;
+              }
+              // lib.optionalAttrs (app.services.runtimes.container.enable && app.test.script != "") {
+                test-container = app.test.result.containerBuild;
+              };
 
             # finalApp parameter is currently not used in this function
             appPassthru = app: finalApp: mkPassthru app;

--- a/forge/modules/apps/test/container.nix
+++ b/forge/modules/apps/test/container.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+
+  app,
+  config,
+  pkgs,
+  ...
+}:
+{
+  options = {
+    result.containerBuild = lib.mkOption {
+      internal = true;
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "NixOS test derivation for the container runtime.";
+    };
+  };
+
+  config = {
+    result.containerBuild = lib.mkIf app.services.runtimes.container.enable (
+      let
+        containerRuntime = app.services.runtimes.container;
+      in
+      (pkgs.testers.runNixOSTest {
+        name = "${app.name}-container-test";
+        nodes.machine = {
+          virtualisation.podman.enable = true;
+          virtualisation.containers.enable = true;
+          virtualisation.diskSize = 4096;
+          system.stateVersion = "25.11";
+          environment.systemPackages = app.programs.packages ++ config.packages ++ [ pkgs.podman-compose ];
+        };
+        testScript = ''
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+          machine.succeed("${containerRuntime.result.build}/bin/build-oci-image")
+          machine.succeed("podman load < ${app.name}.tar")
+          machine.succeed(
+            "podman-compose --file ${containerRuntime.result.build}/${app.name}/compose.yaml up --detach"
+          )
+          machine.succeed("${pkgs.writeShellScript "${app.name}-container-test-script" config.script}")
+        '';
+      }).overrideTestDerivation
+        (_: lib.optionalAttrs (!config.sandbox) { __noChroot = true; })
+    );
+  };
+}

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -7,6 +7,11 @@
   ...
 }:
 {
+  imports = [
+    ./nixos.nix
+    ./container.nix
+  ];
+
   options = {
     packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
@@ -15,16 +20,37 @@
       example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
     };
 
+    sandbox = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable the Nix sandbox when running tests.
+
+        Set to false to allow internet access during tests, which may be
+        required when tests need to download additional resources at runtime,
+        such as container images pulled by compose files.
+
+        When disabled, tests must be launched with Nix sandbox relaxed.
+
+          - nix build .#<app>.test --option sandbox relaxed --builders ""
+          - nix build .#<app>.test-container --option sandbox relaxed --builders ""
+
+        Disable sandbox only when necessary.
+      '';
+    };
+
     script = lib.mkOption {
       type = lib.types.str;
       default = ''
         echo "Test script"
       '';
       description = ''
-        Bash script to run application tests inside a NixOS machine.
+        Bash script to test application services inside a NixOS machine
+        or container.
 
-        The application's services are available in the machine.
-        Run with: nix build .#<app>.test
+        Launch tests with:
+          - nix build .#<app>.test
+          - nix build .#<app>.test-container
       '';
       example = lib.literalExpression ''
         '''
@@ -33,53 +59,16 @@
       '';
     };
 
-    testScript = lib.mkOption {
-      internal = true;
-      type = lib.types.str;
-      default = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
-        ${lib.concatMapAttrsStringSep "\n" (
-          name: _: "machine.wait_for_unit(\"${name}.service\")"
-        ) app.services.components}
-        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
-      '';
-      description = "Python test script passed to the NixOS test driver.";
-    };
-
     result = {
-      build = lib.mkOption {
-        internal = true;
-        readOnly = true;
-        type = lib.types.package;
-        description = "NixOS test derivation.";
-      };
-
       # HACK:
-      # Prevent toJSON from attempting to convert the `build` option,
-      # which won't work because it's a whole NixOS test evaluation.
+      # Prevent toJSON from attempting to convert the `build` options,
+      # which won't work because they are whole NixOS test evaluations.
       __toString = lib.mkOption {
         internal = true;
         readOnly = true;
         type = with lib.types; functionTo str;
         default = self: "nixos-test";
       };
-    };
-  };
-
-  config = {
-    result.build = pkgs.testers.runNixOSTest {
-      name = "${app.name}-test";
-      nodes.machine = {
-        imports = with app.services.runtimes.nixos.result.modules; [
-          nimi
-          setup
-          extraConfig
-        ];
-        system.stateVersion = "25.11";
-        environment.systemPackages = app.programs.packages ++ config.packages;
-      };
-      inherit (config) testScript;
     };
   };
 }

--- a/forge/modules/apps/test/nixos.nix
+++ b/forge/modules/apps/test/nixos.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+
+  app,
+  config,
+  pkgs,
+  ...
+}:
+{
+  options = {
+    testScript = lib.mkOption {
+      internal = true;
+      type = lib.types.str;
+      default = ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        ${lib.concatMapAttrsStringSep "\n" (
+          name: _: "machine.wait_for_unit(\"${name}.service\")"
+        ) app.services.components}
+        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
+      '';
+      description = "Python test script passed to the NixOS test driver.";
+    };
+
+    result.build = lib.mkOption {
+      internal = true;
+      type = lib.types.package;
+      description = "NixOS test derivation.";
+    };
+  };
+
+  config = {
+    result.build =
+      (pkgs.testers.runNixOSTest {
+        name = "${app.name}-test";
+        nodes.machine = {
+          imports = with app.services.runtimes.nixos.result.modules; [
+            nimi
+            setup
+            extraConfig
+          ];
+          system.stateVersion = "25.11";
+          environment.systemPackages = app.programs.packages ++ config.packages;
+        };
+        inherit (config) testScript;
+      }).overrideTestDerivation
+        (_: lib.optionalAttrs (!config.sandbox) { __noChroot = true; });
+  };
+}

--- a/recipes/apps/mox-app/compose.yaml
+++ b/recipes/apps/mox-app/compose.yaml
@@ -2,4 +2,6 @@ services:
   mox-app:
     image: localhost/mox-app:latest
     ports:
-      - "8080:80"
+      - "8080:8080"
+      - "8081:8081"
+      - "8082:8082"

--- a/recipes/apps/mox-app/mox.conf
+++ b/recipes/apps/mox-app/mox.conf
@@ -18,12 +18,15 @@ Listeners:
 
 		AccountHTTP:
 			Enabled: true
+			Port: 8080
 
 		AdminHTTP:
 			Enabled: true
+			Port: 8081
 
 		WebmailHTTP:
 			Enabled: true
+			Port: 8082
 
 		IMAP:
 			Enabled: true

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -26,12 +26,11 @@
     chown mox /var/lib/mox/config/adminpasswd
     ```
 
-    Access the admin web interface at `http://localhost:8080/admin`.
+    #### URLs
 
-    List of available commands:
-    ```
-    mox --help
-    ```
+    * Admin web interface: `http://localhost:8080`
+    * Account web interface: `http://localhost:8081`
+    * Webmail interface: `http://localhost:8081`
 
     _Available in: container, nixos._
   '';
@@ -145,15 +144,19 @@
           environment.systemPackages = [ pkgs.mypkgs.mox ];
         };
         vm.forwardPorts = [
-          "8080:80"
+          "8080:8080"
+          "8081:8081"
+          "8082:8082"
         ];
       };
     };
   };
 
   test.script = ''
-    curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+    curl="curl --retry 20 --retry-max-time 120 --retry-all-errors"
 
-    $curl localhost | grep "Mox Account"
+    $curl --location localhost:8080 | grep "Mox Account"
+    $curl --location localhost:8081/admin | grep "Mox Admin"
+    $curl --location localhost:8082/webmail | grep "Mox Webmail"
   '';
 }

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -86,16 +86,20 @@
     };
   };
 
-  test.script = ''
-    curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+  test = {
+    script = ''
+      curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
 
-    $curl -X POST localhost:5000/init
+      $curl -X POST localhost:5000/init
 
-    $curl -X POST \
-      --header "Content-Type: application/json" \
-      --data '{"name":"username"}' \
-      localhost:5000/users
+      $curl -X POST \
+        --header "Content-Type: application/json" \
+        --data '{"name":"username"}' \
+        localhost:5000/users
 
-    $curl localhost:5000/users
-  '';
+      $curl localhost:5000/users
+    '';
+    # test-container requires database image from Internet registry
+    sandbox = false;
+  };
 }


### PR DESCRIPTION
Also add `apps.*.test.sandbox` option which allows to disable Nix sandbox
when necessary.

Run container tests with

```
nix build .#<app>.test-container
```

for example:
```
nix build .#tau-app.test-container
```


Disabled sandbox is used for `python-web-app` tests because test-container requires to download database image from Internet registry.