### PR TITLE
feat: add service shell

### DIFF
--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -101,6 +101,10 @@ in
                   vm = app.services.runtimes.nixos.result.build;
                 };
               }
+              # Enable service shell when at least nixos or container runtimes are enabled
+              // lib.optionalAttrs (lib.any (x: x ? enable && x.enable) (lib.attrValues app.services.runtimes)) {
+                shell = app.services.runtimes.shell.result;
+              }
               // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.test.script != "") {
                 test = app.test.result.build;
               }

--- a/forge/modules/apps/services/runtimes/default.nix
+++ b/forge/modules/apps/services/runtimes/default.nix
@@ -25,5 +25,15 @@
       default = { };
       description = "NixOS system configuration.";
     };
+
+    shell = lib.mkOption {
+      internal = true;
+      type = lib.types.submoduleWith {
+        inherit specialArgs;
+        modules = [ ./shell ];
+      };
+      default = { };
+      description = "Service shell configuration.";
+    };
   };
 }

--- a/forge/modules/apps/services/runtimes/shell/default.nix
+++ b/forge/modules/apps/services/runtimes/shell/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+
+  nimi,
+  app,
+  ...
+}:
+{
+
+  options = {
+    result = lib.mkOption {
+      internal = true;
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "Script that start service shell.";
+    };
+  };
+
+  config = {
+    result = nimi.mkNimiBin { config = app.services.runtimes.container.result.modules; };
+  };
+}


### PR DESCRIPTION
Related: https://github.com/ngi-nix/forge/issues/267

```shellSession
$ nix run .#python-web-app.shell
[2026-05-01T08:35:15Z INFO  nimi::cli] Launching process manager...
[2026-05-01T08:35:15Z INFO  nimi::process_manager] Starting process manager...
[2026-05-01T08:35:16Z DEBUG python-web]  * Serving Flask app 'python_web.app'
[2026-05-01T08:35:16Z DEBUG python-web]  * Debug mode: off
[2026-05-01T08:35:16Z ERROR python-web] WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
[2026-05-01T08:35:16Z ERROR python-web]  * Running on all addresses (0.0.0.0)
[2026-05-01T08:35:16Z ERROR python-web]  * Running on http://127.0.0.1:5000
[2026-05-01T08:35:16Z ERROR python-web]  * Running on http://192.168.1.100:5000
[2026-05-01T08:35:16Z ERROR python-web] Press CTRL+C to quit
```