### PR TITLE
feat: add npm package builder

### DIFF
--- a/forge/modules/builders/npm-package-builder/builder-options.nix
+++ b/forge/modules/builders/npm-package-builder/builder-options.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  ...
+}:
+{
+  options.build.npmPackageBuilder = {
+    enable = lib.mkEnableOption ''
+      NPM package builder for JavaScript/TypeScript packages.
+
+      Uses buildNpmPackage'';
+
+    packages = {
+      build = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        description = ''
+          Build-time dependencies (native architecture).
+
+          Tools needed during compilation that run on the build machine.
+        '';
+        example = lib.literalExpression "[ pkgs.nodejs ]";
+      };
+      run = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        description = ''
+          Runtime dependencies (target architecture).
+
+          Libraries needed by the package at runtime.
+        '';
+        example = lib.literalExpression "[ pkgs.vips ]";
+      };
+      check = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        description = ''
+          Test dependencies.
+
+          Packages needed to run tests.
+        '';
+      };
+    };
+
+    npmDepsHash = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        SHA256 hash of the package-lock.json file or source.
+
+        Leave empty initially - nix will provide the correct hash on first build.
+      '';
+      example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+
+    npmInstallFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Flags to pass to `npm ci`.
+      '';
+      example = [
+        "--ignore-scripts"
+      ];
+    };
+  };
+}

--- a/forge/modules/builders/npm-package-builder/default.nix
+++ b/forge/modules/builders/npm-package-builder/default.nix
@@ -1,0 +1,65 @@
+{
+  flake-parts-lib,
+  lib,
+  ...
+}:
+
+let
+  inherit (flake-parts-lib)
+    mkPerSystemOption
+    ;
+in
+{
+  options.perSystem = mkPerSystemOption (
+    {
+      config,
+      pkgs,
+      sharedBuildAttrs,
+      ...
+    }:
+    {
+      options.forge.packages = lib.mkOption {
+        type = lib.types.listOf (lib.types.submodule ./builder-options.nix);
+      };
+
+      config.packages =
+        let
+          cfg = config.forge;
+
+          composePkg = pkg: {
+            name = pkg.name;
+            value = pkgs.callPackage (
+              # Derivation start
+              { }:
+              pkgs.buildNpmPackage (
+                finalAttrs:
+                {
+                  pname = pkg.name;
+                  version = pkg.version;
+                  src = sharedBuildAttrs.pkgSource pkg;
+                  patches = pkg.source.patches or [ ];
+
+                  nativeBuildInputs = [ pkgs.nodejs ] ++ pkg.build.npmPackageBuilder.packages.build;
+                  buildInputs = pkg.build.npmPackageBuilder.packages.run;
+                  nativeCheckInputs = pkg.build.npmPackageBuilder.packages.check;
+                  npmDepsHash = pkg.build.npmPackageBuilder.npmDepsHash;
+                  npmInstallFlags = pkg.build.npmPackageBuilder.npmInstallFlags;
+
+                  passthru = sharedBuildAttrs.pkgPassthru pkg finalAttrs.finalPackage;
+                  meta = sharedBuildAttrs.pkgMeta pkg;
+                }
+                // pkg.build.extraAttrs
+                // lib.optionalAttrs pkg.build.debug sharedBuildAttrs.debugShellHookAttr
+              )
+              # Derivation end
+            ) { };
+          };
+
+          enabledPkgs = lib.filter (p: p.build.npmPackageBuilder.enable) cfg.packages;
+
+          npmPackageBuilderPkgs = lib.listToAttrs (map composePkg enabledPkgs);
+        in
+        npmPackageBuilderPkgs;
+    }
+  );
+}

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -15,6 +15,7 @@ in
     ./builders/shared.nix
     ./builders/standard-builder.nix
     ./builders/go-builder.nix
+    ./builders/npm-package-builder
     ./builders/python-app-builder.nix
     ./builders/python-package-builder.nix
     ./builders/rust-package-builder

--- a/recipes/packages/pagedjs-cli/recipe.nix
+++ b/recipes/packages/pagedjs-cli/recipe.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  name = "pagedjs-cli";
+  version = "0-main-2026-01-05";
+  description = "Command line interface for Pagedjs PDF renderer.";
+  homePage = "https://pagedjs.org";
+  mainProgram = "pagedjs-cli";
+  license = lib.licenses.mit;
+
+  source = {
+    git = "github:pagedjs/pagedjs-cli/1fc8c8956d665347a6a105c927be405a3ac462d6";
+    hash = "sha256-393Q2B64lIPSYIckPOqVdhhQiHKcUE1jOpsYlFsiJvg=";
+  };
+
+  build.npmPackageBuilder = {
+    enable = true;
+    packages = {
+      build = [
+        pkgs.nodejs_22
+        pkgs.makeWrapper
+      ];
+      run = [
+        pkgs.chromium
+      ];
+    };
+    npmDepsHash = "sha256-h3R+L9gROCqvKpzTg9woI0Om1J5Eo4NA1FCXjfnjwdU=";
+    npmInstallFlags = [ "--ignore-scripts" ];
+  };
+
+  build.extraAttrs = {
+    # Skip Puppeteer's Chrome download during dependency installation
+    env.PUPPETEER_SKIP_DOWNLOAD = true;
+
+    # Wrap the binary to set Chromium path
+    # Launch browser with no sandboxing
+    postInstall = ''
+      mkdir -p $out/lib/node_modules/pagedjs-cli/docker-userdata
+
+      wrapProgram $out/bin/pagedjs-cli \
+        --set PUPPETEER_EXECUTABLE_PATH "${pkgs.chromium}/bin/chromium" \
+        --add-flags "--browserArgs --no-sandbox"
+    '';
+  };
+
+  test.script = ''
+    pagedjs-cli --help | grep -q "Usage:"
+  '';
+}


### PR DESCRIPTION
and use it to package [`pagedjs-cli` from NGIpkgs](https://github.com/ngi-nix/ngipkgs/blob/main/pkgs/by-name/pagedjs-cli/package.nix).

Closes https://github.com/ngi-nix/forge/issues/324

**PS:** this will also be useful for other packages such as [qlever](https://github.com/ngi-nix/projects/issues/173), and specifically [qlever-ui](https://github.com/qlever-dev/qlever-ui) (see wip in https://github.com/ngi-nix/forge/pull/332).