### PR TITLE
fix: handle sourceRoot properly in pnpm builder

### DIFF
--- a/forge/modules/builders/pnpm-package-builder/default.nix
+++ b/forge/modules/builders/pnpm-package-builder/default.nix
@@ -81,7 +81,7 @@ in
                   meta = sharedBuildAttrs.pkgMeta pkg;
                 }
                 // lib.optionalAttrs (builderCfg.sourceRoot != null) {
-                  sourceRoot = "source/${lib.last (lib.splitString "/" builderCfg.sourceRoot)}";
+                  inherit (builderCfg) sourceRoot;
                 }
                 // pkg.build.extraAttrs
                 // lib.optionalAttrs pkg.build.debug sharedBuildAttrs.debugShellHookAttr


### PR DESCRIPTION
See https://github.com/ngi-nix/forge/pull/368#discussion_r3170561267

Existing logic prevents anything other than a single level deep `source/dir`.
