### PR TITLE
feat: implement bublewrapped service shell runner

### DIFF
--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -56,6 +56,7 @@
         }
         // lib.optionalAttrs app.services.runtimes.container.enable {
           container = app.services.runtimes.container.result.build;
+          services = app.services.runtimes.container.result.shellRunner;
         }
         // lib.optionalAttrs app.services.runtimes.nixos.enable {
           vm = app.services.runtimes.nixos.result.build;

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -116,6 +116,13 @@
         description = "Script that builds container image.";
       };
 
+      shellRunner = lib.mkOption {
+        internal = true;
+        type = with lib.types; lazyAttrsOf (nullOr package);
+        default = { };
+        description = "Per-service bubblewrap-sandboxed runner.";
+      };
+
       # HACK:
       # Prevent toJSON conversion from attempting to convert the `eval` option,
       # which won't work because it's a whole NixOS evaluation.
@@ -153,6 +160,27 @@
       name: value:
       inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkContainerImage {
         config = config.result.modules.${name};
+      }
+    ) app.services.components;
+
+    result.shellRunner = lib.mapAttrs (
+      serviceName: service:
+      let
+        componentPackages = service.packages;
+        runtimeComponentPackages = config.components.${serviceName}.packages or [ ];
+        binPaths = lib.makeBinPath ([ pkgs.coreutils ] ++ componentPackages ++ runtimeComponentPackages);
+      in
+      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkBwrap {
+        settings.bubblewrap.environment = service.environment // {
+          PATH = binPaths;
+        };
+        settings.bubblewrap.chdir = "/var/lib/${serviceName}";
+        settings.bubblewrap.unshare.user = false;
+        settings.bubblewrap.appendFlags = [
+          "--dir"
+          "/var/lib/${serviceName}"
+        ];
+        imports = [ { inherit (config.result.modules.${serviceName}) services settings; } ];
       }
     ) app.services.components;
 

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -102,10 +102,10 @@
 
                 # only copy db on first run so we don't overwrite it
                 if [ ! -d "$WORKDIR/db" ]; then
-                  rsync -a --chmod=u=rwX,g=rwX,o=rX ${pkgs.qlever-ui}/opt/db "$WORKDIR"
+                  rsync -a --no-owner --no-group --chmod=u=rwX,g=rwX,o=rX ${pkgs.qlever-ui}/opt/db "$WORKDIR"
                 fi
 
-                rsync -a --chmod=u=rwX,go=rX --exclude='/db/' ${pkgs.qlever-ui}/opt/ "$WORKDIR"
+                rsync -a --no-owner --no-group --chmod=u=rwX,go=rX --exclude='/db/' ${pkgs.qlever-ui}/opt/ "$WORKDIR"
               '';
             packages = with pkgs; [
               rsync # required by setup


### PR DESCRIPTION
Run a single service in shell using `nix run
.#<app>.services.<service>`.

For example:

```
nix run .#offen-app.services.offen

warning: Git tree '/home/imincik/Projects/ngi/forge/code' is dirty
[2026-05-21T21:45:49Z INFO  nimi::cli] Launching process manager...
[2026-05-21T21:45:49Z INFO  nimi::process_manager] Starting process manager...
[2026-05-21T21:45:49Z INFO  offen] Running pre-start script (/nix/store/jdvlbrj1i3xjc97f86gq6jmdizwkx38a-offen-pre-start)
[2026-05-21T21:45:49Z ERROR offen] time="2026-05-21T21:45:49Z" level=warning msg="SMTP for transactional email is not configured right now, mail delivery will be unreliable"
[2026-05-21T21:45:49Z ERROR offen] time="2026-05-21T21:45:49Z" level=warning msg="Refer to the documentation to find out how to configure SMTP"
[2026-05-21T21:45:49Z ERROR offen] time="2026-05-21T21:45:49Z" level=info msg="Successfully applied database migrations"
[2026-05-21T21:45:49Z ERROR offen] time="2026-05-21T21:45:49Z" level=info msg="Server now listening on port 3000"
[2026-05-21T21:45:49Z ERROR offen] time="2026-05-21T21:45:49Z" level=info msg="Cron successfully pruned expired events" removed=0
```

This feature provides a quick way to test service configuration during recipe development. Host system is protected against the service using bubblewrap.

Safer alternative to #385 .

Closes #400
