### PR TITLE
feat(ui): handle multiple licenses

### DIFF
--- a/ui/src/Main/Config/Package.elm
+++ b/ui/src/Main/Config/Package.elm
@@ -10,7 +10,7 @@ type alias Package =
     , package_version : String
     , package_homePage : String
     , package_mainProgram : String
-    , package_license : PackageLicense
+    , package_licenses : List PackageLicense
     , package_source : PackageSource
     , package_recipePath : String
     }
@@ -24,7 +24,7 @@ decodePackage =
         (Decode.field "version" Decode.string)
         (Decode.field "homePage" Decode.string)
         (Decode.field "mainProgram" Decode.string)
-        (Decode.field "license" decodeLicense)
+        (Decode.field "license" decodeLicenses)
         (Decode.field "source" decodeSource)
         (Decode.field "recipePath" Decode.string)
 
@@ -53,23 +53,31 @@ decodeSource =
 
 
 type alias PackageLicense =
-    { license_deprecated : Bool
-    , license_free : Bool
-    , license_fullName : String
-    , license_redistributable : Bool
-    , license_shortName : String
-    , license_spdxId : String
-    , license_url : String
+    { license_deprecated : Maybe Bool
+    , license_free : Maybe Bool
+    , license_fullName : Maybe String
+    , license_redistributable : Maybe Bool
+    , license_shortName : Maybe String
+    , license_spdxId : Maybe String
+    , license_url : Maybe String
     }
 
 
-decodeLicense : Decoder PackageLicense
-decodeLicense =
+decodeLicenses : Decoder (List PackageLicense)
+decodeLicenses =
+    Decode.oneOf
+        [ Decode.list decodePackageLicense
+        , Decode.map List.singleton decodePackageLicense
+        ]
+
+
+decodePackageLicense : Decoder PackageLicense
+decodePackageLicense =
     Decode.map7 PackageLicense
-        (Decode.field "deprecated" Decode.bool)
-        (Decode.field "free" Decode.bool)
-        (Decode.field "fullName" Decode.string)
-        (Decode.field "redistributable" Decode.bool)
-        (Decode.field "shortName" Decode.string)
-        (Decode.field "spdxId" Decode.string)
-        (Decode.field "url" Decode.string)
+        (Decode.maybe (Decode.field "deprecated" Decode.bool))
+        (Decode.maybe (Decode.field "free" Decode.bool))
+        (Decode.maybe (Decode.field "fullName" Decode.string))
+        (Decode.maybe (Decode.field "redistributable" Decode.bool))
+        (Decode.maybe (Decode.field "shortName" Decode.string))
+        (Decode.maybe (Decode.field "spdxId" Decode.string))
+        (Decode.maybe (Decode.field "url" Decode.string))

--- a/ui/src/Main/View/Page/Packages.elm
+++ b/ui/src/Main/View/Page/Packages.elm
@@ -97,22 +97,39 @@ viewPagePackagesItem model pagePackages package =
             , package.package_description |> Markdown.render
             ]
         , div [ class "d-flex gap-3" ]
-            [ a
-                [ href package.package_license.license_url
-                , target "_blank"
-                , rel "noopener"
-                , onClickStopPropagation
+            (List.append
+                (package.package_licenses |> List.map viewLicense)
+                [ a
+                    [ href <| showPackageRecipeLink model package
+                    , target "_blank"
+                    , rel "noopener"
+                    , onClickStopPropagation
+                    ]
+                    [ text "Forge Recipe" ]
                 ]
-                [ text package.package_license.license_spdxId ]
-            , a
-                [ href <| showPackageRecipeLink model package
-                , target "_blank"
-                , rel "noopener"
-                , onClickStopPropagation
-                ]
-                [ text "Forge Recipe" ]
-            ]
+            )
         ]
+
+
+viewLicense : PackageLicense -> Html Update
+viewLicense obj =
+    let
+        label =
+            obj.license_spdxId
+                |> Maybe.withDefault (obj.license_fullName |> Maybe.withDefault "Unknown License")
+    in
+    case obj.license_url of
+        Just url ->
+            a
+                [ href url
+                , target "_blank"
+                , rel "noopener"
+                , onClickStopPropagation
+                ]
+                [ text label ]
+
+        Nothing ->
+            span [] [ text label ]
 
 
 showPackageRecipeLink : Model -> Package -> String


### PR DESCRIPTION
In the packages licenses we already allow multiple licenses, but this wasn't
handled in the Elm code.

See #379 which is rebased on top of this.