### PR TITLE
feat: expose nixosModules for apps

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,22 +28,8 @@ let
     nimi = def.nimi-def.nimi;
     nimiLib = def.nimi.passthru;
 
-    debug = flake.outputs.allSystems.x86_64-linux;
-
-    apps = lib.listToAttrs (
-      map (v: {
-        name = v.name;
-        value = v;
-      }) def.debug.forge.apps
-    );
-
-    forgePkgs = lib.listToAttrs (
-      map (v: {
-        name = v.name;
-        value = v;
-      }) def.debug.forge.packages
-    );
-
+    apps = flake.outputs.apps.${system};
+    forgePkgs = flake.outputs.packages.${system};
     shells = flake.outputs.devShells.${system};
   });
 

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -96,6 +96,18 @@ in
               }
               // lib.optionalAttrs app.services.runtimes.nixos.enable {
                 vm = app.services.runtimes.nixos.result.build;
+                nixosModules.default = {
+                  imports =
+                    let
+                      m = app.services.runtimes.nixos.result.modules;
+                    in
+                    [
+                      m.setup
+                      m.nimi
+                      m.packages
+                      m.extraConfig
+                    ];
+                };
                 nixos = {
                   modules = app.services.runtimes.nixos.result.modules;
                   vm = app.services.runtimes.nixos.result.build;


### PR DESCRIPTION
Made for https://github.com/ngi-nix/forge/pull/311#discussion_r3192851207

Another way to solve this is to expose `nixosModules.<app>-app` for all apps.