### PR TITLE
+dev@perf(_forge-config): avoid building the whole forge when generating the JSON for the frontend

### DIFF
--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -55,7 +55,20 @@
       packages = {
         _forge-config = pkgs.writeTextFile {
           name = "forge-config.json";
-          text = builtins.toJSON config.forge;
+          text =
+            let
+              scrubConfig =
+                x:
+                if lib.isString x || lib.isDerivation x then
+                  lib.unsafeDiscardStringContext x
+                else if lib.isList x then
+                  map scrubConfig x
+                else if lib.isAttrs x then
+                  lib.mapAttrs (n: v: scrubConfig v) x
+                else
+                  x;
+            in
+            builtins.toJSON (scrubConfig config.forge);
         };
 
         _forge-options = pkgs.runCommand "options.json" { } ''


### PR DESCRIPTION
Adapted from `lib.scrubOptionValue`, adding a `lib.unsafeDiscardStringContext`.

Closes: https://github.com/ngi-nix/forge/issues/381
As far as I've tested (by changing the underlying `inputs.nixpkgs` to various commits) it works well,
but please let me know:
1. if the CI is indeed faster with that scrubbing,
2. if there's still a problem, eg. when updating a `forge.packages.*.source`.

Note that this scrubbing is kinda like a workaround,
to keep things simple.
One can also imagine regrouping/filtering options manually one way or the other.