### PR TITLE
feat: relocate compose file to result/<appname>/compose.yaml

### DIFF
--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -161,7 +161,8 @@
       chmod +x $out/bin/build-oci-image
 
       ${lib.optionalString (config.composeFile != null) ''
-        cp ${config.composeFile} $out/compose.yaml
+        mkdir -p $out/${app.name}
+        cp ${config.composeFile} $out/${app.name}/compose.yaml
       ''}
     '';
   };

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -310,7 +310,7 @@ viewPageAppRunContainer model pageApp =
                 , "./result/bin/build-oci-image"
                 , ""
                 , "podman load < " ++ pageApp.pageApp_app.app_name ++ ".tar"
-                , "podman-compose --file $(pwd)/result/compose.yaml up"
+                , "podman-compose --file $(pwd)/result/" ++ pageApp.pageApp_app.app_name ++ "/compose.yaml up --force-recreate"
                 ]
         ]
 


### PR DESCRIPTION
The idea is to allow easy ux for the users.

```console
$ ls -l result
dr-xr-xr-x - root  1 Jan  1970 bin
dr-xr-xr-x - root  1 Jan  1970 tau-app
$ ls -l result/tau-app/
.r--r--r-- 139 root  1 Jan  1970 compose.yaml
$ podman load < tau-app.tar
Getting image source signatures
Copying blob b8e50c578000 skipped: already exists
Copying config 80a7165958 done   |
Writing manifest to image destination
Loaded image: localhost/tau-app:latest
$ podman-compose --profile services --file $(pwd)/result/tau-app/compose.yaml up -d
08ac33df6c2fb7d54311792ab53717534ba8efff2d13dad73fd38afb0251abd2
d321100670ed24fff1b5fba3b11bf13aa1245790a877b7be084ee6ff2862b093
tau-app_tau-app_1
$ podman pod ls
POD ID        NAME                                                  STATUS      CREATED        INFRA ID    # OF CONTAINERS
08ac33df6c2f  pod_tau-app                                           Running     3 seconds ago              1
4563e9c5fc6d  pod_rmpb7kachf7ypkaw3d25mzvscichzpj2-build-oci-image  Exited      18 hours ago               1
fd55ffa26280  pod_yr1zmlfqm18cyh6mm29vb0gdzwx27cwm-build-oci-image  Exited      19 hours ago               1
```

In this above example I can clearly see in the output the pod belongs to tau-app. unlike the previous case where it is not  at all clear. Now this allows me to `podman pod restart` etc. easily by human readable name.

NOTE: there is a caveat, we have to use `podman-compose ... up --force-recreate -d` because the name is not unique anymore for redeploying the same app.