### PR TITLE
Add WeasyPrint app recipe

### DIFF
--- a/recipes/apps/weasyprint-app/recipe.nix
+++ b/recipes/apps/weasyprint-app/recipe.nix
@@ -53,4 +53,13 @@
       enable = true;
     };
   };
+
+  test = {
+    packages = [ pkgs.file ];
+    script = ''
+      echo "<html><body><h1>test</h1></body></html>" > /tmp/test.html
+      weasyprint /tmp/test.html /tmp/output.pdf
+      file /tmp/output.pdf | grep -q "PDF"
+    '';
+  };
 }

--- a/recipes/apps/weasyprint-app/recipe.nix
+++ b/recipes/apps/weasyprint-app/recipe.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  name = "weasyprint-app";
+  displayName = "WeasyPrint";
+  description = "Print rendering engine for HTML and CSS.";
+  usage = ''
+    WeasyPrint converts HTML and CSS documents into PDF files.
+
+    #### Example
+
+    Convert an HTML file to PDF
+
+    ```
+    weasyprint input.html output.pdf
+    ```
+
+    Convert a URL to PDF
+
+    ```
+    weasyprint https://example.com output.pdf
+    ```
+
+    Specify a base URL for resolving relative assets
+
+    ```
+    weasyprint --base-url . input.html output.pdf
+    ```
+  '';
+
+  links = {
+    website = "https://weasyprint.org";
+    source = "https://github.com/Kozea/WeasyPrint";
+  };
+
+  ngi.grants = {
+    Core = [
+      "WeasyPrint"
+    ];
+  };
+
+  programs = {
+    packages = [
+      pkgs.python3Packages.weasyprint
+    ];
+
+    runtimes.shell = {
+      enable = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Adds `recipes/apps/weasyprint-app/recipe.nix` exposing WeasyPrintvia shell runtime. Uses `pkgs.python3Packages.weasyprint` from nixpkgs directly — no package recipe needed since it's already packaged upstream as `python3Packages.weasyprint` v68.0.

## How to test

- `git add recipes/apps/weasyprint-app/recipe.nix recipes/apps/weasyprint-app/icon.svg`
- `nix build .#weasyprint-app -L`

## Related Issue

ngi-nix/projects#901