### PR TITLE
fix: correctly set environment variables in NixOS service

### DIFF
--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -18,5 +18,8 @@
     };
   }) app.services.components;
 
-  environment.variables = lib.concatMapAttrs (_: value: value.environment) app.services.components;
+  systemd.services = lib.mapAttrs (_: service: {
+    environment = service.environment;
+    serviceConfig.PassEnvironment = builtins.attrNames service.environment;
+  }) app.services.components;
 }


### PR DESCRIPTION
Set environment variables to service for which they are configured and
pass them to Nimi subproces.

Tested in #368 .
