### PR TITLE
feat: build individual container for each service

### DIFF
--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -49,5 +49,19 @@
       default = null;
       apply = self: if self != null then pkgs.writeShellScript "${name}-pre-start" self else null;
     };
+
+    ports = lib.mkOption {
+      type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
+      default = [ ];
+      description = ''
+        List of ports exposed by the application's services.
+
+        Format: HOST_PORT:SERVICE_PORT
+      '';
+      example = lib.literalExpression ''
+        [ "8000:8000" "5432:5432" ]
+      '';
+    };
+
   };
 }

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -100,15 +100,10 @@
           else
             pkgs.writeText "${app.name}-compose.yaml" (
               lib.generators.toYAML { } {
-                services = lib.mapAttrs (
-                  name: value:
-                  {
-                    image = "localhost/${name}:latest";
-                  }
-                  // lib.optionalAttrs (app.services.ports != [ ]) {
-                    ports = app.services.ports;
-                  }
-                ) app.services.components;
+                services = lib.mapAttrs (name: service: {
+                  image = "localhost/${name}:latest";
+                  ports = app.services.ports ++ service.ports;
+                }) app.services.components;
               }
             );
 

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -45,16 +45,16 @@
         description = "Nimi configuration.";
       };
 
-      eval = lib.mkOption {
+      evals = lib.mkOption {
         internal = true;
         readOnly = true;
         type = with lib.types; lazyAttrsOf (either attrs anything);
         description = "Nimi module evaluation.";
       };
 
-      recipe = lib.mkOption {
+      recipes = lib.mkOption {
         internal = true;
-        type = lib.types.nullOr lib.types.package;
+        type = with lib.types; lazyAttrsOf (nullOr package);
         default = null;
         description = "Script that builds container image recipe.";
       };
@@ -79,14 +79,18 @@
   };
 
   config = {
-    result.modules = {
+    result.modules = lib.mapAttrs (serviceName: service: {
       settings = import ./modules/settings.nix args;
-      services = import ./modules/services.nix args;
-    };
+      services = import ../mkNimiImports.nix { inherit lib service serviceName; };
+    }) app.services.components;
 
-    result.eval = nimi.passthru.evalNimiModule { config = config.result.modules; };
+    result.evals = lib.mapAttrs (
+      name: value: nimi.passthru.evalNimiModule { config = config.result.modules.${name}; }
+    ) app.services.components;
 
-    result.recipe = nimi.mkContainerImage { config = config.result.modules; };
+    result.recipes = lib.mapAttrs (
+      name: value: nimi.mkContainerImage { config = config.result.modules.${name}; }
+    ) app.services.components;
 
     result.build =
       let
@@ -96,30 +100,48 @@
           else
             pkgs.writeText "${app.name}-compose.yaml" (
               lib.generators.toYAML { } {
-                services.${app.name} = {
-                  image = "localhost/${app.name}:latest";
-                }
-                // lib.optionalAttrs (app.services.ports != [ ]) {
-                  ports = app.services.ports;
-                };
+                services = lib.mapAttrs (
+                  name: value:
+                  {
+                    image = "localhost/${name}:latest";
+                  }
+                  // lib.optionalAttrs (app.services.ports != [ ]) {
+                    ports = app.services.ports;
+                  }
+                ) app.services.components;
               }
             );
-        build-oci-image = pkgs.writeShellScriptBin "build-oci-image" ''
-          ${config.result.recipe.copyTo}/bin/copy-to \
-            oci-archive:${app.name}.tar:${app.name}:latest
-          echo "Container image created in $(pwd)/${app.name}.tar ."
-        '';
+
+        build-oci-images = pkgs.writeShellScriptBin "build-oci-images" (
+          lib.concatMapAttrsStringSep "\n" (name: value: ''
+            ${value.copyTo}/bin/copy-to oci-archive:${name}.tar:${name}:latest
+            echo "Created container image in $(pwd)/${name}.tar"
+          '') config.result.recipes
+        );
+
         compose-file = pkgs.runCommand "compose-file" { } ''
-          mkdir -p $out/${app.name}
-          cp ${effectiveComposeFile} $out/${app.name}/compose.yaml
+          install -D ${effectiveComposeFile} $out/${app.name}/compose.yaml
         '';
+
         run-podman = pkgs.writeShellScriptBin "run-podman" ''
-          ${lib.getExe build-oci-image}
-          podman load <${app.name}.tar
+          TMPDIR=$(mktemp -d)
+
+          trap 'rm -rf "$TMPDIR"' EXIT
+
+          pushd $TMPDIR
+            ${lib.getExe build-oci-images}
+
+            for image in *.tar; do
+              podman load < "$image"
+              rm "$image"
+            done
+          popd
+
           ${lib.getExe pkgs.podman-compose} \
             -f ${compose-file}/${app.name}/compose.yaml \
             up --force-recreate "$@"
         '';
+
         run-container = pkgs.writeShellScriptBin "run-container" ''
           ${lib.getExe run-podman} "$@"
         '';
@@ -127,7 +149,7 @@
       pkgs.symlinkJoin {
         name = "run-container";
         paths = [
-          build-oci-image
+          build-oci-images
           compose-file
           run-podman
           run-container

--- a/forge/modules/apps/services/runtimes/mkNimiImports.nix
+++ b/forge/modules/apps/services/runtimes/mkNimiImports.nix
@@ -1,19 +1,22 @@
 {
   lib,
   service,
+  serviceName,
 }:
 {
-  imports = [
-    service.result
-    {
-      options.nimi = lib.mkOption {
-        type = with lib.types; deferredModule;
-        default = { };
-        description = ''
-          Let the modular service know that it's evaluated for nimi,
-          by testing `options ? nimi`.
-        '';
-      };
-    }
-  ];
+  ${serviceName} = {
+    imports = [
+      service.result
+      {
+        options.nimi = lib.mkOption {
+          type = with lib.types; deferredModule;
+          default = { };
+          description = ''
+            Let the modular service know that it's evaluated for nimi,
+            by testing `options ? nimi`.
+          '';
+        };
+      }
+    ];
+  };
 }

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -13,9 +13,7 @@
 
   nimi = lib.mapAttrs (serviceName: service: {
     settings.binName = "${serviceName}-service";
-    services.${serviceName} = import ../../mkNimiImports.nix {
-      inherit lib service;
-    };
+    services = import ../../mkNimiImports.nix { inherit lib service serviceName; };
   }) app.services.components;
 
   systemd.services = lib.mapAttrs (_: service: {

--- a/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
@@ -25,16 +25,21 @@
     # Pass entropy from host to VM to prevent slow service startup due to entropy starvation.
     qemu.options = [ "-device virtio-rng-pci" ];
 
-    forwardPorts = map (
-      portRange:
+    forwardPorts =
       let
-        portSplit = lib.splitString ":" portRange;
+        servicePorts = lib.concatMap (service: service.ports) (lib.attrValues app.services.components);
+        appPorts = app.services.ports ++ servicePorts;
       in
-      {
-        from = "host";
-        host.port = lib.toInt (lib.elemAt portSplit 0);
-        guest.port = lib.toInt (lib.elemAt portSplit 1);
-      }
-    ) app.services.ports;
+      map (
+        portRange:
+        let
+          portSplit = lib.splitString ":" portRange;
+        in
+        {
+          from = "host";
+          host.port = lib.toInt (lib.elemAt portSplit 0);
+          guest.port = lib.toInt (lib.elemAt portSplit 1);
+        }
+      ) appPorts;
   };
 }

--- a/recipes/apps/goupile-app/compose.yaml
+++ b/recipes/apps/goupile-app/compose.yaml
@@ -1,6 +1,6 @@
 services:
-  goupile-app:
-    image: localhost/goupile-app:latest
+  goupile:
+    image: localhost/goupile:latest
     ports:
       - 8181:8181
     volumes:

--- a/recipes/apps/ironcalc-app/compose.yaml
+++ b/recipes/apps/ironcalc-app/compose.yaml
@@ -1,6 +1,6 @@
 services:
-  ironcalc-app:
-    image: localhost/ironcalc-app:latest
+  ironcalc:
+    image: localhost/ironcalc:latest
     environment:
       - ROCKET_ADDRESS=0.0.0.0
     ports:

--- a/recipes/apps/python-web-app/compose.yaml
+++ b/recipes/apps/python-web-app/compose.yaml
@@ -1,6 +1,6 @@
 services:
-  python-web-app:
-    image: localhost/python-web-app:latest
+  python-web:
+    image: localhost/python-web:latest
     environment:
       - DB_HOST=database
       - DB_NAME=postgres

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -47,6 +47,9 @@
       preStart = ''
         qlever-ui-manage makemigrations --merge && qlever-ui-manage migrate
       '';
+      ports = [
+        "8080:8080"
+      ];
     };
 
     components.qlever-server = {
@@ -70,6 +73,9 @@
         "/var/lib/qlever/Qleverfile"
         "start"
         "--run-in-foreground"
+      ];
+      ports = [
+        "7019:7019"
       ];
     };
 
@@ -165,11 +171,6 @@
         };
       };
     };
-
-    ports = [
-      "8080:8080"
-      "7019:7019"
-    ];
   };
 
   test = {


### PR DESCRIPTION
## Changes

- Generate 1 container for each service component
- Add per-service ports, because currently we can only map one global `ports` for each container, but that can result in a `port already taken` situation

Closes https://github.com/ngi-nix/forge/issues/431