### PR TITLE
feat(ui): add language highlight in codeblocks

### DIFF
--- a/docs/manuals/developer/how_to/test.md
+++ b/docs/manuals/developer/how_to/test.md
@@ -2,6 +2,12 @@
 
 ## How to test the UI
 
+There are two commands available to run the elm UI in the project devshell.
+
+- `forge-ui` serves the production UI locally.
+- `dev-ui` serves a UI with generated apps meant to be used for testing purposes
+  and for faster iteration on UI changes.
+
 ### Basic test
 
 Run basic tests using [Playwright](https://playwright.dev/):
@@ -12,9 +18,8 @@ dev-ui
 test-ui --project=chromium
 ```
 
-::: {note}
-`test-ui` is a shell wrapper around `playwright test -c ui/tests/e2e` without
-any extra arguments forwarded to that command.
+::: {note} `test-ui` is a shell wrapper around `playwright test -c ui/tests/e2e`
+without any extra arguments forwarded to that command.
 
 :::
 

--- a/flake/develop/commands/dev/dev-ui-config/default.nix
+++ b/flake/develop/commands/dev/dev-ui-config/default.nix
@@ -7,14 +7,14 @@
   writeShellApplication,
 }:
 let
-  devUIDir = builtins.toString ../dev-ui;
+  forgeUIDir = builtins.toString ../forge-ui;
   script = writers.writePython3Bin "dev-ui-config.py" {
     libraries = [ python3.pkgs.faker ];
     flakeIgnore = [
       "E402"
       "E501"
     ];
-  } (builtins.replaceStrings [ "@devUIDir@" ] [ devUIDir ] (builtins.readFile ./generate.py));
+  } (builtins.replaceStrings [ "@forgeUIDir@" ] [ forgeUIDir ] (builtins.readFile ./generate.py));
 in
 writeShellApplication {
   name = "dev-ui-config";

--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -223,7 +223,7 @@ def main():
     out_path.symlink_to(real_file.relative_to(out_path.parent))
     print(f"Mock config symlinked: {out_path} -> {real_file}")
 
-    sys.path.append("@devUIDir@")
+    sys.path.append("@forgeUIDir@")
     try:
         from build_app_resources import populate_resources_dir
 

--- a/flake/develop/commands/dev/forge-ui/ui.sh
+++ b/flake/develop/commands/dev/forge-ui/ui.sh
@@ -10,6 +10,10 @@ listenPort="${listenPort:-@defaultListenPort@}"
 unit=ngi_nix_dev-"$listenPort"
 slice=session-"$unit"
 
+nix="$(command -v nix)"
+elm_review="$(command -v elm-review)"
+elm_watch="$(command -v elm-watch)"
+
 function clean {
   systemctl --user stop "$slice".slice || true
   rm -f /run/user/"$UID"/systemd/user/"$unit"-*
@@ -26,8 +30,6 @@ trap onExit EXIT
 clean
 set -ex
 
-mkdir -p "$rootDir/ui/build/js"
-
 # Warning(correctness): when using `nix build`,
 # be careful to either register the resulting output(s)
 # in $rootDir/ui/build as roots to nix's garbage-collector (GC)
@@ -38,7 +40,7 @@ if [ "@mockBackend@" = "true" ]; then
   # Using the explicit path from our devshell environment
   BACKEND_COMMAND="$DEVSHELL_DIR/bin/dev-ui-config @numApps@ @numPackages@ \"$rootDir/ui/build/forge-config.json\""
 else
-  BACKEND_COMMAND="$(command -v nix) build -f \"$rootDir\" _forge-config -o \"$rootDir/ui/build/forge-config.json\" --show-trace"
+  BACKEND_COMMAND="$nix build -f \"$rootDir\" _forge-config -o \"$rootDir/ui/build/forge-config.json\" --show-trace"
 fi
 
 systemctl --user edit --runtime --force --full "$unit"-backend.service --stdin <<EOT
@@ -50,10 +52,7 @@ RemainAfterExit=yes
 Slice=$slice.slice
 Environment=PATH=$PATH
 WorkingDirectory=$rootDir
-ExecStart=$(command -v nix) build -f "$rootDir" _forge-ui.passthru.bootstrapCss -o "$rootDir/ui/build/bootstrap" --show-trace
-ExecStart=$(command -v nix) build -f "$rootDir" _forge-options -o "$rootDir/ui/build/forge-options.json" --show-trace
-ExecStart=$(command -v nix) build -f "$rootDir" _forge-docs -o "$rootDir/ui/build/docs" --show-trace
-ExecStart=$(command -v nix) build -f "$rootDir" highlight-js -o "$rootDir/ui/build/js/highlight.min.js" --show-trace
+ExecStart=$nix run -f "$rootDir" _forge-ui-dev --show-trace
 ExecStart=$BACKEND_COMMAND
 ExecStart=$rootDir/flake/develop/commands/dev/forge-ui/build_app_resources.py
 EOT
@@ -68,8 +67,8 @@ Type=simple
 Slice=$slice.slice
 WorkingDirectory=$rootDir/ui
 Environment=ELM_WATCH_HOST="${ELM_WATCH_HOST:-"127.0.0.1"}"
-Environment=PATH=$(dirname "$(command -v elm-review)"):$PATH
-ExecStart=$(command -v elm-watch) hot
+Environment=PATH=$(dirname "$elm_review"):$PATH
+ExecStart=$elm_watch hot
 EOT
 
 # Remark(correctness): --serve-fallback= prevents 404 errors

--- a/flake/develop/commands/dev/forge-ui/ui.sh
+++ b/flake/develop/commands/dev/forge-ui/ui.sh
@@ -53,6 +53,7 @@ WorkingDirectory=$rootDir
 ExecStart=$(command -v nix) build -f "$rootDir" _forge-ui.passthru.bootstrapCss -o "$rootDir/ui/build/bootstrap" --show-trace
 ExecStart=$(command -v nix) build -f "$rootDir" _forge-options -o "$rootDir/ui/build/forge-options.json" --show-trace
 ExecStart=$(command -v nix) build -f "$rootDir" _forge-docs -o "$rootDir/ui/build/docs" --show-trace
+ExecStart=$(command -v nix) build -f "$rootDir" highlight-js -o "$rootDir/ui/build/js/highlight.min.js" --show-trace
 ExecStart=$BACKEND_COMMAND
 ExecStart=$rootDir/flake/develop/commands/dev/forge-ui/build_app_resources.py
 EOT

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -2,6 +2,7 @@
 {
   perSystem =
     {
+      self',
       config,
       lib,
       pkgs,

--- a/flake/packages/forge-ui-dev.nix
+++ b/flake/packages/forge-ui-dev.nix
@@ -1,0 +1,22 @@
+{
+  writeShellApplication,
+  _forge-ui,
+  _forge-options,
+  _forge-docs,
+  highlight-js,
+}:
+(writeShellApplication {
+  name = "forge-ui-dev";
+  text = ''
+    out=./ui/build
+    mkdir -p $out/js $out/css
+    ln -snvf ${_forge-ui.passthru.bootstrapCss} $out/bootstrap
+    ln -snvf ${_forge-options} $out/forge-options.json
+    ln -snvf ${_forge-docs} $out/docs
+    ln -snvf ${highlight-js}/highlight.min.js $out/js/highlight.min.js
+    ln -snvf ${highlight-js}/theme.css $out/css/highlightjs-theme.css
+  '';
+  passthru = {
+    inherit highlight-js;
+  };
+})

--- a/flake/packages/highlight-js.nix
+++ b/flake/packages/highlight-js.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  perl,
+  languages ? [
+    "plaintext"
+    "bash"
+    "json"
+    "nix"
+    "python"
+    "sql"
+  ],
+  # https://highlightjs.org/examples
+  # https://highlightjs.org/demo
+  theme ? "github-dark",
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "highlight.js";
+  # TODO: updateScript
+  version = "11.11.1";
+
+  src = fetchFromGitHub {
+    owner = "highlightjs";
+    repo = "highlight.js";
+    rev = finalAttrs.version;
+    hash = "sha256-f+yC6SHkFKoY2ecP5EUENzewq+4PFC3Yy+8VRKY/+NY=";
+  };
+
+  npmDepsHash = "sha256-hMci5DCdcxh9RoPB2HUAsSa25FffyatZ4NXeoutIjHI=";
+
+  # Remove impurity: highlight.js build script tries to run git to get the version hash.
+  postPatch = ''
+    ${perl}/bin/perl -0777 -i -pe 's/git_sha: child_process\s*\.execSync\("git rev-parse --short=10 HEAD"\)\s*\.toString\(\)\.trim\(\)/git_sha: "built-with-nix"/g' tools/build_browser.js
+  '';
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    node tools/build.js \
+      --target browser \
+      ${lib.concatStringsSep " " languages}
+
+    mkdir -p $out
+    cp -v build/highlight.min.js $out/
+
+    THEME_PATH="build/demo/styles/${theme}.css"
+    if [ ! -f "$THEME_PATH" ]; then
+      # Check base16 subfolder
+      THEME_PATH="build/demo/styles/base16/${theme}.css"
+    fi
+
+    if [ -f "$THEME_PATH" ]; then
+      cp -v "$THEME_PATH" $out/theme.css
+    else
+      echo "Error: Theme '${theme}' not found in build/demo/styles/ or build/demo/styles/base16/"
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minified highlight.js bundle with pre-selected languages";
+    homepage = "https://highlightjs.org/";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+  };
+})

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -63,9 +63,23 @@
         '';
 
         _forge-ui = pkgs.callPackage ../ui/package.nix {
-          inherit (config.packages) _forge-config _forge-docs _forge-options;
+          inherit (config.packages)
+            _forge-config
+            _forge-docs
+            _forge-options
+            ;
           inherit appIcons;
           buildElmApplication = (inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
+          highlight-js = pkgs.callPackage ../flake/packages/highlight-js.nix { };
+        };
+
+        _forge-ui-dev = pkgs.callPackage ../flake/packages/forge-ui-dev.nix {
+          inherit (config.packages)
+            _forge-ui
+            _forge-docs
+            _forge-options
+            ;
+          highlight-js = pkgs.callPackage ../flake/packages/highlight-js.nix { };
         };
 
         _forge-docs = pkgs.callPackage ../flake/packages/forge-docs.nix { };

--- a/recipes/apps/bang-app/recipe.nix
+++ b/recipes/apps/bang-app/recipe.nix
@@ -15,7 +15,7 @@
 
     #### Scan a binary file
 
-    ```
+    ```bash
     bang scan -u /tmp/bang-results /path/to/firmware.bin
     ```
 

--- a/recipes/apps/goupile-app/recipe.nix
+++ b/recipes/apps/goupile-app/recipe.nix
@@ -12,7 +12,7 @@
   usage = ''
     Goupile is a tool for creating secure forms, especially Clinical Report Forms (eCRF).
 
-    It runs as a web service. It has been configured to run on http://localhost:8181.
+    It runs as a web service. It has been configured to run on [http://localhost:8181](http://localhost:8181).
   '';
 
   icon = ./icon.svg;

--- a/recipes/apps/kepler-formal-app/recipe.nix
+++ b/recipes/apps/kepler-formal-app/recipe.nix
@@ -16,7 +16,7 @@
 
     Download example Verilog files
 
-    ```
+    ```bash
     mkdir example-data && cd example-data
 
     for file in \
@@ -32,7 +32,7 @@
 
     Run program
 
-    ```
+    ```bash
     kepler-formal -verilog \
       tinyrocket.v \
       tinyrocket_edited.v \

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -13,24 +13,26 @@
     Mox is a modern, full-featured, open source secure mail server providing
     SMTP, IMAP4, webmail, SPF/DKIM/DMARC, and more.
 
-    #### Administration
+    ##### Administration
 
     If running inside a container, connect to it with:
-    ```
+
+    ```bash
     podman-compose -f result/mox-app/compose.yaml exec mox-app bash
     ```
 
     Set admin password:
-    ```
+
+    ```bash
     echo "adminpassword" | mox -config /var/lib/mox/config/mox.conf setadminpassword
     chown mox /var/lib/mox/config/adminpasswd
     ```
 
-    #### URLs
+    ##### URLs
 
-    * Admin web interface: `http://localhost:8080`
-    * Account web interface: `http://localhost:8081`
-    * Webmail interface: `http://localhost:8081`
+    * Admin web interface: [http://localhost:8080](http://localhost:8080)
+    * Account web interface: [http://localhost:8081](http://localhost:8081)
+    * Webmail interface: [http://localhost:8082](http://localhost:8082)
 
   '';
 

--- a/recipes/apps/offen-app/recipe.nix
+++ b/recipes/apps/offen-app/recipe.nix
@@ -15,12 +15,13 @@
 
     #### Access
 
-    Open the Offen interface at `http://localhost:3000`.
+    Open the Offen interface at [http://localhost:3000](http://localhost:3000).
 
     #### Initial Setup
 
     Create an account on first run:
-    ```
+
+    ```bash
     export OFFEN_DATABASE_CONNECTIONSTRING="/var/lib/offen/offen.db"
     offen setup -name <account-name> -email <email> -password <password>
     ```

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -14,12 +14,14 @@
     managing a list of users.
 
     * Initialize database
-    ```
+
+    ```bash
     curl -X POST localhost:5000/init
     ```
 
     * Add a new user
-    ```
+
+    ```bash
     curl -X POST \
       --header "Content-Type: application/json" \
       --data '{"name":"username"}' \
@@ -27,7 +29,8 @@
     ```
 
     * Get list of all users
-    ```
+
+    ```bash
     curl localhost:5000/users
     ```
 

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -13,7 +13,7 @@
     By default, the Olympics dataset is downloaded and indexed on startup.
     To use a different dataset, choose one from the [available use cases](https://docs.qlever.dev/use-cases) and update your `./Qleverfile` accordingly.
 
-    Once indexing is complete, open the UI in your browser at `http://localhost:8080` and run the following query:
+    Once indexing is complete, open the UI in your browser at [http://localhost:8080](http://localhost:8080) and run the following query:
 
     ```sparql
     SELECT * WHERE { ?s ?p ?o } LIMIT 10

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -25,6 +25,7 @@
     Client CLI for capturing audio from your device and streaming it to _tau-tower_.
 
     Usage:
+
     ```
     tau-radio --username <user> --password <pass> --ip <server-ip> --port <server-port>
     ```

--- a/ui/elm.json
+++ b/ui/elm.json
@@ -17,7 +17,6 @@
       "elmcraft/core-extra": "2.3.0",
       "lydell/elm-app-url": "1.0.4",
       "mpizenberg/elm-url-navigation-port": "1.1.0",
-      "pablohirafuji/elm-syntax-highlight": "3.7.1",
       "zwilias/elm-rosetree": "1.5.0"
     },
     "indirect": {

--- a/ui/elm.lock
+++ b/ui/elm.lock
@@ -114,12 +114,6 @@
         "sha256": "04gm52qn9rd4llabdj5gbf0g4yk43w4h9anvm4gpdwz1i835q3p2"
     },
     {
-        "author": "pablohirafuji",
-        "package": "elm-syntax-highlight",
-        "version": "3.7.1",
-        "sha256": "1z8pyqnfq090hkiw2jhprs735bb06hckab5cn6maivrjff13l0rj"
-    },
-    {
         "author": "rtfeldman",
         "package": "elm-hex",
         "version": "1.0.0",

--- a/ui/package.nix
+++ b/ui/package.nix
@@ -3,13 +3,13 @@
   fetchzip,
   jq,
   symlinkJoin,
-  callPackage,
 
   appIcons,
 
   _forge-config,
   _forge-docs,
   _forge-options,
+  highlight-js,
   ...
 }:
 
@@ -36,8 +36,6 @@ let
     url = "https://github.com/twbs/bootstrap/releases/download/v${version}/bootstrap-${version}-dist.zip";
     hash = "sha256-StRhHJIRGzguLlo0BGOAMy0PCCmMovzgU/5xZJgVrqQ=";
   };
-
-  highlight-js = callPackage ../flake/packages/highlight-js.nix { };
 in
 symlinkJoin {
   name = "forge-ui";

--- a/ui/package.nix
+++ b/ui/package.nix
@@ -3,11 +3,13 @@
   fetchzip,
   jq,
   symlinkJoin,
+  callPackage,
+
+  appIcons,
 
   _forge-config,
   _forge-docs,
   _forge-options,
-  appIcons,
   ...
 }:
 
@@ -29,10 +31,13 @@ let
 
   bootstrapCss = fetchzip rec {
     pname = "bootstrap";
+    # TODO updateScript
     version = "5.3.8";
     url = "https://github.com/twbs/bootstrap/releases/download/v${version}/bootstrap-${version}-dist.zip";
     hash = "sha256-StRhHJIRGzguLlo0BGOAMy0PCCmMovzgU/5xZJgVrqQ=";
   };
+
+  highlight-js = callPackage ../flake/packages/highlight-js.nix { };
 in
 symlinkJoin {
   name = "forge-ui";
@@ -47,6 +52,8 @@ symlinkJoin {
     cp -aR ${./src/js}/. js
     chmod -R u+w css js
     install -D ${bootstrapCss}/css/bootstrap.min.css bootstrap/css/bootstrap.min.css
+    install -D ${highlight-js}/highlight.min.js js/highlight.min.js
+    install -D ${highlight-js}/theme.css css/highlightjs-theme.css
 
     # Rename minimized Elm output
     mv js/Elm.min.js js/Elm.js

--- a/ui/src/Main/Helpers/Html.elm
+++ b/ui/src/Main/Helpers/Html.elm
@@ -48,6 +48,14 @@ nixCodeBlock content =
         }
 
 
+bashCodeBlock : String -> Html Update
+bashCodeBlock content =
+    codeBlock
+        { body = content
+        , language = Just "bash"
+        }
+
+
 codeBlock : CodeBlock -> Html Update
 codeBlock body =
     let

--- a/ui/src/Main/Helpers/Html.elm
+++ b/ui/src/Main/Helpers/Html.elm
@@ -1,23 +1,76 @@
 module Main.Helpers.Html exposing (..)
 
-import Html exposing (Attribute, Html, button, code, div, pre, text)
-import Html.Attributes exposing (class)
+import Html exposing (Attribute, Html, button, code, div, node, pre, text)
+import Html.Attributes exposing (attribute, class)
 import Html.Events
 import Json.Decode
 import Main.Icons exposing (iconCopy)
 import Main.Update.Types exposing (..)
 
 
-codeBlock : String -> Html Update
-codeBlock content =
+mdResolveLangCodeAlias : String -> String
+mdResolveLangCodeAlias lang =
+    case lang of
+        "python3" ->
+            "python"
+
+        "py" ->
+            "python"
+
+        -- sparql is not sql but we don't need to bring in https://github.com/redmer/highlightjs-sparql
+        -- for a single line in qlever app where sql highlighting works fine
+        "sparql" ->
+            "sql"
+
+        any ->
+            any
+
+
+type alias CodeBlock =
+    { body : String
+    , language : Maybe String
+    }
+
+
+plainCodeBlock : String -> Html Update
+plainCodeBlock content =
+    codeBlock
+        { body = content
+        , language = Nothing
+        }
+
+
+nixCodeBlock : String -> Html Update
+nixCodeBlock content =
+    codeBlock
+        { body = content
+        , language = Just "nix"
+        }
+
+
+codeBlock : CodeBlock -> Html Update
+codeBlock body =
+    let
+        lang =
+            body.language
+                |> Maybe.withDefault ""
+                |> mdResolveLangCodeAlias
+
+        copyBtn =
+            button
+                [ class "btn btn-sm btn-secondary position-absolute top-0 end-0 m-2 button copy"
+                , onClick (Update_CopyToClipboard body.body)
+                ]
+                [ iconCopy ]
+    in
     div [ class "markdown-content position-relative" ]
-        [ button
-            [ class "btn btn-sm btn-secondary position-absolute top-0 end-0 m-2 button copy"
-            , onClick (Update_CopyToClipboard content)
+        [ copyBtn
+        , node
+            "highlightjs-code"
+            [ attribute "language" lang
+            , attribute "body" body.body
             ]
-            [ iconCopy ]
-        , pre [ class "p-3 rounded border border-secondary" ]
-            [ code [] [ text content ] ]
+            []
         ]
 
 

--- a/ui/src/Main/Helpers/Markdown.elm
+++ b/ui/src/Main/Helpers/Markdown.elm
@@ -35,5 +35,5 @@ renderer =
     { defaultHtmlRenderer
         | codeBlock =
             \block ->
-                block.body |> codeBlock
+                block |> codeBlock
     }

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -170,31 +170,31 @@ viewPageAppRunNixInstall model pageApp =
                     ]
                  , case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
-                        codeBlock <|
+                        plainCodeBlock <|
                             String.join "\n"
                                 [ "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install --enable-flakes" ]
 
                     PreferencesInstall_NixTraditional ->
-                        codeBlock <|
+                        plainCodeBlock <|
                             String.join "\n"
                                 [ "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install" ]
                  , small [ class "mb-1" ]
                     [ text "to uninstall, run:" ]
-                 , codeBlock <|
+                 , plainCodeBlock <|
                     "/nix/nix-installer uninstall"
                  ]
                     ++ (case model.model_preferences.preferences_install of
                             PreferencesInstall_NixFlakes ->
                                 [ p [ class "mt-3 mb-1" ]
                                     [ text "2. Accept binaries pre-built by NGI Forge (optional, highly recommended) " ]
-                                , codeBlock <|
+                                , plainCodeBlock <|
                                     "export NIX_CONFIG=\"accept-flake-config = true\""
                                 ]
 
                             PreferencesInstall_NixTraditional ->
                                 [ p [ class "mt-3 mb-1" ]
                                     [ text "2. Configure substitutors (optional, highly recommended)" ]
-                                , codeBlock <|
+                                , plainCodeBlock <|
                                     String.join "\n"
                                         [ "export NIX_CONFIG='substituters = https://cache.nixos.org https://ngi-forge.cachix.org"
                                         , "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ngi-forge.cachix.org-1:PK0qK+LhWt4GQVpUtPapyXWxJSM1GhtmPW6CRCoygz0='"
@@ -266,7 +266,7 @@ viewPageAppRunProgram model pageApp =
         [ p [ style "margin-bottom" "0em" ]
             [ text "Launch the program" ]
         , br [] []
-        , codeBlock <|
+        , plainCodeBlock <|
             String.concat
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -306,7 +306,7 @@ viewPageAppRunShell model pageApp =
         [ p [ style "margin-bottom" "0em" ]
             [ text "Enter a shell environment with CLI or GUI programs available" ]
         , br [] []
-        , codeBlock <|
+        , plainCodeBlock <|
             String.concat
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -333,7 +333,7 @@ viewPageAppRunContainer model pageApp =
     div []
         [ p [ style "margin-bottom" "0em" ] [ text "Run application services in OCI containers" ]
         , br [] []
-        , codeBlock <|
+        , plainCodeBlock <|
             String.join "\n"
                 [ case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -368,7 +368,7 @@ viewPageAppRunContainerBuildOCI model pageApp =
     details []
         [ summary [] [ text "Build container images manually" ]
         , br [] []
-        , codeBlock <|
+        , plainCodeBlock <|
             case model.model_preferences.preferences_install of
                 PreferencesInstall_NixFlakes ->
                     String.join "\n"
@@ -403,7 +403,7 @@ viewPageAppRunNixOS model pageApp =
     div []
         [ p [ style "margin-bottom" "0em" ] [ text "Run application services in a NixOS VM" ]
         , br [] []
-        , codeBlock <|
+        , plainCodeBlock <|
             case model.model_preferences.preferences_install of
                 PreferencesInstall_NixFlakes ->
                     String.concat
@@ -438,7 +438,7 @@ viewPageAppRunNixOSModule model pageApp =
     details []
         [ summary [] [ text "Enable module in a NixOS configuration" ]
         , br [] []
-        , codeBlock <|
+        , nixCodeBlock <|
             case model.model_preferences.preferences_install of
                 PreferencesInstall_NixFlakes ->
                     String.join "\n"

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -170,31 +170,31 @@ viewPageAppRunNixInstall model pageApp =
                     ]
                  , case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
-                        plainCodeBlock <|
+                        bashCodeBlock <|
                             String.join "\n"
                                 [ "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install --enable-flakes" ]
 
                     PreferencesInstall_NixTraditional ->
-                        plainCodeBlock <|
+                        bashCodeBlock <|
                             String.join "\n"
                                 [ "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install" ]
                  , small [ class "mb-1" ]
                     [ text "to uninstall, run:" ]
-                 , plainCodeBlock <|
+                 , bashCodeBlock <|
                     "/nix/nix-installer uninstall"
                  ]
                     ++ (case model.model_preferences.preferences_install of
                             PreferencesInstall_NixFlakes ->
                                 [ p [ class "mt-3 mb-1" ]
                                     [ text "2. Accept binaries pre-built by NGI Forge (optional, highly recommended) " ]
-                                , plainCodeBlock <|
+                                , bashCodeBlock <|
                                     "export NIX_CONFIG=\"accept-flake-config = true\""
                                 ]
 
                             PreferencesInstall_NixTraditional ->
                                 [ p [ class "mt-3 mb-1" ]
                                     [ text "2. Configure substitutors (optional, highly recommended)" ]
-                                , plainCodeBlock <|
+                                , bashCodeBlock <|
                                     String.join "\n"
                                         [ "export NIX_CONFIG='substituters = https://cache.nixos.org https://ngi-forge.cachix.org"
                                         , "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ngi-forge.cachix.org-1:PK0qK+LhWt4GQVpUtPapyXWxJSM1GhtmPW6CRCoygz0='"
@@ -266,7 +266,7 @@ viewPageAppRunProgram model pageApp =
         [ p [ style "margin-bottom" "0em" ]
             [ text "Launch the program" ]
         , br [] []
-        , plainCodeBlock <|
+        , bashCodeBlock <|
             String.concat
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -306,7 +306,7 @@ viewPageAppRunShell model pageApp =
         [ p [ style "margin-bottom" "0em" ]
             [ text "Enter a shell environment with CLI or GUI programs available" ]
         , br [] []
-        , plainCodeBlock <|
+        , bashCodeBlock <|
             String.concat
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -333,7 +333,7 @@ viewPageAppRunContainer model pageApp =
     div []
         [ p [ style "margin-bottom" "0em" ] [ text "Run application services in OCI containers" ]
         , br [] []
-        , plainCodeBlock <|
+        , bashCodeBlock <|
             String.join "\n"
                 [ case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
@@ -368,7 +368,7 @@ viewPageAppRunContainerBuildOCI model pageApp =
     details []
         [ summary [] [ text "Build container images manually" ]
         , br [] []
-        , plainCodeBlock <|
+        , bashCodeBlock <|
             case model.model_preferences.preferences_install of
                 PreferencesInstall_NixFlakes ->
                     String.join "\n"
@@ -403,7 +403,7 @@ viewPageAppRunNixOS model pageApp =
     div []
         [ p [ style "margin-bottom" "0em" ] [ text "Run application services in a NixOS VM" ]
         , br [] []
-        , plainCodeBlock <|
+        , bashCodeBlock <|
             case model.model_preferences.preferences_install of
                 PreferencesInstall_NixFlakes ->
                     String.concat

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -379,3 +379,8 @@ a:link {
 [data-bs-theme="dark"] {
   --bs-code-color: #b2d5ff;
 }
+
+/* highlight js customised */
+pre code.hljs {
+  padding: 0px !important;
+}

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -7,9 +7,12 @@
 		<base href="/">
 		<link rel="icon" type="image/svg+xml" href="favicon.svg">
 		<link rel="stylesheet" href="bootstrap/css/bootstrap.min.css">
+		<link rel="stylesheet" href="css/highlightjs-theme.css">
+		<!-- NOTE: main.css should come at the end or we could be overriden by other css -->
 		<link rel="stylesheet" href="css/main.css">
 		<link rel="prefetch" href="forge-config.json">
 		<link rel="prefetch" href="forge-options.json">
+		<script src="js/highlight.min.js" type="text/javascript" defer></script>
 		<script src="js/Elm.js" type="text/javascript" defer></script>
 		<script src="js/main.js" type="module" defer></script>
 	</head>

--- a/ui/src/js/CodeHighlightJS.js
+++ b/ui/src/js/CodeHighlightJS.js
@@ -1,0 +1,26 @@
+customElements.define(
+  "highlightjs-code",
+  class extends HTMLElement {
+    constructor() {
+      super();
+    }
+    connectedCallback() {
+      this.setTextContent();
+    }
+    attributeChangedCallback() {
+      this.setTextContent();
+    }
+    static get observedAttributes() {
+      return ["language", "body"];
+    }
+
+    setTextContent() {
+      const lang = this.getAttribute("language") || "plaintext";
+      const code = this.getAttribute("body") || "";
+      const hljsVal = hljs.highlight(code, { language: lang });
+      this.innerHTML = `
+        <pre class="p-3 rounded border border-secondary"><code class="hljs language-${lang}">${hljsVal.value}</code></pre>
+      `;
+    }
+  },
+);

--- a/ui/src/js/main.js
+++ b/ui/src/js/main.js
@@ -2,6 +2,7 @@ import { initClipboard } from "./Clipboard.js";
 import { initNavigation } from "./Navigation.js";
 import { getPreferences, initPreferences } from "./Preferences.js";
 import { initSmoothScroll } from "./SmoothScroll.js";
+import "./CodeHighlightJS.js";
 
 // work around github pages adding extra trailing slash
 if (


### PR DESCRIPTION
- closes #399

Using highlight.js we are now able to highlight the markdown content as well as normal codeblocks not
part of a markdown.

There is a simple way to use highlight js
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/misc/documentation-highlighter/default.nix
- https://github.com/NixOS/nixpkgs/blob/master/doc/doc-support/package.nix

But this hard codes the languages required, I have built it from source and we can switch themes and add more languages easily.