### PR TITLE
Very good options documentation

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -13,38 +13,54 @@
   options = {
     # General configuration
     name = lib.mkOption {
-      type = lib.types.str;
-      default = "my-application";
+      type = lib.types.strMatching "^[a-zA-Z0-9-]+$";
+      default = "forge-app";
+      description = "Application name. Only letters, numbers and hyphens are allowed.";
+      example = "my-hello-app";
     };
     displayName = lib.mkOption {
       type = lib.types.str;
       default = config.name;
       description = "Human readable application name. Defaults to `name` if not set.";
+      example = "My Hello Application";
     };
     description = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.strMatching "^$|^.{1,119}\\.$";
       default = "";
+      description = "Short application description. Maximum 120 characters.";
+      example = "A fast and secure web server for self-hosted applications.";
     };
     usage = lib.mkOption {
       type = lib.types.str;
       default = "";
       description = "Application usage description in markdown format.";
+      example = ''
+        Launch the application in your browser at `http://localhost:8080`.
+
+        ## Default credentials
+
+        - Username: `admin`
+        - Password: `admin`
+      '';
     };
     icon = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
-      description = "Path to application icon (SVG file). If not specified, a default icon will be used.";
+      description = ''
+        Path to application icon in SVG format. If not specified, a default icon
+        will be used.
+      '';
       example = lib.literalExpression "./icon.svg";
     };
     links = lib.mkOption {
       type = lib.types.submodule ./links.nix;
       default = { };
-      description = "Links related to this project";
+      description = "Links related to this project.";
     };
     ngi = lib.mkOption {
       type = lib.types.submodule ./ngi;
       default = { };
-      description = "NGI-specific options.";
+      description = "NGI specific options.";
     };
 
     # Portable services configuration
@@ -63,7 +79,7 @@
         modules = [ ./services ];
       };
       default = { };
-      description = "Portable services configuration.";
+      description = "Services configuration.";
     };
 
     # Programs configuration

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -13,9 +13,9 @@
   options = {
     # General configuration
     name = lib.mkOption {
-      type = lib.types.strMatching "^[a-zA-Z0-9-]+$";
-      default = "forge-app";
-      description = "Application name. Only letters, numbers and hyphens are allowed.";
+      type = lib.types.strMatching "^[a-zA-Z0-9-]+-app$";
+      default = "noname-app";
+      description = "Application name. Only letters, numbers and hyphens are allowed. The name must end with the \"-app\" suffix.";
       example = "my-hello-app";
     };
     displayName = lib.mkOption {

--- a/forge/modules/apps/ngi/grants.nix
+++ b/forge/modules/apps/ngi/grants.nix
@@ -1,9 +1,11 @@
 /**
-  Funding that software authors receive from NLnet to support various software projects.
-  Each subgrant comes from a fund, which is in turn bound to a grant agreement with the European commission.
+  Funding that software authors receive from NLnet to support various software
+  projects. Each subgrant comes from a fund, which is in turn bound to a grant
+  agreement with the European commission.
 
-  We track: `Commons`, `Core`, `Entrust` and `Review`.
-  While the first three are current fund themes, `Review` encompasses all non-current NGI funds (e.g. Assure, Discovery, PET, ...).
+  We track: `Commons`, `Core`, `Entrust` and `Review`. While the first three
+  are current fund themes, `Review` encompasses all non-current NGI funds (e.g.
+  Assure, Discovery, PET, ...).
 
   See [NLnet - Thematics Funds](https://nlnet.nl/themes/) for more information.
 */
@@ -23,9 +25,10 @@
       (
         name:
         lib.mkOption {
-          description = "subgrants under the ${name} fund";
+          description = "list of subgrants under the ${name} fund.";
           type = lib.types.listOf lib.types.str;
           default = [ ];
+          example = lib.literalExpression ''[ "Hello-rust" ]'';
         }
       );
 }

--- a/forge/modules/apps/ngi/grants.nix
+++ b/forge/modules/apps/ngi/grants.nix
@@ -28,7 +28,7 @@
           description = "list of subgrants under the ${name} fund.";
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          example = lib.literalExpression ''[ "Hello-rust" ]'';
+          example = [ "Hello-rust" ];
         }
       );
 }

--- a/forge/modules/apps/programs/default.nix
+++ b/forge/modules/apps/programs/default.nix
@@ -8,7 +8,7 @@
     packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
-      description = "Packages to include in the shell environment.";
+      description = "Packages to include in the _shell_ runtime.";
       example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
     };
 
@@ -23,16 +23,17 @@
     mainPackage = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
       default = null;
-      description = "Main package for the application";
+      description = "Package launched by the _program_ runtime.";
+      example = lib.literalExpression "pkgs.hello";
     };
 
-    runCommand = lib.mkOption {
+    runProgram = lib.mkOption {
       type = lib.types.str;
       internal = true;
       readOnly = true;
       default = config.mainPackage.meta.mainProgram or "";
       defaultText = lib.literalExpression ''config.mainPackage.meta.mainProgram or ""'';
-      description = "Main command for the application";
+      description = "Program used to launch the `mainPackage`.";
     };
   };
 }

--- a/forge/modules/apps/programs/runtimes/default.nix
+++ b/forge/modules/apps/programs/runtimes/default.nix
@@ -6,12 +6,12 @@
   options = {
     program = {
       enable = lib.mkEnableOption ''
-        Single program runtime
+        Program runtime
       '';
     };
     shell = {
       enable = lib.mkEnableOption ''
-        Programs shell environment
+        Shell runtime
       '';
     };
   };

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -22,19 +22,27 @@
 
     command = lib.mkOption {
       type = lib.types.either lib.types.package lib.types.str;
-      description = "Main command to use for the service.";
+      description = "Main command used to launch a service.";
+      example = lib.literalExpression ''
+        # Package
+        pkgs.hello
+
+        # Explicit binary path
+        "''${pkgs.hello}/bin/hello"
+      '';
     };
 
     argv = lib.mkOption {
       type = lib.types.listOf lib.types.singleLineStr;
       default = [ ];
       description = "List of arguments that will be passed to the main program.";
+      example = lib.literalExpression ''[ "--config" "service.toml" ]'';
     };
 
     environment = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = { };
-      description = "Environment variables.";
+      description = "Environment variables passed to the service.";
       example = lib.literalExpression ''
         {
           DEBUG = "1";
@@ -56,15 +64,21 @@
       type = lib.types.nullOr lib.types.str;
       default = null;
       apply = self: if self != null then pkgs.writeShellScript "${name}-pre-start" self else null;
+      example = lib.literalExpression ''
+        # bash
+        echo "Running DB migration ..."
+        program-manage makemigrations && program-manage migrate
+      '';
     };
 
     ports = lib.mkOption {
       type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
       default = [ ];
       description = ''
-        List of ports exposed by the application's services.
+        List of ports exposed by the service.
 
-        Format: HOST_PORT:SERVICE_PORT
+        Format:
+          _HOST_PORT:SERVICE_PORT_
       '';
       example = lib.literalExpression ''
         [ "8000:8000" "5432:5432" ]

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -36,7 +36,10 @@
       type = lib.types.listOf lib.types.singleLineStr;
       default = [ ];
       description = "List of arguments that will be passed to the main program.";
-      example = lib.literalExpression ''[ "--config" "service.toml" ]'';
+      example = [
+        "--config"
+        "service.toml"
+      ];
     };
 
     environment = lib.mkOption {

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -17,16 +17,6 @@
       );
       default = { };
       description = "Portable service components.";
-      example = lib.literalExpression ''
-        {
-          service1 = {
-            command = pkgs.mypkgs.service1;
-          };
-          service2 = {
-            command = pkgs.mypkgs.service2;
-          };
-        }
-      '';
       # map user-config to a format which can be used by modular services
       apply =
         self:

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -16,7 +16,7 @@
         }
       );
       default = { };
-      description = "Portable service components.";
+      description = "Portable services components.";
       # map user-config to a format which can be used by modular services
       apply =
         self:

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -9,12 +9,16 @@
 }@args:
 {
   options = {
-    enable = lib.mkEnableOption "container image output";
+    enable = lib.mkEnableOption "Container runtime";
 
     composeFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
-      description = "Path to the application container's compose file. When null, a default compose file is generated.";
+      description = ''
+        Path to the custom container compose file.
+        Set to null to automatically generate this file.
+      '';
+      example = lib.literalExpression "./compose.yaml";
     };
 
     components = lib.mkOption {
@@ -24,13 +28,22 @@
             setup = lib.mkOption {
               type = lib.types.str;
               default = "";
-              description = "Script to run once at container startup.";
+              description = ''
+                Script to run once at the container startup.
+                Use this option for one-off system preparation steps.
+              '';
+              example = ''
+                # bash
+                echo "Creating directory structure ..."
+                mkdir --parents /var/lib/service/config /var/lib/service/db
+              '';
             };
 
             packages = lib.mkOption {
               type = lib.types.listOf lib.types.package;
               default = [ ];
-              description = "List of packages to add to the container's `/bin` directory.";
+              description = "List of packages to add to the container.";
+              example = lib.literalExpression "[ pkgs.curl ]";
             };
 
             # NOTE: config is reserved by the module system
@@ -38,14 +51,22 @@
               type = with lib.types; lazyAttrsOf anything;
               default = { };
               description = ''
-                OCI image configuration as specified in <https://specs.opencontainers.org/image-spec/config/#properties>.
+                OCI image configuration.
+
+                See the list of available
+                [OCI image configuration options](https://specs.opencontainers.org/image-spec/config/#properties) .
+              '';
+              example = lib.literalExpression ''
+                {
+                  WorkingDir = "/var/lib/myapp";
+                }
               '';
             };
           };
         }
       );
       default = { };
-      description = "Per-component container configuration.";
+      description = "Per-component container runtime configuration.";
       apply =
         self:
         let

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -26,7 +26,7 @@
         lib.types.submodule {
           options = {
             setup = lib.mkOption {
-              type = lib.types.str;
+              type = lib.types.lines;
               default = "";
               description = ''
                 Script to run once at the container startup.

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -9,19 +9,27 @@
 }@args:
 {
   options = {
-    enable = lib.mkEnableOption "NixOS/VM output";
+    enable = lib.mkEnableOption "NixOS runtime";
 
     setup = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Script to run once at startup.";
+      description = ''
+        Script to run once at system startup.
+        Use this option for one-off system preparation steps.
+      '';
+      example = ''
+        # bash
+        echo "Creating directory structure ..."
+        mkdir --parents /var/lib/service/config /var/lib/service/db
+      '';
     };
 
     packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
       description = ''
-        Packages to add to the NixOS system.
+        List of packages to add to the NixOS system.
 
         This is a convenience option equivalent to setting
         `extraConfig.environment.systemPackages`.
@@ -33,9 +41,10 @@
       type = with lib.types; deferredModule;
       default = { };
       description = ''
-        NixOS system configuration
+        NixOS system configuration.
 
-        See: https://search.nixos.org/options
+        See the list of available
+        [NixOS options](https://search.nixos.org/options) .
       '';
       example = lib.literalExpression ''
         {

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -12,7 +12,7 @@
     enable = lib.mkEnableOption "NixOS runtime";
 
     setup = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.lines;
       default = "";
       description = ''
         Script to run once at system startup.

--- a/forge/modules/apps/test/default.nix
+++ b/forge/modules/apps/test/default.nix
@@ -16,7 +16,7 @@
     packages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
-      description = "Additional packages required for running tests.";
+      description = "List of packages available in the test script.";
       example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
     };
 
@@ -26,16 +26,18 @@
       description = ''
         Enable the Nix sandbox when running tests.
 
-        Set to false to allow internet access during tests, which may be
+        Set to _false_ to allow internet access during tests, which may be
         required when tests need to download additional resources at runtime,
         such as container images pulled by compose files.
 
-        When disabled, tests must be launched with Nix sandbox relaxed.
+        When disabled, tests must be launched with Nix sandbox set to relaxed
+        using following commands:
 
-          - nix build .#<app>.test --option sandbox relaxed --builders ""
-          - nix build .#<app>.test-container --option sandbox relaxed --builders ""
+          - `nix build .#<app>.test --option sandbox relaxed --builders ""`
+          - `nix build .#<app>.test-container --option sandbox relaxed --builders ""`
 
-        Disable sandbox only when necessary.
+        Disabling sandbox can cause problems with test reproducibility.
+        Use only when necessary.
       '';
     };
 
@@ -45,17 +47,14 @@
         echo "Test script"
       '';
       description = ''
-        Bash script to test application services inside a NixOS machine
-        or container.
+        Script to test application services inside a NixOS machine or container.
 
         Launch tests with:
-          - nix build .#<app>.test
-          - nix build .#<app>.test-container
+          - `nix build .#<app>.test`
+          - `nix build .#<app>.test-container`
       '';
-      example = lib.literalExpression ''
-        '''
-        curl -f http://localhost:5000/users
-        '''
+      example = ''
+        curl --fail http://localhost:5000 | grep "Hello"
       '';
     };
 

--- a/forge/modules/builders/go-builder/options.nix
+++ b/forge/modules/builders/go-builder/options.nix
@@ -7,15 +7,21 @@
     enable = lib.mkEnableOption ''
       Go module builder for applications and libraries.
 
-      Uses buildGoModule from nixpkgs under the hood.'';
+      Uses `buildGoModule` from Nixpkgs, which builds Go modules using the
+      standard Go toolchain with module-aware dependency management.
+
+      For more information, see the
+      [Nixpkgs Go documentation](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go)
+    '';
     packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Native build-time dependencies.
+          List of build-time dependencies needed during compilation (native
+          architecture).
 
-          Use this for tools needed during the build, such as pkg-config.
+          Mapped to `nativeBuildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.pkg-config pkgs.installShellFiles ]";
       };
@@ -23,9 +29,10 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Build and runtime dependencies for the target platform.
+          List of runtime dependencies needed by the package (target architecture),
+          such as C libraries for cgo.
 
-          Use this for libraries needed by cgo-enabled packages.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.openssl pkgs.sqlite ]";
       };
@@ -33,9 +40,9 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run Go tests.
+          Mapped to `nativeCheckInputs`.
         '';
         example = lib.literalExpression "[ pkgs.gotestsum ]";
       };
@@ -47,7 +54,10 @@
         Hash of the vendored Go module dependency tree.
 
         Leave empty initially to let Nix print the correct hash on first build.
+
+        Mapped to `vendorHash`.
       '';
+      example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     };
     modRoot = lib.mkOption {
       type = lib.types.str;
@@ -56,6 +66,8 @@
         Relative path to the directory containing go.mod.
 
         Useful for monorepos where the Go module is not at the repository root.
+
+        Mapped to `modRoot`.
       '';
       example = "cmd/my-app";
     };
@@ -65,7 +77,10 @@
       description = ''
         List of Go packages to build.
 
-        Keep the default for a single main package, or provide multiple package paths.
+        Keep the default for a single main package, or provide multiple package
+        paths.
+
+        Mapped to `subPackages`.
       '';
       example = [
         "."
@@ -78,7 +93,9 @@
       description = ''
         Linker flags passed to the Go compiler.
 
-        Commonly used to embed version information.
+        Commonly used to embed version information at build time.
+
+        Mapped to `ldflags`.
       '';
       example = [
         "-s"
@@ -89,7 +106,11 @@
     tags = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      description = "Build tags passed to the Go compiler.";
+      description = ''
+        Build tags passed to the Go compiler.
+
+        Mapped to `tags`.
+      '';
       example = [
         "sqlite"
         "netgo"
@@ -99,10 +120,14 @@
       type = lib.types.bool;
       default = false;
       description = ''
-        Fetch dependencies via the Go module proxy instead of vendoring from source.
+        Fetch dependencies via the Go module proxy instead of vendoring from
+        source.
 
         Enable this only when upstream vendoring is incomplete or unsuitable.
+
+        Mapped to `proxyVendor`.
       '';
+      example = true;
     };
   };
 }

--- a/forge/modules/builders/npm-package-builder/options.nix
+++ b/forge/modules/builders/npm-package-builder/options.nix
@@ -5,28 +5,36 @@
 {
   options.build.npmPackageBuilder = {
     enable = lib.mkEnableOption ''
-      NPM package builder for JavaScript/TypeScript packages.
+      NPM package builder for JavaScript and TypeScript packages.
 
-      Uses buildNpmPackage'';
+      Uses `buildNpmPackage` from Nixpkgs, which builds Node.js packages
+      using `npm ci` with a locked dependency set from `package-lock.json`.
+      Node.js is automatically included as a build-time dependency.
+
+      For more information, see the
+      [Nixpkgs Node.js documentation](https://nixos.org/manual/nixpkgs/unstable/#language-javascript)
+    '';
 
     packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Build-time dependencies (native architecture).
+          List of additional build-time dependencies needed during compilation (native architecture).
 
-          Tools needed during compilation that run on the build machine.
+          Node.js is included automatically.
+
+          Mapped to `nativeBuildInputs`.
         '';
-        example = lib.literalExpression "[ pkgs.nodejs ]";
+        example = lib.literalExpression "[ pkgs.pkg-config ]";
       };
       run = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Runtime dependencies (target architecture).
+          List of runtime dependencies needed by the package (target architecture).
 
-          Libraries needed by the package at runtime.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.vips ]";
       };
@@ -34,10 +42,11 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run tests.
+          Mapped to `nativeCheckInputs`.
         '';
+        example = lib.literalExpression "[ pkgs.chromium ]";
       };
     };
 
@@ -45,9 +54,11 @@
       type = lib.types.str;
       default = "";
       description = ''
-        SHA256 hash of the package-lock.json file or source.
+        Hash of the npm dependencies fetched from `package-lock.json`.
 
-        Leave empty initially - nix will provide the correct hash on first build.
+        Leave empty initially to let Nix print the correct hash on first build.
+
+        Mapped to `npmDepsHash`.
       '';
       example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     };
@@ -56,11 +67,11 @@
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        Flags to pass to `npm ci`.
+        Additional flags passed to `npm ci` during the install phase.
+
+        Mapped to `npmInstallFlags`.
       '';
-      example = [
-        "--ignore-scripts"
-      ];
+      example = lib.literalExpression ''[ "--ignore-scripts" ]'';
     };
   };
 }

--- a/forge/modules/builders/npm-package-builder/options.nix
+++ b/forge/modules/builders/npm-package-builder/options.nix
@@ -71,7 +71,7 @@
 
         Mapped to `npmInstallFlags`.
       '';
-      example = lib.literalExpression ''[ "--ignore-scripts" ]'';
+      example = [ "--ignore-scripts" ];
     };
   };
 }

--- a/forge/modules/builders/pnpm-package-builder/options.nix
+++ b/forge/modules/builders/pnpm-package-builder/options.nix
@@ -5,33 +5,49 @@
 {
   options.build.pnpmPackageBuilder = {
     enable = lib.mkEnableOption ''
-      PNPM package builder for JavaScript/TypeScript packages.
+      PNPM package builder for JavaScript and TypeScript packages.
 
-      Uses fetchPnpmDeps and stdenvNoCC.mkDerivation with pnpmConfigHook'';
+      Uses `fetchPnpmDeps` and `stdenvNoCC.mkDerivation` with `pnpmConfigHook`
+      from Nixpkgs, which builds Node.js packages using pnpm with a locked
+      dependency set from `pnpm-lock.yaml`.
+      Node.js and pnpm are automatically included as build-time dependencies.
+
+      For more information, see the
+      [Nixpkgs Node.js documentation](https://nixos.org/manual/nixpkgs/unstable/#language-javascript)
+    '';
 
     packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Build-time dependencies (native architecture).
+          List of additional build-time dependencies needed during compilation (native architecture).
 
-          Tools needed during compilation that run on the build machine.
+          Node.js and pnpm are included automatically.
+
+          Mapped to `nativeBuildInputs`.
         '';
+        example = lib.literalExpression "[ pkgs.pkg-config ]";
       };
       run = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Runtime dependencies (target architecture).
+          List of runtime dependencies needed by the package (target architecture).
 
-          Libraries needed by the package at runtime.
+          Mapped to `buildInputs`.
         '';
+        example = lib.literalExpression "[ pkgs.vips ]";
       };
       check = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "Test dependencies.";
+        description = ''
+          List of test dependencies needed to run the test suite.
+
+          Mapped to `nativeCheckInputs`.
+        '';
+        example = lib.literalExpression "[ pkgs.chromium ]";
       };
     };
 
@@ -39,9 +55,12 @@
       type = lib.types.int;
       default = 3;
       description = ''
-        Version of the pnpm fetcher to use (passed to fetchPnpmDeps as fetcherVersion).
+        Version of the pnpm fetcher to use.
 
-        Version 3 supports pnpm lockfile v9 (pnpm >= 9). Use version 1 for older lockfiles.
+        Version 3 supports pnpm lockfile v9 (pnpm >= 9).
+        Use version 1 for older lockfiles.
+
+        Mapped to `fetcherVersion`.
       '';
       example = 1;
     };
@@ -50,9 +69,11 @@
       type = lib.types.str;
       default = "";
       description = ''
-        SHA256 hash of the fetched pnpm dependencies.
+        Hash of the fetched pnpm dependencies.
 
-        Leave empty initially - nix will provide the correct hash on first build.
+        Leave empty initially to let Nix print the correct hash on first build.
+
+        Mapped to `hash` in `fetchPnpmDeps`.
       '';
       example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     };
@@ -60,24 +81,35 @@
     buildScript = lib.mkOption {
       type = lib.types.str;
       default = "build";
-      description = "The pnpm script to run for building (passed to pnpm run).";
-      example = "build";
+      description = ''
+        The pnpm script to run for building (`pnpm run <script>`).
+
+        Mapped to `buildScript`.
+      '';
+      example = "build:prod";
     };
 
     installDir = lib.mkOption {
       type = lib.types.str;
       default = "dist";
-      description = "Directory containing build output to install to \$out.";
-      example = "dist";
+      description = ''
+        Directory containing the build output to install into `$out`.
+
+        Mapped to `installDir`.
+      '';
+      example = "build";
     };
 
     sourceRoot = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
       description = ''
-        Path to the subdirectory within the source containing pnpm-lock.yaml.
-        Format: "source/<subdir>" (e.g. "source/frontend").
-        The builder will also set sourceRoot for the derivation to cd into this directory.
+        Path to the subdirectory within the source containing `pnpm-lock.yaml`.
+
+        Use this for monorepos where the pnpm workspace is not at the repository root.
+        Format: `"source/<subdir>"`.
+
+        Mapped to `sourceRoot`.
       '';
       example = "source/frontend";
     };

--- a/forge/modules/builders/python-app-builder/options.nix
+++ b/forge/modules/builders/python-app-builder/options.nix
@@ -7,21 +7,32 @@
     enable = lib.mkEnableOption ''
       Python application builder for executable Python programs.
 
-      Uses buildPythonApplication which prevents the package from being used as a dependency'';
+      Uses `buildPythonApplication` from Nixpkgs, which builds Python packages
+      following PEP-517 (`pyproject.toml`) as standalone applications not
+      importable as a dependency by other Python packages.
+
+      For more information, see the
+      [Nixpkgs Python documentation](https://nixos.org/manual/nixpkgs/unstable/#python)
+    '';
     packages = {
       build-system = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "PEP-517 build system dependencies.";
+        description = ''
+          List of PEP-517 build system dependencies (e.g. setuptools, hatchling).
+
+          Mapped to `build-system`.
+        '';
         example = lib.literalExpression "[ pkgs.python3Packages.setuptools pkgs.python3Packages.wheel ]";
       };
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Native build-time dependencies.
+          List of non-Python native build-time dependencies needed during the
+          build, such as pkg-config or compilers.
 
-          Use this for tools needed during the build, such as pkg-config or compilers.
+          Mapped to `nativeBuildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.pkg-config pkgs.kaitai-struct-compiler ]";
       };
@@ -29,25 +40,31 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Native runtime dependencies.
+          List of non-Python native runtime dependencies needed at runtime, such
+          as C libraries.
 
-          Use this for non-Python libraries or tools needed at runtime.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.openssl pkgs.sqlite ]";
       };
       dependencies = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "Runtime dependencies (PEP-621).";
+        description = ''
+          List of Python runtime dependencies required at runtime (PEP-621).
+
+          Mapped to `dependencies`.
+        '';
         example = lib.literalExpression "[ pkgs.python3Packages.click pkgs.python3Packages.requests ]";
       };
       optional-dependencies = lib.mkOption {
         type = lib.types.attrsOf (lib.types.listOf lib.types.package);
         default = { };
         description = ''
-          PEP-621 optional dependencies (extras).
+          List of optional Python runtime dependencies grouped by extra name
+          (PEP-621 extras).
 
-          These are additional dependencies that can be installed optionally.
+          Mapped to `optional-dependencies`.
         '';
         example = lib.literalExpression ''
           {
@@ -60,10 +77,11 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run the test suite. When non-empty, tests are
-          automatically enabled (doCheck = true).
+          When non-empty, tests are automatically enabled (`doCheck = true`).
+
+          Mapped to `nativeCheckInputs`.
         '';
         example = lib.literalExpression "[ pkgs.python3Packages.pytestCheckHook ]";
       };
@@ -72,9 +90,10 @@
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        List of Python modules to verify can be imported after installation.
+        List of Python modules to import-check after installation as a smoke
+        test.
 
-        This provides a simple smoke test to ensure the package was built correctly.
+        Mapped to `pythonImportsCheck`.
       '';
       example = [
         "myapp"
@@ -87,8 +106,11 @@
       description = ''
         Remove version constraints from specified dependencies.
 
-        Use when the package requires specific versions but works fine with versions in nixpkgs.
-        Set to true to relax all dependencies, or provide a list of dependency names.
+        Use when the package specifies strict version bounds that are still
+        satisfied by the versions available in Nixpkgs. Set to `true` to relax
+        all dependencies, or list specific dependency names.
+
+        Mapped to `pythonRelaxDeps`.
       '';
       example = [
         "click"
@@ -101,7 +123,10 @@
       description = ''
         List of pytest test names to skip.
 
-        Useful for disabling flaky or network-dependent tests.
+        Useful for disabling flaky or network-dependent tests that cannot pass
+        in the Nix sandbox.
+
+        Mapped to `disabledTests`.
       '';
       example = [
         "test_network"

--- a/forge/modules/builders/python-package-builder/options.nix
+++ b/forge/modules/builders/python-package-builder/options.nix
@@ -7,21 +7,32 @@
     enable = lib.mkEnableOption ''
       Python package builder for reusable Python libraries.
 
-      Uses buildPythonPackage which allows the package to be used as a dependency by other packages'';
+      Uses `buildPythonPackage` from Nixpkgs, which builds Python packages
+      following PEP-517 (`pyproject.toml`) and makes the result importable
+      as a dependency by other Python packages.
+
+      For more information, see the
+      [Nixpkgs Python documentation](https://nixos.org/manual/nixpkgs/unstable/#python)
+    '';
     packages = {
       build-system = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "PEP-517 build system dependencies.";
+        description = ''
+          List of PEP-517 build system dependencies (e.g. setuptools, hatchling).
+
+          Mapped to `build-system`.
+        '';
         example = lib.literalExpression "[ pkgs.python3Packages.setuptools pkgs.python3Packages.wheel ]";
       };
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Native build-time dependencies.
+          List of non-Python native build-time dependencies needed during the
+          build, such as pkg-config or compilers.
 
-          Use this for tools needed during the build, such as pkg-config or compilers.
+          Mapped to `nativeBuildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.pkg-config pkgs.cmake ]";
       };
@@ -29,25 +40,31 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Native runtime dependencies.
+          List of non-Python native runtime dependencies needed at runtime, such
+          as C libraries.
 
-          Use this for non-Python libraries or tools needed at runtime.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.openssl pkgs.sqlite ]";
       };
       dependencies = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "Runtime dependencies (PEP-621).";
+        description = ''
+          List of Python runtime dependencies required at runtime (PEP-621).
+
+          Mapped to `dependencies`.
+        '';
         example = lib.literalExpression "[ pkgs.python3Packages.numpy pkgs.python3Packages.attrs ]";
       };
       optional-dependencies = lib.mkOption {
         type = lib.types.attrsOf (lib.types.listOf lib.types.package);
         default = { };
         description = ''
-          PEP-621 optional dependencies (extras).
+          List of optional Python runtime dependencies grouped by extra name
+          (PEP-621 extras).
 
-          These are additional dependencies that can be installed optionally.
+          Mapped to `optional-dependencies`.
         '';
         example = lib.literalExpression ''
           {
@@ -60,10 +77,11 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run the test suite. When non-empty, tests are
-          automatically enabled (doCheck = true).
+          When non-empty, tests are automatically enabled (`doCheck = true`).
+
+          Mapped to `nativeCheckInputs`.
         '';
         example = lib.literalExpression "[ pkgs.python3Packages.pytestCheckHook ]";
       };
@@ -72,9 +90,10 @@
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        List of Python modules to verify can be imported after installation.
+        List of Python modules to import-check after installation as a smoke
+        test.
 
-        This provides a simple smoke test to ensure the package was built correctly.
+        Mapped to `pythonImportsCheck`.
       '';
       example = [
         "requests"
@@ -87,8 +106,11 @@
       description = ''
         Remove version constraints from specified dependencies.
 
-        Use when the package requires specific versions but works fine with versions in nixpkgs.
-        Set to true to relax all dependencies, or provide a list of dependency names.
+        Use when the package specifies strict version bounds that are still
+        satisfied by the versions available in Nixpkgs. Set to `true` to relax
+        all dependencies, or list specific dependency names.
+
+        Mapped to `pythonRelaxDeps`.
       '';
       example = [
         "click"
@@ -101,7 +123,10 @@
       description = ''
         List of pytest test names to skip.
 
-        Useful for disabling flaky or network-dependent tests.
+        Useful for disabling flaky or network-dependent tests that cannot pass
+        in the Nix sandbox.
+
+        Mapped to `disabledTests`.
       '';
       example = [
         "test_network"

--- a/forge/modules/builders/rust-package-builder/options.nix
+++ b/forge/modules/builders/rust-package-builder/options.nix
@@ -8,18 +8,23 @@
 {
   options.build.rustPackageBuilder = {
     enable = lib.mkEnableOption ''
-      Rust package builder for reusable Rust crates.
+      Rust package builder for applications and libraries.
 
-      Uses rustPlatform.buildRustPackage'';
+      Uses `rustPlatform.buildRustPackage` from Nixpkgs, which builds Rust
+      packages using Cargo with a vendored dependency set locked by `Cargo.lock`.
+
+      For more information, see the
+      [Nixpkgs Rust documentation](https://nixos.org/manual/nixpkgs/unstable/#rust)
+    '';
 
     packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Build-time dependencies (native architecture).
+          List of build-time dependencies needed during compilation (native architecture).
 
-          Tools needed during compilation that run on the build machine.
+          Mapped to `nativeBuildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.pkg-config pkgs.rustPlatform.bindgenHook ]";
       };
@@ -27,9 +32,9 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Runtime dependencies (target architecture).
+          List of runtime dependencies needed by the package (target architecture).
 
-          Libraries needed by the package at runtime.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.openssl pkgs.sqlite pkgs.libopus ]";
       };
@@ -37,9 +42,9 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run Rust tests.
+          Mapped to `nativeCheckInputs`.
         '';
         example = lib.literalExpression "[ pkgs.cargo-nextest ]";
       };
@@ -49,10 +54,11 @@
       type = lib.types.str;
       default = "";
       description = ''
-        SHA256 hash of the Cargo.lock file or source.
+        Hash of the Cargo dependencies vendored from `Cargo.lock`.
 
-        For git sources without Cargo.lock, this is the source hash.
-        Leave empty initially - nix will provide the correct hash on first build.
+        Leave empty initially to let Nix print the correct hash on first build.
+
+        Mapped to `cargoHash`.
       '';
       example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     };
@@ -61,12 +67,11 @@
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        Additional flags to pass to cargo build.
+        Additional flags passed to `cargo build`.
+
+        Mapped to `cargoBuildFlags`.
       '';
-      example = [
-        "--release"
-        "--features enable-feature"
-      ];
+      example = lib.literalExpression ''[ "--features" "enable-feature" ]'';
     };
   };
 }

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -131,8 +131,8 @@ in
               inputsFrom = [
                 finalPkg
               ];
-              packages = pkg.development.packages;
-              shellHook = pkg.development.shellHook;
+              packages = pkg.develop.packages;
+              shellHook = pkg.develop.shellHook;
             };
           };
 

--- a/forge/modules/builders/standard-builder/options.nix
+++ b/forge/modules/builders/standard-builder/options.nix
@@ -8,15 +8,21 @@
     enable = lib.mkEnableOption ''
       Standard builder for autotools, CMake, or Makefile-based projects.
 
-      Automatically handles configure, build, and install phases'';
+      Uses `stdenv.mkDerivation` from Nixpkgs, which supports the standard
+      GNU build system (`./configure && make && make install`).
+
+      For more information, see the
+      [Nixpkgs stdenv documentation](https://nixos.org/manual/nixpkgs/unstable/#chap-stdenv)
+    '';
     packages = {
       build = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Build-time dependencies (native architecture).
+          List of build-time dependencies needed during compilation (native
+          architecture).
 
-          Tools needed during compilation that run on the build machine.
+          Mapped to `nativeBuildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.cmake pkgs.pkg-config pkgs.ninja ]";
       };
@@ -24,9 +30,10 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Runtime dependencies (target architecture).
+          List of runtime dependencies needed by the package (target
+          architecture).
 
-          Libraries needed by the package at runtime.
+          Mapped to `buildInputs`.
         '';
         example = lib.literalExpression "[ pkgs.openssl pkgs.sqlite pkgs.zlib ]";
       };
@@ -34,9 +41,9 @@
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Test dependencies.
+          List of test dependencies needed to run the test suite.
 
-          Packages needed to run tests.
+          Mapped to `nativeCheckInputs`.
         '';
         example = lib.literalExpression "[ pkgs.cunit ]";
       };
@@ -48,7 +55,12 @@
       defaultText = lib.literalExpression "pkgs.stdenv";
       example = lib.literalExpression "pkgs.stdenvNoCC";
       description = ''
-        The stdenv to use for the build.
+        The stdenv used for the build.
+
+        Override to use a different compiler toolchain or to strip down the
+        build environment. For example, use `pkgs.stdenvNoCC` for packages
+        that do not require a C compiler, or `pkgs.clangStdenv` to build
+        with Clang instead of GCC.
       '';
     };
   };

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -7,15 +7,15 @@
     # General configuration
     name = lib.mkOption {
       type = lib.types.str;
-      default = "my-package";
+      default = "forge-package";
       description = "Package name.";
       example = "hello";
     };
     description = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.strMatching "^$|^.{1,119}\\.$";
       default = "";
-      description = "Package description.";
-      example = "A program that prints greeting messages";
+      description = "Short package description. Maximum 120 characters.";
+      example = "A program that prints greeting messages.";
     };
     version = lib.mkOption {
       type = lib.types.str;
@@ -24,10 +24,10 @@
       example = "2.12.1";
     };
     homePage = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.strMatching "[a-zA-Z][a-zA-Z0-9+\-.]*://[^ \t\n]+";
       default = "";
       description = "Package home page URL.";
-      example = "https://www.gnu.org/software/hello/hello-2.12.1.tar.gz";
+      example = "https://www.gnu.org/software/hello/";
     };
     mainProgram = lib.mkOption {
       type = lib.types.str;
@@ -45,7 +45,13 @@
         ];
       default = [ ];
       description = "License, or licenses, for the package.";
-      example = lib.literalExpression "lib.licenses.gpl3Only";
+      example = ''
+        # Single license
+        lib.licenses.gpl3Only
+
+        # Multiple licenses
+        [ lib.licenses.mit lib.licenses.asl20 ]
+      '';
     };
 
     # Source configuration
@@ -56,12 +62,28 @@
         description = ''
           Git repository URL with revision.
 
-          Formats:
-            - platform:owner/repo/revision
-            - git:url?tag=version
-            - git:url?rev=hash
+          Supported forges:
+            - `github:owner/repo/revision`
+            - `gitlab:owner/repo/revision`
+            - `codeberg:owner/repo/revision`
+            - `forgejo:domain/owner/repo/revision`
+            - `gitea:domain/owner/repo/revision`
+            - `git:https://url?rev=hash`
+            - `git:https://url?tag=version`
         '';
-        example = "github:my-user/my-repo/v1.0.0";
+        example = lib.literalExpression ''
+          # GitHub
+          "github:my-user/my-repo/v1.0.0"
+
+          # Codeberg
+          "codeberg:my-user/my-repo/v1.0.0"
+
+          # Self-hosted Forgejo instance
+          "forgejo:git.example.com/my-user/my-repo/v1.0.0"
+
+          # Arbitrary git URL
+          "git:https://git.example.com/my-repo?tag=v1.0.0"
+        '';
       };
       url = lib.mkOption {
         type = lib.types.nullOr (lib.types.strMatching "^.*://.*");
@@ -89,7 +111,7 @@
         type = lib.types.bool;
         default = false;
         description = ''
-          Fetch git submodules along with the repository source.
+          Fetch Git submodules along with the repository source.
 
           Only applicable when using `source.git`.
         '';
@@ -99,7 +121,7 @@
         type = lib.types.listOf lib.types.path;
         default = [ ];
         description = ''
-          List of patch files to apply to the source code.
+          List of patch files to be applied to the source code.
 
           Patches are applied in the order specified using the patch command.
         '';
@@ -118,14 +140,29 @@
         type = lib.types.attrsOf lib.types.anything;
         default = { };
         description = ''
-          Expert option.
+          Extra attributes merged into the derivation produced by the selected builder.
 
-          Set extra Nix derivation attributes.
+          Use this to pass builder-specific phase hooks (`preConfigure`,
+          `postInstall`, …), environment variables, or any other
+          `stdenv.mkDerivation` attribute not exposed as a dedicated option.
+          Attributes set here take precedence over the builder defaults.
+
+          Expert option. For more information see the
+          [Nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/).
         '';
         example = lib.literalExpression ''
           {
-            preConfigure = "export HOME=$(mktemp -d)"
-            postInstall = "rm $out/somefile.txt"
+            # Set HOME for tools that require a writable home directory
+            preConfigure = "export HOME=$(mktemp -d)";
+
+            # Remove unwanted files from the output
+            postInstall = "rm $out/share/doc/my-package/INSTALL";
+
+            # Pass extra flags to configure
+            configureFlags = [ "--disable-static" "--enable-shared" ];
+
+            # Set an environment variable for the build
+            MY_VARIABLE = "value";
           }
         '';
       };
@@ -136,6 +173,7 @@
           Enable interactive package build environment for debugging.
 
           Launch environment:
+
           ```
           mkdir dev && cd dev
           nix develop .#<package>
@@ -151,7 +189,7 @@
       packages = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
-        description = "Additional packages required for running tests.";
+        description = "List of packages available in the test script.";
         example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
       };
       script = lib.mkOption {
@@ -160,26 +198,25 @@
           echo "Test script"
         '';
         description = ''
-          Bash script to run package tests.
-
+          Script to test the package.
           The package being tested is available in PATH.
-          Run with: nix build .#<package>.test
+
+          Launch test with:
+            - `nix build .#<package>.test`
         '';
-        example = lib.literalExpression ''
-          '''
+        example = ''
           hello | grep "Hello, world"
-          '''
         '';
       };
     };
 
     # Development configuration
-    development = {
+    develop = {
       packages = lib.mkOption {
         type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
-          Additional packages to include in the development environment.
+          List of packages available in the development environment.
 
           All build inputs are automatically included.
         '';
@@ -195,15 +232,14 @@
           echo "or from the upstream repository and you are all set to start hacking."
         '';
         description = ''
-          Bash script to run when entering the development environment.
+          Script which is launched when entering the development environment.
 
-          Enter with: nix develop .#<package>
+          Enter with:
+            - `nix develop .#<package>`
         '';
-        example = lib.literalExpression ''
-          '''
+        example = ''
           echo "Welcome to my-package development environment!"
           echo "Run 'make' to build the project"
-          '''
         '';
       };
     };

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -6,9 +6,9 @@
   options = {
     # General configuration
     name = lib.mkOption {
-      type = lib.types.str;
-      default = "forge-package";
-      description = "Package name.";
+      type = lib.types.strMatching "^[a-zA-Z0-9-]+$";
+      default = "noname";
+      description = "Package name. Only letters, numbers and hyphens are allowed.";
       example = "hello";
     };
     description = lib.mkOption {

--- a/recipes/apps/goupile-app/recipe.nix
+++ b/recipes/apps/goupile-app/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "goupile-app";
   displayName = "Goupile";
-  description = "Free design tool for secure forms including Clinical Report Forms (eCRF)";
+  description = "Free design tool for secure forms including Clinical Report Forms (eCRF).";
   usage = ''
     Goupile is a tool for creating secure forms, especially Clinical Report Forms (eCRF).
 

--- a/recipes/packages/aerogramme/recipe.nix
+++ b/recipes/packages/aerogramme/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "aerogramme";
   version = "0.3.0";
-  description = "Encrypted e-mail storage over Garage";
+  description = "Encrypted e-mail storage over Garage.";
   homePage = "https://aerogramme.deuxfleurs.fr/";
   mainProgram = "aerogramme";
   license = lib.licenses.eupl12;

--- a/recipes/packages/arwen/recipe.nix
+++ b/recipes/packages/arwen/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "arwen";
   version = "0.0.5-unstable-2026-04-07";
-  description = "Cross-platform patching of shared libraries in Rust";
+  description = "Cross-platform patching of shared libraries in Rust.";
   homePage = "https://github.com/nichmor/arwen";
   mainProgram = "arwen";
   license = lib.licenses.mit;

--- a/recipes/packages/ironcalc-docs/recipe.nix
+++ b/recipes/packages/ironcalc-docs/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-docs";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Ironcalc documentation site";
+  description = "Ironcalc documentation site.";
   homePage = "https://docs.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc-frontend/recipe.nix
+++ b/recipes/packages/ironcalc-frontend/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-frontend";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Ironcalc frontend package";
+  description = "Ironcalc frontend package.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc-nodejs/recipe.nix
+++ b/recipes/packages/ironcalc-nodejs/recipe.nix
@@ -7,7 +7,7 @@
 
 {
   name = "ironcalc-nodejs";
-  description = "Node.js bindings for IronCalc";
+  description = "Node.js bindings for IronCalc.";
   homePage = "https://www.ironcalc.com";
   version = "0.7.1-unstable-2026-04-29";
   license = with lib.licenses; [

--- a/recipes/packages/ironcalc-python/recipe.nix
+++ b/recipes/packages/ironcalc-python/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-python";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Python bindings for IronCalc";
+  description = "Python bindings for IronCalc.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     asl20

--- a/recipes/packages/ironcalc-server/recipe.nix
+++ b/recipes/packages/ironcalc-server/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-server";
   version = "0.7.1-unstable-2026-04-29";
-  description = "IronCalc server package";
+  description = "IronCalc server package.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc-tools/recipe.nix
+++ b/recipes/packages/ironcalc-tools/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-tools";
   version = "0.7.1-unstable-2026-04-29";
-  description = "IronCalc helper tools";
+  description = "IronCalc helper tools.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc-wasm/recipe.nix
+++ b/recipes/packages/ironcalc-wasm/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-wasm";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Ironcalc wasm bindings";
+  description = "Ironcalc wasm bindings.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc-widget/recipe.nix
+++ b/recipes/packages/ironcalc-widget/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc-widget";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Ironcalc frontend widget package";
+  description = "Ironcalc frontend widget package.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/ironcalc/recipe.nix
+++ b/recipes/packages/ironcalc/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "ironcalc";
   version = "0.7.1-unstable-2026-04-29";
-  description = "Open source selfhosted spreadsheet engine";
+  description = "Open source selfhosted spreadsheet engine.";
   homePage = "https://www.ironcalc.com";
   license = with lib.licenses; [
     mit

--- a/recipes/packages/mox/recipe.nix
+++ b/recipes/packages/mox/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "mox";
   version = "0.0.15";
-  description = "Modern full-featured open source secure mail server for low-maintenance self-hosted email";
+  description = "Modern full-featured open source secure mail server for low-maintenance self-hosted email.";
   homePage = "https://github.com/mjl-/mox";
   mainProgram = "mox";
   license = lib.licenses.mit;

--- a/recipes/packages/py-arwen/recipe.nix
+++ b/recipes/packages/py-arwen/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "py-arwen";
   version = "0.0.5-unstable-2026-04-07";
-  description = "Python library for cross-platform patching of shared libraries";
+  description = "Python library for cross-platform patching of shared libraries.";
   homePage = "https://github.com/nichmor/arwen";
   license = lib.licenses.mit;
 

--- a/recipes/packages/qlever-control/recipe.nix
+++ b/recipes/packages/qlever-control/recipe.nix
@@ -9,7 +9,7 @@
 {
   name = "qlever-control";
   version = "0.5.46";
-  description = "Command-line tool for controlling the QLever graph database";
+  description = "Command-line tool for controlling the QLever graph database.";
   license = lib.licenses.asl20;
 
   homePage = "https://github.com/qlever-dev/qlever-control";

--- a/recipes/packages/qlever-ui-frontend/recipe.nix
+++ b/recipes/packages/qlever-ui-frontend/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "qlever-ui-frontend";
   version = "0-unstable-2026-04-16";
-  description = "Frontend for QLever UI";
+  description = "Frontend for QLever UI.";
   homePage = "https://github.com/qlever-dev/qlever-ui";
   license = lib.licenses.asl20;
 

--- a/recipes/packages/qlever-ui/recipe.nix
+++ b/recipes/packages/qlever-ui/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "qlever-ui";
   version = "0-unstable-2026-04-16";
-  description = "User interface for QLever";
+  description = "User interface for QLever.";
   homePage = "https://github.com/qlever-dev/qlever-ui";
   mainProgram = "qlever-ui";
   license = lib.licenses.asl20;

--- a/recipes/packages/qlever/recipe.nix
+++ b/recipes/packages/qlever/recipe.nix
@@ -75,7 +75,7 @@ in
 {
   name = "qlever";
   version = "0.5.46";
-  description = "Graph database implementing the RDF and SPARQL standards";
+  description = "Graph database implementing the RDF and SPARQL standards.";
   license = lib.licenses.asl20;
 
   homePage = "https://github.com/ad-freiburg/qlever";

--- a/recipes/packages/requests-sse/recipe.nix
+++ b/recipes/packages/requests-sse/recipe.nix
@@ -9,7 +9,7 @@
 {
   name = "requests-sse";
   version = "0.5.3";
-  description = "Server-sent events python client library based on requests";
+  description = "Server-sent events python client library based on requests.";
   license = lib.licenses.asl20;
 
   homePage = "https://github.com/overcat/requests-sse";

--- a/recipes/packages/tau-radio/recipe.nix
+++ b/recipes/packages/tau-radio/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "tau-radio";
   version = "0.2.101-unstable-2025-12-17";
-  description = "Web radio - Hijacks audio device using CLAP and Ogg/Opus";
+  description = "Web radio - Hijacks audio device using CLAP and Ogg/Opus.";
   homePage = "https://github.com/tau-org/tau-radio";
   mainProgram = "tau-radio";
   license = lib.licenses.eupl12;

--- a/recipes/packages/tau-tower/recipe.nix
+++ b/recipes/packages/tau-tower/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "tau-tower";
   version = "0.2.2-beta-unstable-2026-03-14";
-  description = "Webradio server - broadcasts audio source to clients";
+  description = "Webradio server - broadcasts audio source to clients.";
   homePage = "https://github.com/tau-org/tau-tower";
   mainProgram = "tau-tower";
   license = lib.licenses.eupl12;

--- a/recipes/packages/tslib/recipe.nix
+++ b/recipes/packages/tslib/recipe.nix
@@ -8,7 +8,7 @@
 {
   name = "tslib";
   version = "1.24";
-  description = "Touchscreen access library";
+  description = "Touchscreen access library.";
   homePage = "http://www.tslib.org/";
   mainProgram = "";
   license = lib.licenses.lgpl21;

--- a/templates/provider/recipes/packages/hello-nix/recipe.nix
+++ b/templates/provider/recipes/packages/hello-nix/recipe.nix
@@ -7,7 +7,7 @@
 
 {
   name = "hello-nix";
-  description = "Hello Nix package built from local source";
+  description = "Hello Nix package built from local source.";
   homePage = "https://github.com/ngi-nix/ngi-forge";
   mainProgram = "hello";
 

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -54,7 +54,7 @@ type alias AppProgramsRuntimes =
 
 type alias AppPrograms =
     { appPrograms_runtimes : AppProgramsRuntimes
-    , appPrograms_runCommand : String
+    , appPrograms_runProgram : String
     }
 
 
@@ -62,7 +62,7 @@ decodeAppPrograms : Decoder AppPrograms
 decodeAppPrograms =
     Decode.map2 AppPrograms
         (Decode.field "runtimes" decodeAppProgramsRuntimes)
-        (Decode.field "runCommand" Decode.string)
+        (Decode.field "runProgram" Decode.string)
 
 
 decodeAppProgramsRuntimes : Decoder AppProgramsRuntimes

--- a/ui/src/Main/View/Nix.elm
+++ b/ui/src/Main/View/Nix.elm
@@ -1,9 +1,9 @@
 module Main.View.Nix exposing (..)
 
 import Html exposing (Html, code, text)
+import Html.Attributes exposing (style)
 import Main.Config exposing (..)
 import Main.Config.App exposing (..)
-import Main.Helpers.Html exposing (..)
 import Main.Helpers.Nix exposing (..)
 import Main.Icons exposing (..)
 import Main.Model exposing (..)
@@ -20,7 +20,7 @@ viewNixLiteralExpression : NixLiteralExpression -> Html Update
 viewNixLiteralExpression lit =
     case lit.nixLiteralExpression_type of
         "literalExpression" ->
-            code [] [ text lit.nixLiteralExpression_text ]
+            code [ style "white-space" "pre" ] [ text lit.nixLiteralExpression_text ]
 
         _ ->
             text lit.nixLiteralExpression_text

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -285,7 +285,7 @@ viewPageAppRunProgram model pageApp =
                         , pageApp.pageApp_app.app_name
                         , ".program"
                         , "'"
-                        , case pageApp.pageApp_app.app_programs.appPrograms_runCommand of
+                        , case pageApp.pageApp_app.app_programs.appPrograms_runProgram of
                             "" ->
                                 ""
 

--- a/ui/src/Main/View/Page/Recipe/Items.elm
+++ b/ui/src/Main/View/Page/Recipe/Items.elm
@@ -75,7 +75,11 @@ viewPageRecipeOptionsItem _ page ( optionPath, option ) =
 
             Just nixLitExpr ->
                 div []
-                    [ span [ class "fw-bold" ] [ text "Example: " ]
-                    , nixLitExpr |> viewNixLiteralExpression
+                    [ span [ class "fw-bold" ] [ text "Example:" ]
+                    , if String.contains "\n" nixLitExpr.nixLiteralExpression_text then
+                        div [] [ nixLitExpr |> viewNixLiteralExpression ]
+
+                      else
+                        span [] [ text " ", nixLitExpr |> viewNixLiteralExpression ]
                     ]
         ]


### PR DESCRIPTION
- Update description and examples of all options used this project
- Rename `rename packages.*.development` to `develop`
- Rename internal `apps.*.programs.runCommand` option to `runProgram`
- Add regex checks for length of package and app description and require full stop at the end
- Update all recipe descriptions to contain full stop at the end
- Fix rendering of multi line examples in the options browser 

Closes #375
