### PR TITLE
fix: disallow build phase for devenvs

### DIFF
--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -123,6 +123,9 @@ in
               script = pkg.test.script + "\ntouch $out";
             };
             devenv = pkgs.mkShell {
+              dontBuild = true;
+              phases = [ "installPhase" ];
+              installPhase = "touch $out";
               env.DEVENV_PACKAGE_NAME = "${pkg.name}";
               env.DEVENV_PACKAGE_SOURCE = "${finalPkg.src}";
               inputsFrom = [


### PR DESCRIPTION
During nix flake checks the `.devenv` checks are building the packages. So

```console
nix develop .#somepkg.devenv
# succeeds
# vs
nix build .#somepkg.devenv
# fails for ironcalc-python due to maturinBuildHook
```

With this pr, nix build of a .devenv doesn't run the derivation's phases except the `installPhase`.

