### PR TITLE
refactor: rename apps.*.services.runtimes.container.imageConfig to extraConfig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,7 +547,7 @@ container = {
 
   # OCI image configuration
   # See: https://specs.opencontainers.org/image-spec/config/#properties
-  imageConfig = {
+  extraConfig = {
     Cmd = [ "my-package" "--serve" ];  # Default command
     Env = [                             # Environment variables
       "PORT=8080"
@@ -671,7 +671,7 @@ Each app output type can be independently enabled or disabled:
     enable = true;
     tag = "latest";
     packages = [ pkgs.mypkgs.python-web ];
-    imageConfig = {
+    extraConfig = {
       Env = [ "PORT=5000" ];
       ExposedPorts = { "5000/tcp" = { }; };
     };

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -30,7 +30,7 @@
     };
 
     # NOTE: config is reserved by the module system
-    imageConfig = lib.mkOption {
+    extraConfig = lib.mkOption {
       type = with lib.types; lazyAttrsOf anything;
       default = { };
       description = ''

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -16,7 +16,7 @@
       pathsToLink = [ "/bin" ];
     };
 
-    imageConfig = config.imageConfig // {
+    imageConfig = config.extraConfig // {
       Env =
         let
           # { K = "V"; } -> [ "K=V" ]
@@ -24,7 +24,7 @@
 
           appEnv = lib.concatMapAttrs (_: value: value.environment) app.services.components;
 
-          # imageConfig.Env follows OCI spec: list of "K=V" strings
+          # extraConfig.Env follows OCI spec: list of "K=V" strings
           containerEnv = lib.listToAttrs (
             map (
               envPair:
@@ -35,7 +35,7 @@
                 name = lib.head parts;
                 value = lib.concatStringsSep "=" (lib.tail parts);
               }
-            ) (config.imageConfig.Env or [ ])
+            ) (config.extraConfig.Env or [ ])
           );
 
           # NOTE: we merge Attrs to remove duplicate keys


### PR DESCRIPTION
Rename for consistency with similar option in nixos runtime.
