### PR TITLE
feat: throw warning if package of app test is missing

### DIFF
--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -29,11 +29,42 @@
 
       # All output packages
       allPackages = lib.filterAttrs (n: v: !lib.hasPrefix "_forge" n) config.packages;
+
+      # Configuration checks
+      configurationChecks = [
+        {
+          name = "missing test scripts";
+          errors =
+            map (app: "App '${app.name}' is missing test.script") (
+              lib.filter (
+                app: app.services.components != { } && app.services.test.script == null
+              ) config.forge.apps
+            )
+            ++ map (pkg: "Package '${pkg.name}' is missing test.script") (
+              lib.filter (pkg: pkg.test.script == null) config.forge.packages
+            );
+        }
+      ];
+
+      testConfiguration = pkgs.runCommand "testConfiguration" { } (
+        let
+          errors = lib.concatMap (c: c.errors) configurationChecks;
+        in
+        if errors == [ ] then
+          "touch $out"
+        else
+          ''
+            echo "Configuration errors:"
+            ${lib.concatMapStringsSep "\n" (e: "echo '  - ${e}'") errors}
+            exit 1
+          ''
+      );
     in
 
     {
       checks = {
         inherit (config.packages) _forge-config _forge-options _forge-ui;
+        inherit testConfiguration;
       }
       // allPackages
 

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -73,17 +73,6 @@
       description = "Programs configuration.";
     };
 
-    # Test configuration
-    test = lib.mkOption {
-      type = lib.types.submodule {
-        imports = [ ./test ];
-        _module.args.app = config;
-        _module.args.pkgs = pkgs;
-      };
-      default = { };
-      description = "Test configuration.";
-    };
-
     recipePath = lib.mkOption {
       type = lib.types.str;
       default = "";

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -126,11 +126,11 @@ in
                     || throw "${app.name}'s programs.mainPackage is missing a meta.mainProgram attribute";
                   app.programs.mainPackage;
               }
-              // lib.optionalAttrs (app.services.runtimes.container.enable && app.test.script != null) {
-                test-container = app.test.result.containerBuild;
+              // lib.optionalAttrs (app.services.runtimes.container.enable && app.services.test.script != null) {
+                test-container = app.services.test.result.containerBuild;
               }
-              // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.test.script != null) {
-                test = app.test.result.build;
+              // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.services.test.script != null) {
+                test = app.services.test.result.build;
               };
 
             # finalApp parameter is currently not used in this function

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -126,10 +126,10 @@ in
                     || throw "${app.name}'s programs.mainPackage is missing a meta.mainProgram attribute";
                   app.programs.mainPackage;
               }
-              // lib.optionalAttrs (app.services.runtimes.container.enable && app.test.script != "") {
+              // lib.optionalAttrs (app.services.runtimes.container.enable && app.test.script != null) {
                 test-container = app.test.result.containerBuild;
               }
-              // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.test.script != "") {
+              // lib.optionalAttrs (app.services.runtimes.nixos.enable && app.test.script != null) {
                 test = app.test.result.build;
               };
 
@@ -145,6 +145,15 @@ in
           in
           {
             packages = allApps;
+
+            warnings = lib.flatten (
+              map (app: [
+                {
+                  condition = app.services.components != { } && app.services.test.script == null;
+                  message = "App '${app.name}' service test is missing. Use services.test.script option to add a test.";
+                }
+              ]) cfg
+            );
           };
       }
     );

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -66,5 +66,14 @@
       default = { };
       description = "Portable services runtimes.";
     };
+
+    test = lib.mkOption {
+      type = lib.types.submoduleWith {
+        inherit specialArgs;
+        modules = [ ../test ];
+      };
+      default = { };
+      description = "Test configuration.";
+    };
   };
 }

--- a/forge/modules/apps/test/container.nix
+++ b/forge/modules/apps/test/container.nix
@@ -34,7 +34,11 @@
           machine.start()
           machine.wait_for_unit("multi-user.target")
           machine.succeed("${lib.getExe containerRuntime.result.build} --detach")
-          machine.succeed("${pkgs.writeShellScript "${app.name}-container-test-script" config.script}")
+          machine.succeed("${
+            pkgs.writeShellScript "${app.name}-container-test-script" (
+              lib.optionalString (config.script != null) config.script
+            )
+          }")
         '';
       }).overrideTestDerivation
         (_: lib.optionalAttrs (!config.sandbox) { __noChroot = true; })

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -40,21 +40,18 @@
     };
 
     script = lib.mkOption {
-      type = lib.types.str;
-      default = ''
-        echo "Test script"
-      '';
+      type = lib.types.nullOr lib.types.str;
+      default = null;
       description = ''
-        Bash script to test application services inside a NixOS machine
-        or container.
+        Bash script to test the application inside a NixOS machine or container.
 
-        Launch tests with:
+        Launch test:
           - nix build .#<app>.test
           - nix build .#<app>.test-container
       '';
       example = lib.literalExpression ''
         '''
-        curl -f http://localhost:5000/users
+        curl -f http://localhost:8000 | grep "Hello"
         '''
       '';
     };

--- a/forge/modules/apps/test/nixos.nix
+++ b/forge/modules/apps/test/nixos.nix
@@ -17,7 +17,11 @@
         ${lib.concatMapAttrsStringSep "\n" (
           name: _: "machine.wait_for_unit(\"${name}.service\")"
         ) app.services.components}
-        machine.succeed("${pkgs.writeShellScript "${app.name}-test-script" config.script}")
+        machine.succeed("${
+          pkgs.writeShellScript "${app.name}-test-script" (
+            lib.optionalString (config.script != null) config.script
+          )
+        }")
       '';
       description = "Python test script passed to the NixOS test driver.";
     };

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -120,7 +120,7 @@ in
             test = pkgs.testers.runCommand {
               name = "${pkg.name}-test";
               buildInputs = [ finalPkg ] ++ pkg.test.packages;
-              script = pkg.test.script + "\ntouch $out";
+              script = lib.optionalString (pkg.test.script != null) pkg.test.script + "\ntouch $out";
             };
             devenv = pkgs.mkShell {
               dontBuild = true;

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -78,6 +78,10 @@ in
                     Package '${pkg.name}': license is empty.
                   '';
                 }
+                {
+                  condition = pkg.test.script == null;
+                  message = "Package '${pkg.name}' test is missing. Use test.script option to add a test.";
+                }
               ]) cfg
             );
 

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -155,15 +155,14 @@
         example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
       };
       script = lib.mkOption {
-        type = lib.types.str;
-        default = ''
-          echo "Test script"
-        '';
+        type = lib.types.nullOr lib.types.str;
+        default = null;
         description = ''
-          Bash script to run package tests.
-
+          Bash script to test package.
           The package being tested is available in PATH.
-          Run with: nix build .#<package>.test
+
+          Launch test:
+            - nix build .#<package>.test
         '';
         example = lib.literalExpression ''
           '''

--- a/recipes/apps/goupile-app/recipe.nix
+++ b/recipes/apps/goupile-app/recipe.nix
@@ -56,13 +56,14 @@
     };
 
     ports = [ "8181:8181" ];
+
+    test = {
+      script = ''
+        curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+
+        $curl --location localhost:8181 | grep -q "Goupile" >/dev/null
+      '';
+    };
   };
 
-  test = {
-    script = ''
-      curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
-
-      $curl --location localhost:8181 | grep -q "Goupile" >/dev/null
-    '';
-  };
 }

--- a/recipes/apps/ironcalc-app/recipe.nix
+++ b/recipes/apps/ironcalc-app/recipe.nix
@@ -58,11 +58,14 @@
     };
 
     ports = [ "8000:8000" ];
+
+    test = {
+      packages = [ pkgs.curl ];
+      script = ''
+        curl="curl --retry 8 --retry-max-time 120 --retry-all-errors"
+        $curl localhost:8000 | grep -q "IronCalc"
+      '';
+    };
   };
 
-  test.packages = [ pkgs.curl ];
-  test.script = ''
-    curl="curl --retry 8 --retry-max-time 120 --retry-all-errors"
-    $curl localhost:8000 | grep -q "IronCalc"
-  '';
 }

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -147,13 +147,13 @@
       "8081:8081"
       "8082:8082"
     ];
+
+    test.script = ''
+      curl="curl --retry 20 --retry-max-time 120 --retry-all-errors"
+
+      $curl --location localhost:8080 | grep "Mox Account"
+      $curl --location localhost:8081/admin | grep "Mox Admin"
+      $curl --location localhost:8082/webmail | grep "Mox Webmail"
+    '';
   };
-
-  test.script = ''
-    curl="curl --retry 20 --retry-max-time 120 --retry-all-errors"
-
-    $curl --location localhost:8080 | grep "Mox Account"
-    $curl --location localhost:8081/admin | grep "Mox Admin"
-    $curl --location localhost:8082/webmail | grep "Mox Webmail"
-  '';
 }

--- a/recipes/apps/offen-app/recipe.nix
+++ b/recipes/apps/offen-app/recipe.nix
@@ -75,13 +75,13 @@
     };
 
     ports = [ "3000:3000" ];
+
+    test.script = ''
+      curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+
+      export OFFEN_DATABASE_CONNECTIONSTRING="/var/lib/offen/offen.db"
+      offen setup -name test -email test@localhost -password test123456
+      $curl localhost:3000 | grep "Offen Fair Web Analytics"
+    '';
   };
-
-  test.script = ''
-    curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
-
-    export OFFEN_DATABASE_CONNECTIONSTRING="/var/lib/offen/offen.db"
-    offen setup -name test -email test@localhost -password test123456
-    $curl localhost:3000 | grep "Offen Fair Web Analytics"
-  '';
 }

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -82,22 +82,22 @@
     };
 
     ports = [ "5000:5000" ];
-  };
 
-  test = {
-    script = ''
-      curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+    test = {
+      script = ''
+        curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
 
-      $curl -X POST localhost:5000/init
+        $curl -X POST localhost:5000/init
 
-      $curl -X POST \
-        --header "Content-Type: application/json" \
-        --data '{"name":"username"}' \
-        localhost:5000/users
+        $curl -X POST \
+          --header "Content-Type: application/json" \
+          --data '{"name":"username"}' \
+          localhost:5000/users
 
-      $curl localhost:5000/users
-    '';
-    # test-container requires database image from Internet registry
-    sandbox = false;
+        $curl localhost:5000/users
+      '';
+      # test-container requires database image from Internet registry
+      sandbox = false;
+    };
   };
 }

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -170,25 +170,25 @@
       "8080:8080"
       "7019:7019"
     ];
-  };
 
-  test = {
-    script = ''
-      curl="curl --retry 40 --retry-max-time 240 --retry-all-errors"
+    test = {
+      script = ''
+        curl="curl --retry 40 --retry-max-time 240 --retry-all-errors"
 
-      sleep 30
+        sleep 30
 
-      # UI accessible
-      $curl --location localhost:8080 | grep -i "qlever"
+        # UI accessible
+        $curl --location localhost:8080 | grep -i "qlever"
 
-      sleep 30
+        sleep 30
 
-      # query indexed data
-      result=$($curl -s localhost:7019 \
-        -H "Accept: text/tab-separated-values" \
-        --data-urlencode "query=SELECT * WHERE { ?s ?p ?o } LIMIT 10")
-      echo "$result"
-      test "$(printf '%s\n' "$result" | wc -l)" -eq 11
-    '';
+        # query indexed data
+        result=$($curl -s localhost:7019 \
+          -H "Accept: text/tab-separated-values" \
+          --data-urlencode "query=SELECT * WHERE { ?s ?p ?o } LIMIT 10")
+        echo "$result"
+        test "$(printf '%s\n' "$result" | wc -l)" -eq 11
+      '';
+    };
   };
 }

--- a/recipes/apps/tau-app/recipe.nix
+++ b/recipes/apps/tau-app/recipe.nix
@@ -79,11 +79,11 @@
       "3001:3001"
       "3002:3002"
     ];
+
+    test.script = ''
+      curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
+
+      $curl localhost:3002 | grep "Audio Stream"
+    '';
   };
-
-  test.script = ''
-    curl="curl --retry 5 --retry-max-time 120 --retry-all-errors"
-
-    $curl localhost:3002 | grep "Audio Stream"
-  '';
 }

--- a/recipes/packages/python-web/recipe.nix
+++ b/recipes/packages/python-web/recipe.nix
@@ -28,4 +28,10 @@
       pkgs.python3Packages.psycopg2
     ];
   };
+
+  # python-web doesn't provide any --version or similar option which we can use
+  # to test
+  test.script = ''
+    test -x $(command -v python-web)
+  '';
 }

--- a/recipes/packages/qlever-olympics-rdf-data/recipe.nix
+++ b/recipes/packages/qlever-olympics-rdf-data/recipe.nix
@@ -32,4 +32,10 @@
       install -D olympics.nt -t $out
     '';
   };
+
+  test = {
+    script = ''
+      file ${pkgs.mypkgs.qlever-olympics-rdf-data}/olympics.nt | grep "ASCII text"
+    '';
+  };
 }

--- a/recipes/packages/tslib/recipe.nix
+++ b/recipes/packages/tslib/recipe.nix
@@ -24,4 +24,11 @@
       pkgs.cmake
     ];
   };
+
+  test = {
+    packages = [ pkgs.binutils ];
+    script = ''
+      ldd ${pkgs.mypkgs.tslib}/lib/libts.so
+    '';
+  };
 }


### PR DESCRIPTION
The idea is that we guide the contributor with evaluation warnings if something is incorrect and at the same time we prevent incomplete/incorrect configuration to be merged by adding another `configurationCheck` which will fail during `nix flake check`.

We must add all missing tests before merging this PR.

```
nix shell .#sudo-rs-app
...
evaluation warning: App 'sudo-rs-app' test is missing. Add test using test.script option.
```


```
$ nix flake check

evaluation warning: Package 'ironcalc' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-docs' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-frontend' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-nodejs' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-python' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-server' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-tools' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-wasm' test is missing. Add test using test.script option.
evaluation warning: Package 'ironcalc-widget' test is missing. Add test using test.script option.
evaluation warning: Package 'offen-auditorium' test is missing. Add test using test.script option.
evaluation warning: Package 'offen-script' test is missing. Add test using test.script option.
evaluation warning: Package 'offen-vault' test is missing. Add test using test.script option.
evaluation warning: Package 'python-web' test is missing. Add test using test.script option.
evaluation warning: Package 'qlever-olympics-rdf-data' test is missing. Add test using test.script option.
evaluation warning: Package 'tslib' test is missing. Add test using test.script option.
evaluation warning: App 'bang-app' test is missing. Add test using test.script option.
evaluation warning: App 'collabora-desktop-app' test is missing. Add test using test.script option.
evaluation warning: App 'kepler-formal-app' test is missing. Add test using test.script option.
evaluation warning: App 'sudo-rs-app' test is missing. Add test using test.script option.
error: build of '/nix/store/igd5smaiwqpn9jsjiyyazxksp4vm3vc3-testConfiguration.drv' on 'ssh-ng://im-builder.tail6adb8.ts.net' failed: Cannot build '/nix/store/igd5smaiwqpn9jsjiyyazxksp4vm3vc3-testConfiguration.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/wsrir2y6nmpbp2bvg2b5b5k4cdkwh2qb-testConfiguration
       Last 20 log lines:
       > Configuration errors:
       >   - App bang-app is missing test.script
       >   - App collabora-desktop-app is missing test.script
       >   - App kepler-formal-app is missing test.script
       >   - App sudo-rs-app is missing test.script
       >   - Package ironcalc is missing test.script
       >   - Package ironcalc-docs is missing test.script
       >   - Package ironcalc-frontend is missing test.script
       >   - Package ironcalc-nodejs is missing test.script
       >   - Package ironcalc-python is missing test.script
       >   - Package ironcalc-server is missing test.script
       >   - Package ironcalc-tools is missing test.script
       >   - Package ironcalc-wasm is missing test.script
       >   - Package ironcalc-widget is missing test.script
       >   - Package offen-auditorium is missing test.script
       >   - Package offen-script is missing test.script
       >   - Package offen-vault is missing test.script
       >   - Package python-web is missing test.script
       >   - Package qlever-olympics-rdf-data is missing test.script
       >   - Package tslib is missing test.script
       For full logs, run:
         nix log /nix/store/igd5smaiwqpn9jsjiyyazxksp4vm3vc3-testConfiguration.drv
error: Cannot build '/nix/store/igd5smaiwqpn9jsjiyyazxksp4vm3vc3-testConfiguration.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/wsrir2y6nmpbp2bvg2b5b5k4cdkwh2qb-testConfiguration
error: build of '/nix/store/3r8m2limqrqh4jb3p9pm7kvshb3p8lz6-forge-ui.drv', '/nix/store/bvwcx3mxl96hw3pffc67xgpv7wspvzy8-forge-config.json.drv', '/nix/store/igd5smaiwqpn9jsjiyyazxksp4vm3vc3-testConfiguration.drv' failed
```