### PR TITLE
Rename extraConfig(s) options to be more intuitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,10 +490,11 @@ Apps can optionally specify a custom icon in SVG format. When creating app recip
 Services define processes that run within the application. They can be used across all output types (container, VM, etc.):
 
 ```nix
-services = {
+services.components = {
   my-service = {
     command = pkgs.mypkgs.my-package;  # Package or string
     argv = [ "--port" "8080" ];        # Additional arguments
+    ports = [ "8080:8080" ];           # HOST_PORT:SERVICE_PORT
     environment = {                     # Environment variables
       DATABASE_URL = "postgresql://localhost/db";
       LOG_LEVEL = "info";
@@ -503,6 +504,7 @@ services = {
   another-service = {
     command = "python";
     argv = [ "-m" "http.server" "8000" ];
+    ports = [ "8000:8000" ];
   };
 };
 ```
@@ -537,29 +539,31 @@ programs = {
 Builds a single OCI-compliant container image:
 
 ```nix
-container = {
+runtimes.container = {
   enable = true;  # Set to true to enable container image output
-  tag = "latest";  # Optional, defaults to "latest"
 
-  packages = [
-    pkgs.mypkgs.my-package  # Packages to include in /bin
-  ];
+  composeFile = ./compose.yaml;  # Optional: custom Docker Compose file
 
-  # OCI image configuration
-  # See: https://specs.opencontainers.org/image-spec/config/#properties
-  extraConfig = {
-    Cmd = [ "my-package" "--serve" ];  # Default command
-    Env = [                             # Environment variables
-      "PORT=8080"
-      "LOG_LEVEL=info"
+  # Per-component container configuration
+  components.<name> = {
+    packages = [
+      pkgs.mypkgs.my-package  # Packages to include in /bin
     ];
-    ExposedPorts = {
-      "8080/tcp" = { };
-    };
-    WorkingDir = "/app";
-  };
 
-  composeFile = ./compose.yaml;  # Optional: Docker Compose file
+    # OCI image configuration
+    # See: https://specs.opencontainers.org/image-spec/config/#properties
+    imageConfig = {
+      Cmd = [ "my-package" "--serve" ];  # Default command
+      Env = [                             # Environment variables
+        "PORT=8080"
+        "LOG_LEVEL=info"
+      ];
+      ExposedPorts = {
+        "8080/tcp" = { };
+      };
+      WorkingDir = "/app";
+    };
+  };
 };
 ```
 
@@ -572,12 +576,12 @@ container = {
 Builds a complete NixOS virtual machine:
 
 ```nix
-nixos = {
+runtimes.nixos = {
   enable = true;  # Set to true to enable VM output
 
   # NixOS system configuration
   # See: https://search.nixos.org/options
-  extraConfig = {
+  nixosConfig = {
     services.postgresql = {
       enable = true;
       enableTCPIP = true;
@@ -645,9 +649,10 @@ Each app output type can be independently enabled or disabled:
   '';
 
   # Define the web service
-  services.python-web = {
+  services.components.python-web = {
     command = pkgs.mypkgs.python-web;
     argv = [ "--host" "0.0.0.0" ];
+    ports = [ "5000:5000" ];
     environment = {
       FLASK_ENV = "production";
     };
@@ -667,21 +672,22 @@ Each app output type can be independently enabled or disabled:
   };
 
   # Container image
-  container = {
+  services.runtimes.container = {
     enable = true;
-    tag = "latest";
-    packages = [ pkgs.mypkgs.python-web ];
-    extraConfig = {
-      Env = [ "PORT=5000" ];
-      ExposedPorts = { "5000/tcp" = { }; };
-    };
     composeFile = ./compose.yaml;
+    components.python-web = {
+      packages = [ pkgs.mypkgs.python-web ];
+      imageConfig = {
+        Env = [ "PORT=5000" ];
+        ExposedPorts = { "5000/tcp" = { }; };
+      };
+    };
   };
 
   # VM with PostgreSQL
-  nixos = {
+  services.runtimes.nixos = {
     enable = true;
-    extraConfig = {
+    nixosConfig = {
       services.postgresql = {
         enable = true;
         enableTCPIP = true;

--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -92,7 +92,7 @@ def generate_app_recipe(name, index, is_test_app=False):
       }};
       nixos = {{
         enable = {nixos_vm_en};
-        extraConfig = {{ }};
+        nixosConfig = {{ }};
       }};
     }};
   }};

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -108,7 +108,7 @@ in
                       m.setup
                       m.nimi
                       m.packages
-                      m.extraConfig
+                      m.nixosConfig
                     ];
                 };
                 nixos = {

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -33,12 +33,18 @@
               description = "List of packages to add to the container's `/bin` directory.";
             };
 
-            # NOTE: config is reserved by the module system
-            extraConfig = lib.mkOption {
+            imageConfig = lib.mkOption {
               type = with lib.types; lazyAttrsOf anything;
               default = { };
               description = ''
-                OCI image configuration as specified in <https://specs.opencontainers.org/image-spec/config/#properties>.
+                OCI image configuration.
+
+                Available options: <https://specs.opencontainers.org/image-spec/config/#properties>
+              '';
+              example = lib.literalExpression ''
+                {
+                  WorkingDir = "/var/lib/myapp";
+                }
               '';
             };
           };

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -5,7 +5,7 @@
   componentConfig ? {
     setup = "";
     packages = [ ];
-    extraConfig = { };
+    imageConfig = { };
   },
   pkgs,
   lib,
@@ -21,13 +21,13 @@
       pathsToLink = [ "/bin" ];
     };
 
-    imageConfig = componentConfig.extraConfig // {
+    imageConfig = componentConfig.imageConfig // {
       Env =
         let
           # { K = "V"; } -> [ "K=V" ]
           envAttrsToList = attrs: lib.mapAttrsToList (n: v: "${n}=${v}") attrs;
 
-          # extraConfig.Env follows OCI spec: list of "K=V" strings
+          # imageConfig.Env follows OCI spec: list of "K=V" strings
           containerEnv = lib.listToAttrs (
             map (
               envPair:
@@ -38,7 +38,7 @@
                 name = lib.head parts;
                 value = lib.concatStringsSep "=" (lib.tail parts);
               }
-            ) (componentConfig.extraConfig.Env or [ ])
+            ) (componentConfig.imageConfig.Env or [ ])
           );
 
           # NOTE: we merge Attrs to remove duplicate keys

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -24,18 +24,18 @@
         Packages to add to the NixOS system.
 
         This is a convenience option equivalent to setting
-        `extraConfig.environment.systemPackages`.
+        `nixosConfig.environment.systemPackages`.
       '';
       example = lib.literalExpression "[ pkgs.btop ]";
     };
 
-    extraConfig = lib.mkOption {
+    nixosConfig = lib.mkOption {
       type = with lib.types; deferredModule;
       default = { };
       description = ''
-        NixOS system configuration
+        NixOS system configuration.
 
-        See: https://search.nixos.org/options
+        Available options: <https://search.nixos.org/options>
       '';
       example = lib.literalExpression ''
         {
@@ -106,7 +106,7 @@
       setup = import ./modules/setup.nix args;
       nimi = import ./modules/nimi.nix args;
       virt = import ./modules/virt.nix args;
-      extraConfig = config.extraConfig;
+      nixosConfig = config.nixosConfig;
       packages = {
         environment.systemPackages = config.packages;
       };

--- a/forge/modules/apps/test/nixos.nix
+++ b/forge/modules/apps/test/nixos.nix
@@ -37,7 +37,7 @@
           imports = with app.services.runtimes.nixos.result.modules; [
             nimi
             setup
-            extraConfig
+            nixosConfig
           ];
           # Pass entropy from host to VM to prevent slow service startup due to entropy starvation.
           virtualisation.qemu.options = [ "-device virtio-rng-pci" ];

--- a/recipes/apps/goupile-app/recipe.nix
+++ b/recipes/apps/goupile-app/recipe.nix
@@ -48,7 +48,7 @@
 
       nixos = {
         enable = true;
-        extraConfig = {
+        nixosConfig = {
           systemd.tmpfiles.rules = [
             "d /var/lib/goupile 0700 root root -"
           ];

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -137,7 +137,7 @@
           fi
         '';
         packages = [ pkgs.mypkgs.mox ];
-        extraConfig = {
+        nixosConfig = {
           networking.enableIPv6 = false;
           # Use a public DNSSEC-validating resolver
           networking.nameservers = [ "8.8.8.8" ];

--- a/recipes/apps/python-web-app/recipe.nix
+++ b/recipes/apps/python-web-app/recipe.nix
@@ -70,7 +70,7 @@
 
       nixos = {
         enable = true;
-        extraConfig = {
+        nixosConfig = {
           # database service
           services.postgresql.enable = true;
           services.postgresql.enableTCPIP = true;

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -91,7 +91,7 @@
             rsync
             subversion
           ];
-          extraConfig = {
+          imageConfig = {
             WorkingDir = "/var/lib/qlever";
           };
           setup =
@@ -115,7 +115,7 @@
             mypkgs.qlever
             mypkgs.qlever-control
           ];
-          extraConfig = {
+          imageConfig = {
             WorkingDir = "/var/lib/qlever";
           };
         };

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -124,7 +124,7 @@
       nixos = {
         enable = true;
         setup = config.services.runtimes.container.components.qlever-ui.setup;
-        extraConfig = {
+        nixosConfig = {
           systemd.services."qlever-app-setup" = {
             path = with pkgs; [
               rsync

--- a/templates/consumer/recipes/apps/python-web-app/recipe.nix
+++ b/templates/consumer/recipes/apps/python-web-app/recipe.nix
@@ -9,7 +9,7 @@
   name = "python-web-app";
   description = lib.mkForce "Example web API with database backend (extended).";
 
-  services.runtimes.nixos.extraConfig = {
+  services.runtimes.nixos.nixosConfig = {
     environment.systemPackages = [
       pkgs.postgresql
     ];


### PR DESCRIPTION
- **refactor: rename apps.*.services.runtimes.container.components.<name>.extraConfig to imageConfig**
- **recipes: use imageConfig**
- **refactor: rename apps.*.services.runtimes.nixos.extraConfig to nixosConfig**
- **recipes: use nixosConfig**
