### PR TITLE
feat: pass entropy from host to NixOS VMs

### DIFF
--- a/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
@@ -21,6 +21,9 @@
       memorySize
       ;
 
+    # Pass entropy from host to VM to prevent slow service startup due to entropy starvation.
+    qemu.options = [ "-device virtio-rng-pci" ];
+
     forwardPorts = map (
       portRange:
       if builtins.isString portRange then

--- a/forge/modules/apps/test/nixos.nix
+++ b/forge/modules/apps/test/nixos.nix
@@ -39,6 +39,8 @@
             setup
             extraConfig
           ];
+          # Pass entropy from host to VM to prevent slow service startup due to entropy starvation.
+          virtualisation.qemu.options = [ "-device virtio-rng-pci" ];
           system.stateVersion = "25.11";
           environment.systemPackages = app.programs.packages ++ config.packages;
         };


### PR DESCRIPTION
Pass entropy from host to VM to prevent slow service startup due to
entropy starvation.

I hope this will fix slow Mox start in CI.
