### PR TITLE
feat: managed service users

### DIFF
--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -74,6 +74,29 @@
       '';
     };
 
+    user = lib.mkOption {
+      type = lib.types.enum [
+        "root"
+        "prefer-dynamic"
+        "non-privileged"
+      ];
+      default = "prefer-dynamic";
+      description = ''
+        User account under which the service runs.
+
+        - `root`: service runs as root. A non-privileged user and group named
+          after the service are also created for services that start as root
+          and then drop privileges.
+
+        - `prefer-dynamic`: on NixOS runtime , uses `DynamicUser` - no physical
+          user or group account is created. On container runtime, uses a
+          non-privileged user named after the service.
+
+        - `non-privileged`: service always runs as a non-privileged user named
+          after the service.
+      '';
+    };
+
     ports = lib.mkOption {
       type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
       default = [ ];

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -128,7 +128,7 @@
     result.modules = lib.mapAttrs (serviceName: service: {
       settings = import ./modules/settings.nix (
         {
-          inherit service;
+          inherit service serviceName;
         }
         // args
         // lib.optionalAttrs (config.components ? ${serviceName}) {
@@ -164,6 +164,7 @@
                   image = "localhost/${name}:latest";
                   ports = service.ports;
                   depends_on = lib.genAttrs service.after (_name: { });
+                  tmpfs = [ "/tmp:rw,size=64m" ];
                 }) app.services.components;
               }
             );

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -2,6 +2,7 @@
   app,
 
   service,
+  serviceName,
   componentConfig ? {
     setup = "";
     packages = [ ];
@@ -15,13 +16,32 @@
   binName = "${app.name}-service";
 
   container = {
-    copyToRoot = pkgs.buildEnv {
-      name = "runtime-bins";
-      paths = componentConfig.packages;
-      pathsToLink = [ "/bin" ];
-    };
+    copyToRoot =
+      let
+        uid = "1001";
+        gid = "1001";
+        etcFiles = pkgs.runCommand "etc-${serviceName}" { } ''
+          mkdir -p $out/etc
+          echo 'root:x:0:0:root:/root:/bin/sh' > $out/etc/passwd
+          echo '${serviceName}:x:${uid}:${gid}:${serviceName}:/var/lib/${serviceName}:/sbin/nologin' >> $out/etc/passwd
+          echo 'root:x:0:' > $out/etc/group
+          echo '${serviceName}:x:${gid}:' >> $out/etc/group
+          echo 'root:!:0::::::' > $out/etc/shadow
+          echo '${serviceName}:!:1::::::' >> $out/etc/shadow
+          echo 'hosts: files dns' > $out/etc/nsswitch.conf
+        '';
+      in
+      pkgs.buildEnv {
+        name = "runtime-bins";
+        paths = componentConfig.packages ++ [ etcFiles ];
+        pathsToLink = [
+          "/bin"
+          "/etc"
+        ];
+      };
 
     imageConfig = componentConfig.imageConfig // {
+      User = if service.user == "root" then "root" else serviceName;
       Env =
         let
           # { K = "V"; } -> [ "K=V" ]

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -16,16 +16,43 @@
     services = import ../../mkNimiImports.nix { inherit lib service serviceName; };
   }) app.services.components;
 
+  users.groups = lib.mkMerge (
+    lib.mapAttrsToList (serviceName: _: { ${serviceName} = { }; }) (
+      lib.filterAttrs (_: service: service.user != "prefer-dynamic") app.services.components
+    )
+  );
+
+  users.users = lib.mkMerge (
+    lib.mapAttrsToList (serviceName: _: {
+      ${serviceName} = {
+        isSystemUser = true;
+        group = serviceName;
+      };
+    }) (lib.filterAttrs (_: service: service.user != "prefer-dynamic") app.services.components)
+  );
+
   systemd.services = lib.mapAttrs (
-    _: service:
+    serviceName: service:
     let
-      serviceAfterUntis = map (a: a + ".service") service.after;
+      serviceAfterUnits = map (a: a + ".service") service.after;
     in
     {
       environment = service.environment;
-      serviceConfig.PassEnvironment = lib.attrNames service.environment;
-      after = serviceAfterUntis;
-      requires = serviceAfterUntis;
+      serviceConfig = lib.mkMerge [
+        {
+          PassEnvironment = lib.attrNames service.environment;
+          User = lib.mkDefault serviceName;
+          Group = lib.mkDefault serviceName;
+        }
+        (lib.optionalAttrs (service.user == "prefer-dynamic") {
+          DynamicUser = true;
+        })
+        (lib.optionalAttrs (service.user == "root") {
+          User = "root";
+        })
+      ];
+      after = serviceAfterUnits;
+      requires = serviceAfterUnits;
     }
   ) app.services.components;
 }

--- a/recipes/apps/goupile-app/recipe.nix
+++ b/recipes/apps/goupile-app/recipe.nix
@@ -41,15 +41,23 @@
         container = {
           enable = true;
           composeFile = ./compose.yaml;
-          components.goupile.packages = [ pkgs.goupile ];
+          components.goupile = {
+            packages = [ pkgs.goupile ];
+            imageConfig.Volumes = {
+              "/var/lib/goupile" = { };
+            };
+          };
         };
 
         nixos = {
           enable = true;
           nixosConfig = {
-            systemd.tmpfiles.rules = [
-              "d /var/lib/goupile 0700 root root -"
-            ];
+            systemd.services."goupile" = {
+              serviceConfig = {
+                StateDirectory = [ "goupile" ];
+                WorkingDirectory = "/var/lib/goupile";
+              };
+            };
           };
         };
       };

--- a/recipes/apps/ironcalc-app/recipe.nix
+++ b/recipes/apps/ironcalc-app/recipe.nix
@@ -49,12 +49,25 @@
       runtimes.container = {
         enable = true;
         composeFile = ./compose.yaml;
-        components.ironcalc.packages = [ pkgs.ironcalc ];
+        components.ironcalc = {
+          packages = [ pkgs.ironcalc ];
+          imageConfig.Volumes = {
+            "/var/lib/ironcalc" = { };
+          };
+        };
       };
 
       runtimes.nixos = {
         enable = true;
         packages = [ pkgs.ironcalc ];
+        nixosConfig = {
+          systemd.services."ironcalc" = {
+            serviceConfig = {
+              StateDirectory = [ "ironcalc" ];
+              WorkingDirectory = "/var/lib/ironcalc";
+            };
+          };
+        };
       };
     };
 

--- a/recipes/apps/mox-app/recipe.nix
+++ b/recipes/apps/mox-app/recipe.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  apps,
   ...
 }:
 
@@ -70,6 +71,7 @@
           cp -v ''$XDG_CONFIG_HOME/mox.conf /var/lib/mox/config/mox.conf
           cp -v ''$XDG_CONFIG_HOME/domains.conf /var/lib/mox/config/domains.conf
         '';
+        user = "root";
         command = pkgs.mox;
         argv = [
           "-config"
@@ -88,21 +90,14 @@
           enable = true;
           components.mox = {
             setup = ''
-              # Use a public DNSSEC-validating resolver
-              echo "nameserver 8.8.8.8" >> /etc/resolv.conf
-
-              # Add mox group and user required by mox server
-              groupadd --system mox || true
-              useradd --system --no-create-home --shell /sbin/nologin --gid mox mox || true
-
               # Create Mox keys and data files
-              if ! [ -d /var/lib/mox ]; then
-                mkdir -p /var/lib/mox && cd /var/lib/mox
+              if ! [ -d /var/lib/mox/config ]; then
+                mkdir -p /var/lib/mox/config && cd /var/lib/mox
 
-              # Generate DKIM keys
-              mkdir -p config/dkim
-              ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkima.rsa2048.privatekey.pkcs8.pem
-              ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkimb.rsa2048.privatekey.pkcs8.pem
+                # Generate DKIM keys
+                mkdir -p config/dkim
+                ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkima.rsa2048.privatekey.pkcs8.pem
+                ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkimb.rsa2048.privatekey.pkcs8.pem
 
                 # Create data directory
                 mkdir data
@@ -113,39 +108,18 @@
               pkgs.bash # required for entering the container
               pkgs.coreutils # required for mkdir, echo
               pkgs.mox # required for admin tasks
-              pkgs.shadow # required for useradd
             ];
           };
         };
 
         nixos = {
           enable = true;
-          setup = ''
-            # Create Mox keys and data files
-            if ! [ -d /var/lib/mox ]; then
-              mkdir -p /var/lib/mox && cd /var/lib/mox
-
-              # Generate DKIM keys
-              mkdir -p config/dkim
-              ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkima.rsa2048.privatekey.pkcs8.pem
-              ${lib.getExe' pkgs.mox "mox"} dkim genrsa > config/dkim/dkimb.rsa2048.privatekey.pkcs8.pem
-
-              # Create data directory
-              mkdir data
-              chown mox:mox data
-            fi
-          '';
+          setup = apps.mox.services.runtimes.container.components.mox.setup;
           packages = [ pkgs.mox ];
           nixosConfig = {
             networking.enableIPv6 = false;
             # Use a public DNSSEC-validating resolver
             networking.nameservers = [ "8.8.8.8" ];
-
-            users.groups.mox = { };
-            users.users.mox = {
-              isSystemUser = true;
-              group = "mox";
-            };
           };
         };
       };

--- a/recipes/apps/offen-app/recipe.nix
+++ b/recipes/apps/offen-app/recipe.nix
@@ -59,11 +59,16 @@
       runtimes = {
         container = {
           enable = true;
-          components.offen.packages = [
-            pkgs.bash # required for entering the container
-            pkgs.coreutils # required for mkdir
-            pkgs.offen # required for admin tasks
-          ];
+          components.offen = {
+            packages = [
+              pkgs.bash # required for entering the container
+              pkgs.coreutils # required for mkdir
+              pkgs.offen # required for admin tasks
+            ];
+            imageConfig.Volumes = {
+              "/var/lib/offen" = { };
+            };
+          };
         };
 
         nixos = {
@@ -71,6 +76,14 @@
           packages = [
             pkgs.offen # required for admin tasks
           ];
+          nixosConfig = {
+            systemd.services."offen" = {
+              serviceConfig = {
+                StateDirectory = [ "offen" ];
+                WorkingDirectory = "/var/lib/offen";
+              };
+            };
+          };
         };
       };
     };

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -129,7 +129,6 @@
                 rsync
               ];
               serviceConfig = {
-                DynamicUser = true;
                 StateDirectory = [ "qlever-ui" ];
                 WorkingDirectory = "/var/lib/qlever-ui";
               };
@@ -141,7 +140,6 @@
                 subversion
               ];
               serviceConfig = {
-                DynamicUser = true;
                 StateDirectory = [ "qlever-ui" ];
                 WorkingDirectory = "/var/lib/qlever-ui";
               };
@@ -155,7 +153,6 @@
                 unzip
               ];
               serviceConfig = {
-                DynamicUser = true;
                 StateDirectory = [ "qlever-server" ];
                 WorkingDirectory = "/var/lib/qlever-server";
               };


### PR DESCRIPTION
Add `apps.*.services.components.user` configuration option which will automatically create user for each service. There are three types of user accounts:

- `root`: service runs as root.

- `prefer-dynamic`: on systemd runtimes (NixOS), uses `DynamicUser`;
          on other runtimes (container), uses a non-privileged user named after
          the service.

- `non-privileged`: service always runs as a non-privileged user named
          after the service.

A non-privileged user named after the service is always created, even
when `root` is selected. This is useful for services that start as root
and then drop privileges.

Also, make sure that data (state) directory and container volume is writable for the service user.  Managed state directory will be implemented in https://github.com/ngi-nix/forge/issues/175 . 