### PR TITLE
feat: add apps.*.services.runtimes#apps.*.services.runtimes.nixos.packages option

### DIFF
--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -17,6 +17,18 @@
       description = "Script to run once at startup.";
     };
 
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        Packages to add to the NixOS system.
+
+        This is a convenience option equivalent to setting
+        `extraConfig.environment.systemPackages`.
+      '';
+      example = lib.literalExpression "[ pkgs.btop ]";
+    };
+
     extraConfig = lib.mkOption {
       type = with lib.types; deferredModule;
       default = { };
@@ -107,6 +119,9 @@
       nimi = import ./modules/nimi.nix args;
       virt = import ./modules/virt.nix args;
       extraConfig = config.extraConfig;
+      packages = {
+        environment.systemPackages = config.packages;
+      };
     };
 
     result.eval = inputs.nixpkgs.lib.nixosSystem {

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -130,6 +130,7 @@
             chown mox:mox data
           fi
         '';
+        packages = [ pkgs.mypkgs.mox ];
         extraConfig = {
           networking.enableIPv6 = false;
           # Use a public DNSSEC-validating resolver
@@ -140,9 +141,6 @@
             isSystemUser = true;
             group = "mox";
           };
-
-          # Make mox package available for admin tasks
-          environment.systemPackages = [ pkgs.mypkgs.mox ];
         };
         vm.forwardPorts = [
           "8080:80"

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -72,11 +72,9 @@
 
       nixos = {
         enable = true;
-        extraConfig = {
-          environment.systemPackages = [
-            pkgs.mypkgs.tau-tower
-          ];
-        };
+        packages = [
+          pkgs.mypkgs.tau-tower
+        ];
         vm.forwardPorts = [
           "3001:3001"
           "3002:3002"


### PR DESCRIPTION
Add packages option for consistency with container runtime.


- **feat: add apps.*.services.runtimes#apps.*.services.runtimes.nixos.packages option**
- **recipes(mox-app): use services.runtimes.container.packages option**
- **recipes(tau-app): use services.runtimes.container.packages option**
