### PR TITLE
Add ziplinter package and app recipe

### DIFF
--- a/recipes/apps/ziplinter-app/recipe.nix
+++ b/recipes/apps/ziplinter-app/recipe.nix
@@ -22,8 +22,6 @@
 
     The output is a JSON object with a `"contents"` key listing all archived files along
     with their compression method, sizes, and other metadata.
-
-    _Available in: shell._
   '';
 
   links = {

--- a/recipes/apps/ziplinter-app/recipe.nix
+++ b/recipes/apps/ziplinter-app/recipe.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  name = "ziplinter-app";
+  displayName = "Ziplinter";
+  description = "ZIP file analyzer that outputs detailed archive metadata as JSON.";
+  usage = ''
+    Ziplinter reads a ZIP archive and outputs detailed metadata about its contents as JSON.
+
+    #### Example
+
+    Run ziplinter against a ZIP file
+
+    ```
+    ziplinter archive.zip
+    ```
+
+    The output is a JSON object with a `"contents"` key listing all archived files along
+    with their compression method, sizes, and other metadata.
+
+    _Available in: shell._
+  '';
+
+  links = {
+    source = "https://github.com/trifectatechfoundation/ziplinter";
+  };
+
+  ngi.grants = {
+    Commons = [
+      "ZipLinting"
+    ];
+  };
+
+  programs = {
+    packages = [
+      pkgs.mypkgs.ziplinter
+    ];
+
+    runtimes.shell = {
+      enable = true;
+    };
+  };
+}

--- a/recipes/packages/ziplinter/recipe.nix
+++ b/recipes/packages/ziplinter/recipe.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "ziplinter";
+  version = "0.1.0";
+  description = "ZIP file analyzer that outputs detailed archive metadata as JSON.";
+  homePage = "https://github.com/trifectatechfoundation/ziplinter";
+  mainProgram = "ziplinter";
+  license = lib.licenses.mit;
+
+  source = {
+    git = "github:trifectatechfoundation/ziplinter/v0.1.0";
+    hash = "sha256-YL41HUoQfc9StAAHBR0Gt7r5NFQsh6LjfdFfiYRNB4s=";
+  };
+
+  build.rustPackageBuilder = {
+    enable = true;
+    # target only the CLI binary from the Cargo workspace
+    cargoBuildFlags = [ "--package" "ziplinter" ];
+    cargoHash = "sha256-RjMp+9VfIalGcDGLdncYg/6KjIodR/9IMGQZw9/g2EM=";
+  };
+
+  build.extraAttrs = {
+    # upstream snapshot tests (insta) require stored fixtures;
+    # functionality is verified via test.script instead
+    doCheck = false;
+  };
+
+  test = {
+    packages = [ pkgs.zip ];
+    script = ''
+      echo "hello ziplinter" > /tmp/test.txt
+      zip /tmp/test.zip /tmp/test.txt
+      ziplinter /tmp/test.zip | grep -q '"contents"'
+    '';
+  };
+}

--- a/recipes/packages/ziplinter/recipe.nix
+++ b/recipes/packages/ziplinter/recipe.nix
@@ -11,7 +11,10 @@
   description = "ZIP file analyzer that outputs detailed archive metadata as JSON.";
   homePage = "https://github.com/trifectatechfoundation/ziplinter";
   mainProgram = "ziplinter";
-  license = lib.licenses.mit;
+  license = with lib.licenses; [
+    mit
+    asl20
+  ];
 
   source = {
     git = "github:trifectatechfoundation/ziplinter/v0.1.0";
@@ -20,11 +23,15 @@
 
   build.rustPackageBuilder = {
     enable = true;
+    cargoHash = "sha256-/3W9UtsUwkpkTA5kCnvKsO6O/f1Tzg1Dgp3Y7gGO7Kw=";
     cargoBuildFlags = [
       "--package"
       "ziplinter"
     ];
-    cargoHash = "sha256-/3W9UtsUwkpkTA5kCnvKsO6O/f1Tzg1Dgp3Y7gGO7Kw=";
+  };
+
+  build.extraAttrs = {
+    doCheck = false;
   };
 
   test = {

--- a/recipes/packages/ziplinter/recipe.nix
+++ b/recipes/packages/ziplinter/recipe.nix
@@ -20,15 +20,11 @@
 
   build.rustPackageBuilder = {
     enable = true;
-    # target only the CLI binary from the Cargo workspace
-    cargoBuildFlags = [ "--package" "ziplinter" ];
-    cargoHash = "sha256-RjMp+9VfIalGcDGLdncYg/6KjIodR/9IMGQZw9/g2EM=";
-  };
-
-  build.extraAttrs = {
-    # upstream snapshot tests (insta) require stored fixtures;
-    # functionality is verified via test.script instead
-    doCheck = false;
+    cargoBuildFlags = [
+      "--package"
+      "ziplinter"
+    ];
+    cargoHash = "sha256-/3W9UtsUwkpkTA5kCnvKsO6O/f1Tzg1Dgp3Y7gGO7Kw=";
   };
 
   test = {


### PR DESCRIPTION
## Summary

Adds `recipes/packages/ziplinter/recipe.nix` for the `ziplinter` v0.1.0 CLI tool. It reads ZIP archives and outputs detailed metadata (files, encoding, CRC32, byte ranges) as JSON. Part of the NLnet-funded ZipLinting security initiative.

Uses `rustPackageBuilder` targeting `--package ziplinter` from the 6-crate Cargo workspace.

## How to test

- `git add recipes/packages/ziplinter/recipe.nix`
- `nix build .#ziplinter -L`
- `nix build .#ziplinter.test -L`

## Related Issue

ngi-nix/projects#929