### PR TITLE
feat: add a main command for containers

### DIFF
--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -13,6 +13,7 @@
       devShell = pkgs.callPackage ./devshell.nix { inherit inputs formatter; };
 
       devPkgs = with pkgs; [
+        dive
         elmPackages.elm
         elmPackages.elm-language-server
         elmPackages.elm-review
@@ -22,13 +23,13 @@
         json-diff
         nixfmt
         nodejs
+        playwright-test
+        podman-compose
         python3
         self'.packages.elm-watch
         self'.packages.elm2nix
-        playwright-test
         systemd-manager-tui
         watchman
-        podman-compose
       ];
     in
 

--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -26,23 +26,24 @@
       );
 
       devPkgs = with pkgs; [
-        gnumake
-        sphinxEnv
+        dive
         elmPackages.elm
         elmPackages.elm-language-server
         elmPackages.elm-review
         elmPackages.elm-test
         elmPackages.elm-test-rs
         esbuild
+        gnumake
         json-diff
         nixfmt
         nodejs
+        playwright-test
+        podman-compose
         self'.packages.elm-watch
         self'.packages.elm2nix
-        playwright-test
+        sphinxEnv
         systemd-manager-tui
         watchman
-        podman-compose
       ];
     in
 

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -105,20 +105,35 @@
                 ${app.name}:
                   image: localhost/${app.name}:latest
             '';
+        build-oci-image = pkgs.writeShellScriptBin "build-oci-image" ''
+          ${config.result.recipe.copyTo}/bin/copy-to \
+            oci-archive:${app.name}.tar:${app.name}:${config.tag}
+          echo "Container image created in $(pwd)/${app.name}.tar ."
+        '';
+        compose-file = pkgs.runCommand "compose-file" { } ''
+          mkdir -p $out/${app.name}
+          cp ${effectiveComposeFile} $out/${app.name}/compose.yaml
+        '';
+        run-podman = pkgs.writeShellScriptBin "run-podman" ''
+          ${lib.getExe build-oci-image}
+          podman load <${app.name}.tar
+          ${lib.getExe pkgs.podman-compose} \
+            -f ${compose-file}/${app.name}/compose.yaml \
+            up --force-recreate "$@"
+        '';
+        run-container = pkgs.writeShellScriptBin "run-container" ''
+          ${lib.getExe run-podman} "$@"
+        '';
       in
-      pkgs.runCommand "build-oci-image" { meta.mainProgram = "build-oci-image"; } ''
-        mkdir -p $out/bin
-
-        cat > $out/bin/build-oci-image <<EOF
-        #!${pkgs.runtimeShell}
-        ${config.result.recipe.copyTo}/bin/copy-to \
-          oci-archive:${app.name}.tar:${app.name}:${config.tag}
-        EOF
-
-        chmod +x $out/bin/build-oci-image
-
-        mkdir -p $out/${app.name}
-        cp ${effectiveComposeFile} $out/${app.name}/compose.yaml
-      '';
+      pkgs.symlinkJoin {
+        name = "run-container";
+        paths = [
+          build-oci-image
+          compose-file
+          run-podman
+          run-container
+        ];
+        meta.mainProgram = "run-container";
+      };
   };
 }

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -105,20 +105,35 @@
                 ${app.name}:
                   image: localhost/${app.name}:latest
             '';
+        build-oci-image = pkgs.writeShellScriptBin "build-oci-image" ''
+          set -x
+          ${config.result.recipe.copyTo}/bin/copy-to \
+            oci-archive:${app.name}.tar:${app.name}:${config.tag}
+        '';
+        compose-file = pkgs.runCommand "compose-file" { } ''
+          mkdir -p $out/${app.name}
+          cp ${effectiveComposeFile} $out/${app.name}/compose.yaml
+        '';
+        run-podman = pkgs.writeShellScriptBin "run-podman" ''
+          set -x
+          ${lib.getExe build-oci-image}
+          podman load <${app.name}.tar
+          podman-compose -f ${compose-file}/${app.name}/compose.yaml up --force-recreate
+        '';
+        run-container = pkgs.writeShellScriptBin "run-container" ''
+          set -x
+          ${lib.getExe run-podman}
+        '';
       in
-      pkgs.runCommand "build-oci-image" { meta.mainProgram = "build-oci-image"; } ''
-        mkdir -p $out/bin
-
-        cat > $out/bin/build-oci-image <<EOF
-        #!${pkgs.runtimeShell}
-        ${config.result.recipe.copyTo}/bin/copy-to \
-          oci-archive:${app.name}.tar:${app.name}:${config.tag}
-        EOF
-
-        chmod +x $out/bin/build-oci-image
-
-        mkdir -p $out/${app.name}
-        cp ${effectiveComposeFile} $out/${app.name}/compose.yaml
-      '';
+      pkgs.symlinkJoin {
+        name = "run-container";
+        paths = [
+          build-oci-image
+          compose-file
+          run-podman
+          run-container
+        ];
+        meta.mainProgram = "run-container";
+      };
   };
 }

--- a/forge/modules/apps/test/container.nix
+++ b/forge/modules/apps/test/container.nix
@@ -33,11 +33,7 @@
         testScript = ''
           machine.start()
           machine.wait_for_unit("multi-user.target")
-          machine.succeed("${containerRuntime.result.build}/bin/build-oci-image")
-          machine.succeed("podman load < ${app.name}.tar")
-          machine.succeed(
-            "podman-compose --file ${containerRuntime.result.build}/${app.name}/compose.yaml up --detach"
-          )
+          machine.succeed("${lib.getExe containerRuntime.result.build} --detach")
           machine.succeed("${pkgs.writeShellScript "${app.name}-container-test-script" config.script}")
         '';
       }).overrideTestDerivation

--- a/forge/modules/apps/test/container.nix
+++ b/forge/modules/apps/test/container.nix
@@ -33,11 +33,7 @@
         testScript = ''
           machine.start()
           machine.wait_for_unit("multi-user.target")
-          machine.succeed("${containerRuntime.result.build}/bin/build-oci-image")
-          machine.succeed("podman load < ${app.name}.tar")
-          machine.succeed(
-            "podman-compose --file ${containerRuntime.result.build}/${app.name}/compose.yaml up --detach"
-          )
+          machine.succeed("${lib.getExe containerRuntime.result.build}")
           machine.succeed("${pkgs.writeShellScript "${app.name}-container-test-script" config.script}")
         '';
       }).overrideTestDerivation

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -289,7 +289,7 @@ viewPageAppRunContainer model pageApp =
                 [ case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
                         String.concat
-                            [ "nix build "
+                            [ "nix run "
                             , showForgeInputFlakes model
                             , "#"
                             , pageApp.pageApp_app.app_name
@@ -304,13 +304,10 @@ viewPageAppRunContainer model pageApp =
                             , "."
                             , pageApp.pageApp_app.app_name
                             , ".container"
-                            , "' "
+                            , "' \n"
+                            , "\n"
+                            , "./result/bin/run-container"
                             ]
-                , ""
-                , "./result/bin/build-oci-image"
-                , ""
-                , "podman load < " ++ pageApp.pageApp_app.app_name ++ ".tar"
-                , "podman-compose --file $(pwd)/result/" ++ pageApp.pageApp_app.app_name ++ "/compose.yaml up --force-recreate"
                 ]
         ]
 

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -289,7 +289,7 @@ viewPageAppRunContainer model pageApp =
                 [ case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
                         String.concat
-                            [ "nix build "
+                            [ "nix run "
                             , showForgeInputFlakes model
                             , "#"
                             , pageApp.pageApp_app.app_name
@@ -304,14 +304,48 @@ viewPageAppRunContainer model pageApp =
                             , "."
                             , pageApp.pageApp_app.app_name
                             , ".container"
-                            , "' "
+                            , "' \n"
+                            , "\n"
+                            , "./result/bin/run-container"
                             ]
-                , ""
-                , "./result/bin/build-oci-image"
-                , ""
-                , "podman load < " ++ pageApp.pageApp_app.app_name ++ ".tar"
-                , "podman-compose --file $(pwd)/result/" ++ pageApp.pageApp_app.app_name ++ "/compose.yaml up --force-recreate"
                 ]
+        , hr [] []
+        , viewPageAppRunContainerBuildOCI model pageApp
+        ]
+
+
+viewPageAppRunContainerBuildOCI : Model -> PageApp -> Html Update
+viewPageAppRunContainerBuildOCI model pageApp =
+    details []
+        [ summary [] [ text "Build container image manually" ]
+        , br [] []
+        , codeBlock <|
+            case model.model_preferences.preferences_install of
+                PreferencesInstall_NixFlakes ->
+                    String.join "\n"
+                        [ String.concat
+                            [ "nix build "
+                            , showForgeInputFlakes model
+                            , "#"
+                            , pageApp.pageApp_app.app_name
+                            , ".container"
+                            ]
+                        , ""
+                        , "./result/bin/build-oci-image"
+                        ]
+
+                PreferencesInstall_NixTraditional ->
+                    String.concat
+                        [ "nix-build \\\n"
+                        , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                        , "  -E '(import <forge> {})"
+                        , "."
+                        , pageApp.pageApp_app.app_name
+                        , ".container"
+                        , "' \n"
+                        , "\n"
+                        , "./result/bin/build-oci-image"
+                        ]
         ]
 
 


### PR DESCRIPTION
I added a `run-container` command which calls `run-podman` for now. If we support docker #313 and we detect `docker` and `podman` both installed in the user's system maybe we need to ask user to set a preference or chose podman by defualt and log some helpful info to change it.

For now it's podman only.

We can now `nix run .#app.container` like the vm.