### PR TITLE
docs: add sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,23 @@
+SPHINXOPTS    = -W
+SPHINXBUILD   = sphinx-build
+BUILDDIR      = build
+
+ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
+
+.PHONY: help clean html linkcheck
+
+help:
+	@echo "Usage: make <target>"
+	@echo "  html       Build HTML documentation"
+	@echo "  linkcheck  Check all external links"
+	@echo "  clean      Remove build output"
+
+clean:
+	rm -rf $(BUILDDIR)/*
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo "Build finished. HTML pages are in $(BUILDDIR)/html."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,24 @@
+:root {
+  --sd-color-card-border-hover: var(--pst-color-primary) !important;
+}
+
+.navbar-nav li.toctree-l1 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.navbar-nav li.toctree-l1 > .toctree-toggle {
+  display: none;
+}
+
+.navbar-nav li.toctree-l1 > a {
+  font-weight: 600;
+}
+
+.navbar-nav li.toctree-l1 > ul {
+  padding: 0;
+}
+
+pre {
+  white-space: wrap;
+}

--- a/docs/announcements/index.md
+++ b/docs/announcements/index.md
@@ -1,0 +1,7 @@
+# Announcements
+
+```{toctree}
+:hidden: true
+
+version-0_1.md
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+from datetime import date
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_sitemap",
+    "notfound.extension",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "linkify",
+    "tasklist",
+    "attrs_block",
+]
+
+myst_heading_anchors = 3
+
+myst_number_code_blocks = ["nix", "python"]
+
+copybutton_prompt_text = r"\$ |nix-repl> "
+copybutton_prompt_is_regexp = True
+
+templates_path = ["_templates"]
+
+source_suffix = ".md"
+
+root_doc = "index"
+
+project = "NGI Forge"
+author = 'the <a href="https://nixos.org/community/teams/ngi/">Nix@NGI team</a>.'
+copyright = "2026-" + str(date.today().year) + ", NixOS Foundation / Nix@NGI Team"
+
+release = ""
+
+suppress_warnings = [
+    "ref.option",
+]
+
+todo_include_todos = True
+
+pygments_style = "sphinx"
+
+exclude_patterns = []
+
+html_baseurl = "https://ngi-nix.github.io/forge/"
+
+html_theme = "sphinx_book_theme"
+
+html_theme_options = {
+    "repository_url": "https://github.com/ngi-nix/forge",
+    "repository_branch": "master",
+    "path_to_docs": "docs",
+    "use_repository_button": True,
+    "show_navbar_depth": 2,
+    "max_navbar_depth": 100,
+}
+
+html_title = "NGI Forge"
+html_short_title = "NGI Forge"
+
+html_static_path = ["_static"]
+
+html_css_files = [
+    "css/custom.css",
+]
+
+html_sidebars = {
+    "**": [
+        "search-button-field.html",
+        "sbt-sidebar-nav.html",
+    ],
+}
+
+html_search_language = "en"
+
+sitemap_url_scheme = "{link}"
+
+notfound_urls_prefix = "/"
+
+man_pages = [
+    (
+        "manuals/user/index",
+        "ngi-forge-user",
+        "NGI Forge User Manual",
+        "NGI Forge Contributors",
+        5,
+    ),
+    (
+        "manuals/contributor/index",
+        "ngi-forge-contributor",
+        "NGI Forge Contributor Manual",
+        "NGI Forge Contributors",
+        5,
+    ),
+]
+
+intersphinx_mapping = {}
+
+linkcheck_ignore = [
+    r"https://matrix.to",
+    r"https://github.com/.+/.+#.+$",
+    r"https://github\.com/.+/.+/blob/.*#.*$",
+    r"https://github\.com/.+/.+/tree/.*#.*$",
+]
+
+linkcheck_anchors_ignore = [
+    r"^L(\d+)(-L\d+)?$",
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# NGI Forge
+
+```{toctree}
+:hidden: true
+
+manuals/user/index.md
+manuals/contributor/index.md
+announcements/index.md
+```
+
+NGI Forge provides simple, type-checked configuration recipes for packages and
+multi-component applications using the
+[Nix module system](https://nix.dev/tutorials/module-system/index.html).

--- a/docs/manuals/contributor/index.md
+++ b/docs/manuals/contributor/index.md
@@ -1,0 +1,11 @@
+# Contributor Manual
+
+```{toctree}
+:hidden: true
+
+how_to/develop.md
+how_to/test.md
+how_to/learn.md
+```
+
+TODO: Contributor manual introduction.

--- a/docs/manuals/user/index.md
+++ b/docs/manuals/user/index.md
@@ -1,0 +1,7 @@
+# User Manual
+
+```{toctree}
+:hidden: true
+```
+
+TODO: User manual content.

--- a/flake/develop/commands/dev/dev-ui/ui.sh
+++ b/flake/develop/commands/dev/dev-ui/ui.sh
@@ -52,6 +52,7 @@ Environment=PATH=$PATH
 WorkingDirectory=$rootDir
 ExecStart=$(command -v nix) build -f "$rootDir" _forge-ui.passthru.bootstrapCss -o "$rootDir/ui/build/bootstrap" --show-trace
 ExecStart=$(command -v nix) build -f "$rootDir" _forge-options -o "$rootDir/ui/build/forge-options.json" --show-trace
+ExecStart=$(command -v nix) build -f "$rootDir" _forge-docs -o "$rootDir/ui/build/docs" --show-trace
 ExecStart=$BACKEND_COMMAND
 ExecStart=$rootDir/flake/develop/commands/dev/dev-ui/build_app_resources.py
 EOT
@@ -122,6 +123,12 @@ watchman -j <<EOT
       [
         "pcre",
         "^(forge|recipes)/.*\\\.nix\$",
+        "wholename",
+        {"includedotfiles": false}
+      ],
+      [
+        "pcre",
+        "^docs/.*",
         "wholename",
         {"includedotfiles": false}
       ]

--- a/flake/develop/commands/docs/build-docs/default.nix
+++ b/flake/develop/commands/docs/build-docs/default.nix
@@ -1,0 +1,13 @@
+{
+  gnumake,
+  writeShellApplication,
+}:
+
+writeShellApplication {
+  name = "build-docs";
+  runtimeInputs = [ gnumake ];
+  text = ''
+    make -C "$(git rev-parse --show-toplevel)/docs" html
+  '';
+  meta.description = "build HTML documentation";
+}

--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -12,7 +12,22 @@
       formatter = pkgs.callPackage ./formatter.nix { inherit inputs; };
       devShell = pkgs.callPackage ./devshell.nix { inherit inputs formatter; };
 
+      sphinxEnv = pkgs.python3.withPackages (
+        ps: with ps; [
+          linkify-it-py
+          sphinx
+          myst-parser
+          sphinx-book-theme
+          sphinx-copybutton
+          sphinx-design
+          sphinx-sitemap
+          sphinx-notfound-page
+        ]
+      );
+
       devPkgs = with pkgs; [
+        gnumake
+        sphinxEnv
         elmPackages.elm
         elmPackages.elm-language-server
         elmPackages.elm-review
@@ -22,7 +37,6 @@
         json-diff
         nixfmt
         nodejs
-        python3
         self'.packages.elm-watch
         self'.packages.elm2nix
         playwright-test

--- a/flake/packages/forge-docs.nix
+++ b/flake/packages/forge-docs.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3,
+  stdenv,
+}:
+
+let
+  sphinxEnv = python3.withPackages (
+    ps: with ps; [
+      linkify-it-py
+      sphinx
+      myst-parser
+      sphinx-book-theme
+      sphinx-copybutton
+      sphinx-design
+      sphinx-sitemap
+      sphinx-notfound-page
+    ]
+  );
+in
+
+stdenv.mkDerivation {
+  pname = "_forge-docs";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../../docs;
+    fileset = lib.fileset.difference (lib.fileset.gitTracked ../../docs) (
+      lib.fileset.maybeMissing ../../docs/build
+    );
+  };
+
+  nativeBuildInputs = [ sphinxEnv ];
+
+  buildPhase = ''
+    sphinx-build -b html -W . $out
+  '';
+
+  dontInstall = true;
+
+  meta = {
+    description = "NGI Forge HTML documentation";
+  };
+}

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -62,7 +62,7 @@
         '';
 
         _forge-ui = pkgs.callPackage ../ui/package.nix {
-          inherit (config.packages) _forge-config _forge-options;
+          inherit (config.packages) _forge-config _forge-docs _forge-options;
           inherit appIcons;
           buildElmApplication = (inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
         };

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -66,6 +66,8 @@
           inherit appIcons;
           buildElmApplication = (inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
         };
+
+        _forge-docs = pkgs.callPackage ../flake/packages/forge-docs.nix { };
       };
     };
 }

--- a/ui/package.nix
+++ b/ui/package.nix
@@ -5,6 +5,7 @@
   symlinkJoin,
 
   _forge-config,
+  _forge-docs,
   _forge-options,
   appIcons,
   ...
@@ -77,6 +78,9 @@ symlinkJoin {
       mkdir -p "$page"
       ln -s $out/index.html "$page/index.html"
     done
+
+    # Install docs
+    ln -s ${_forge-docs} docs
 
     popd
   '';

--- a/ui/src/Main/View.elm
+++ b/ui/src/Main/View.elm
@@ -39,6 +39,7 @@ view model =
                     [ class "d-none d-md-flex align-items-center gap-4" ]
                     [ viewPagePackagesLink
                     , viewPageRecipeOptionsLink Layout_Desktop
+                    , viewDocsLink
                     , viewThemeToggle model
                     ]
                 , button
@@ -72,6 +73,7 @@ view model =
                     [ ul [ class "nav flex-column gap-2" ]
                         [ li [ class "nav-item" ] [ viewPagePackagesLink ]
                         , li [ class "nav-item" ] [ viewPageRecipeOptionsLink Layout_Mobile ]
+                        , li [ class "nav-item" ] [ viewDocsLink ]
                         , li [ class "nav-item mt-2 pt-2 border-top" ] [ viewThemeToggle model ]
                         ]
                     ]
@@ -112,6 +114,19 @@ viewTitle =
             [ class "brand-text fw-bold" ]
             [ text "NGI Forge" ]
         ]
+
+
+viewDocsLink : Html Update
+viewDocsLink =
+    a
+        [ href "/docs/"
+        , target "_blank"
+        , style "color" "inherit"
+        , style "text-decoration" "none"
+        , style "cursor" "pointer"
+        , class "nav-link px-0 fw-bold"
+        ]
+        [ text "Docs" ]
 
 
 viewSearchInput : Model -> Html Update


### PR DESCRIPTION
Sphinx configuration taken from [NGIpkgs](https://github.com/ngi-nix/ngipkgs/tree/main/manuals).

* Build documentation in dev environment:

```
nix develop

build-docs
```

Docs is now integrated in Forge UI navbar as well.

Closes #393
