### PR TITLE
+dev@correctness(recipe.nix): use `config` instead of `rec`

### DIFF
--- a/recipes/packages/mox/recipe.nix
+++ b/recipes/packages/mox/recipe.nix
@@ -5,7 +5,7 @@
   ...
 }:
 
-rec {
+{
   name = "mox";
   version = "0.0.15";
   description = "Modern full-featured open source secure mail server for low-maintenance self-hosted email";
@@ -14,7 +14,7 @@ rec {
   license = lib.licenses.mit;
 
   source = {
-    git = "github:mjl-/mox/v${version}";
+    git = "github:mjl-/mox/v${config.version}";
     hash = "sha256-apIV+nClXTUbmCssnvgG9UwpTNTHTe6FgLCxp14/s0A=";
     patches = [
       ./version.patch
@@ -27,12 +27,12 @@ rec {
     ldflags = [
       "-s"
       "-w"
-      "-X github.com/mjl-/mox/moxvar.Version=${version}"
-      "-X github.com/mjl-/mox/moxvar.VersionBare=${version}"
+      "-X github.com/mjl-/mox/moxvar.Version=${config.version}"
+      "-X github.com/mjl-/mox/moxvar.VersionBare=${config.version}"
     ];
   };
 
   test.script = ''
-    mox version | grep "${version}"
+    mox version | grep "${config.version}"
   '';
 }

--- a/recipes/packages/tslib/recipe.nix
+++ b/recipes/packages/tslib/recipe.nix
@@ -5,7 +5,7 @@
   ...
 }:
 
-rec {
+{
   name = "tslib";
   version = "1.24";
   description = "Touchscreen access library";
@@ -14,7 +14,7 @@ rec {
   license = lib.licenses.lgpl21;
 
   source = {
-    git = "github:libts/tslib/${version}";
+    git = "github:libts/tslib/${config.version}";
     hash = "sha256-WrzOTZlceYnFXi5AI5vb+ZDSRoqUDk/yyCdBUWKn0sM=";
   };
 


### PR DESCRIPTION
This use of `rec` is likely a sign that what this `config` is not documented enough.
This also prompts the question of whether `config` should rather be the flake-parts `config` (aka dendritic pattern) or the per-system `config`.
But that's for another PR.