### PR TITLE
flake: update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -30,8 +30,8 @@
       example = "https://www.gnu.org/software/hello/hello-2.12.1.tar.gz";
     };
     mainProgram = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
+      type = lib.types.str;
+      default = "";
       description = "Name of the main executable program.";
       example = "hello";
     };

--- a/ui/src/Main/Config/Package.elm
+++ b/ui/src/Main/Config/Package.elm
@@ -9,7 +9,7 @@ type alias Package =
     , package_description : String
     , package_version : String
     , package_homePage : String
-    , package_mainProgram : Maybe String
+    , package_mainProgram : String
     , package_licenses : List PackageLicense
     , package_source : PackageSource
     , package_recipePath : String
@@ -23,7 +23,7 @@ decodePackage =
         (Decode.field "description" Decode.string)
         (Decode.field "version" Decode.string)
         (Decode.field "homePage" Decode.string)
-        (Decode.field "mainProgram" (Decode.maybe Decode.string))
+        (Decode.field "mainProgram" Decode.string)
         (Decode.field "license" decodeLicenses)
         (Decode.field "source" decodeSource)
         (Decode.field "recipePath" Decode.string)


### PR DESCRIPTION
- **flake: update nixpkgs**

and also

- **fix: set correct type for package mainProgram**

otherwise we get following error

```
 error: The `env` attribute set can only contain derivation, string,
    boolean or integer attributes. The `NIX_MAIN_PROGRAM` attribute is of
    type null.
```
