### PR TITLE
feat(deploy): deploy netlify previews in a subroute

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -87,10 +87,10 @@ jobs:
           DEPLOY_ID=$(grep 'Build logs:' deploy_output.txt | grep -o 'deploys/[^>]*' | cut -d'/' -f2)
 
           SITE_NAME=$(echo "$PREVIEW_URL" | sed -E 's/https:\/\/[^/]+--([^.]+)\.netlify\.app/\1/')
-          DEPLOY_URL="https://${DEPLOY_ID}--${SITE_NAME}.netlify.app"
+          DEPLOY_URL="https://${DEPLOY_ID}--${SITE_NAME}.netlify.app/forge"
 
           {
-            echo "PREVIEW_URL=$PREVIEW_URL"
+            echo "PREVIEW_URL=$PREVIEW_URL/forge"
             echo "DEPLOY_URL=$DEPLOY_URL"
             echo "DEPLOY_ID=$DEPLOY_ID"
           } >>"$GITHUB_ENV"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,16 +93,16 @@ jobs:
 
       - name: Configure the baseUrl
         run: |
-          sed -i "s|:baseUrl|/|g" ui/src/Main/Model/Route.elm
-          sed -i "s|<base href=\"/\"|<base href=\"/\"|g" ui/src/index.html
+          sed -i "s|:baseUrl|/forge/|g" ui/src/Main/Model/Route.elm
+          sed -i "s|<base href=\"/\"|<base href=\"/forge/\"|g" ui/src/index.html
 
       - name: Build UI
         run: nix build .#_forge-ui --accept-flake-config
 
       - name: Resolve Nix Symlink
         run: |
-          mkdir -p deploy_dist
-          cp -rL result/. deploy_dist/
+          mkdir -p deploy_dist/forge
+          cp -rL result/. deploy_dist/forge/
 
       - name: Upload preview ui
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
- closes #416

Tested in https://github.com/phanirithvij/nix-forge/pull/14

It is not going to work in this PR right away we have to merge it to use it. (Because of how the `workflow_run` defined in netlify-deploy.yml file works)