### PR TITLE
ironcalc: use strictDeps to reduce container size

### DIFF
--- a/forge/modules/builders/standard-builder.nix
+++ b/forge/modules/builders/standard-builder.nix
@@ -28,7 +28,17 @@ in
                     enable = lib.mkEnableOption ''
                       Standard builder for autotools, CMake, or Makefile-based projects.
 
-                      Automatically handles configure, build, and install phases'';
+                      Automatically handles configure, build, and install phases
+                    '';
+                    stdenv = lib.mkOption {
+                      type = lib.types.package;
+                      default = pkgs.stdenv;
+                      defaultText = lib.literalExpression "pkgs.stdenv";
+                      example = lib.literalExpression "pkgs.stdenvNoCC";
+                      description = ''
+                        The stdenv to use for the build.
+                      '';
+                    };
                     packages = {
                       build = lib.mkOption {
                         type = lib.types.listOf lib.types.package;
@@ -79,7 +89,7 @@ in
                   value = pkgs.callPackage (
                     # Derivation start
                     { stdenv }:
-                    stdenv.mkDerivation (
+                    pkg.build.standardBuilder.stdenv.mkDerivation (
                       finalAttrs:
                       {
                         pname = pkg.name;

--- a/recipes/packages/ironcalc-server/recipe.nix
+++ b/recipes/packages/ironcalc-server/recipe.nix
@@ -33,6 +33,8 @@
   };
 
   build.extraAttrs = {
+    strictDeps = true;
+    __structuredAttrs = true;
     cargoRoot = "webapp/app.ironcalc.com/server";
     buildAndTestSubdir = "webapp/app.ironcalc.com/server";
     postInstall = ''

--- a/recipes/packages/ironcalc-tools/recipe.nix
+++ b/recipes/packages/ironcalc-tools/recipe.nix
@@ -36,6 +36,8 @@
   };
 
   build.extraAttrs = {
+    strictDeps = true;
+    __structuredAttrs = true;
     doInstallCheck = true;
     installCheckPhase = ''
       { $out/bin/xlsx_2_icalc 2>&1 || true; } | grep -q "Usage:"

--- a/recipes/packages/ironcalc/recipe.nix
+++ b/recipes/packages/ironcalc/recipe.nix
@@ -23,14 +23,11 @@
 
   build.standardBuilder = {
     enable = true;
-    packages.run = [
-      pkgs.mypkgs.ironcalc-server
-      pkgs.mypkgs.ironcalc-frontend
-      pkgs.mypkgs.ironcalc-tools
-    ];
   };
 
   build.extraAttrs = {
+    strictDeps = true;
+    __structuredAttrs = true;
     dontUnpack = true;
     installPhase = ''
       mkdir -p $out/bin
@@ -38,7 +35,7 @@
       #!${pkgs.runtimeShell}
       set -euo pipefail
 
-      export PATH=$PATH:${
+      export PATH=$\PATH:${
         lib.makeBinPath [
           pkgs.coreutils
           pkgs.sqlite


### PR DESCRIPTION
Previously the container came out to be ~400MB because gcc got into its nix store. With `strictDeps` it doesn't show up anymore and it goes down to ~150MB.