### PR TITLE
feat: add app nixos module passthru

### DIFF
--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -91,13 +91,16 @@ in
                 extendRecipe =
                   module: lib.filterAttrsRecursive (name: _: name != "result") (self.extend module).config;
               })
-              // lib.optionalAttrs (app.test.script != "") { test = app.test.result.build; }
               // lib.optionalAttrs app.services.runtimes.container.enable {
                 container = app.services.runtimes.container.result.build;
               }
               // lib.optionalAttrs app.services.runtimes.nixos.enable {
                 vm = app.services.runtimes.nixos.result.build;
-              };
+                nixos = {
+                  modules = app.services.runtimes.nixos.result.modules;
+                };
+              }
+              // lib.optionalAttrs (app.test.script != "") { test = app.test.result.build; };
 
             # finalApp parameter is currently not used in this function
             appPassthru = app: finalApp: mkPassthru app;


### PR DESCRIPTION
Allows to add module to NixOS system

```
nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
  modules = [ inputs.ngi-forge.packages.${system}.my-app.nixos ];
};
```
