### PR TITLE
ui: show page-specific titles in browser tab

### DIFF
--- a/ui/src/Main/Ports/Title.elm
+++ b/ui/src/Main/Ports/Title.elm
@@ -1,0 +1,4 @@
+port module Main.Ports.Title exposing (setTitle)
+
+
+port setTitle : String -> Cmd msg

--- a/ui/src/Main/Update/Route.elm
+++ b/ui/src/Main/Update/Route.elm
@@ -9,6 +9,7 @@ import Main.Model.Page exposing (..)
 import Main.Model.Preferences exposing (..)
 import Main.Model.Route exposing (..)
 import Main.Ports.SmoothScroll exposing (..)
+import Main.Ports.Title exposing (setTitle)
 import Main.Update.Config exposing (..)
 import Main.Update.Focus exposing (..)
 import Main.Update.Route.App exposing (..)
@@ -20,16 +21,47 @@ import Main.Update.Types exposing (..)
 
 
 updateRoute : Route -> Updater
-updateRoute route =
-    case route of
-        Route_App routeApp ->
-            updateRouteApp routeApp
+updateRoute route model =
+    let
+        ( newModel, routeCmd ) =
+            case route of
+                Route_App routeApp ->
+                    updateRouteApp routeApp model
 
-        Route_Apps routeApps ->
-            updateRouteApps routeApps
+                Route_Apps routeApps ->
+                    updateRouteApps routeApps model
 
-        Route_Packages routePackages ->
-            updateRoutePackages routePackages
+                Route_Packages routePackages ->
+                    updateRoutePackages routePackages model
 
-        Route_RecipeOptions routeRecipe ->
-            updateRouteRecipeOptions routeRecipe
+                Route_RecipeOptions routeRecipe ->
+                    updateRouteRecipeOptions routeRecipe model
+
+        titleCmd =
+            setTitle (pageTitle newModel.model_page)
+    in
+    ( newModel
+    , Cmd.batch [ routeCmd, titleCmd ]
+    )
+
+
+{-| Derive the browser tab title from the current `Page`.
+-}
+pageTitle : Page -> String
+pageTitle page =
+    let
+        suffix =
+            "NGI Forge"
+    in
+    case page of
+        Page_App pageApp ->
+            pageApp.pageApp_app.app_displayName ++ " — " ++ suffix
+
+        Page_Apps _ ->
+            "Apps — " ++ suffix
+
+        Page_Packages _ ->
+            "Packages — " ++ suffix
+
+        Page_RecipeOptions _ ->
+            "Recipe Options — " ++ suffix

--- a/ui/src/js/Title.js
+++ b/ui/src/js/Title.js
@@ -1,0 +1,7 @@
+const initTitle = (app) => {
+  app.ports.setTitle.subscribe((title) => {
+    document.title = title;
+  });
+};
+
+export { initTitle };

--- a/ui/src/js/main.js
+++ b/ui/src/js/main.js
@@ -2,6 +2,7 @@ import { initClipboard } from "./Clipboard.js";
 import { initNavigation } from "./Navigation.js";
 import { getPreferences, initPreferences } from "./Preferences.js";
 import { initSmoothScroll } from "./SmoothScroll.js";
+import { initTitle } from "./Title.js";
 import "./CodeHighlightJS.js";
 
 // work around github pages adding extra trailing slash
@@ -30,3 +31,4 @@ initNavigation({
 });
 initPreferences(app);
 initSmoothScroll(app);
+initTitle(app);


### PR DESCRIPTION
Fixes #503

Each page now sets a proper browser tab title instead of always showing "NGI Forge":

- App detail → `<displayName> — NGI Forge`
- Apps list → `Apps — NGI Forge`
- Packages → `Packages — NGI Forge`
- Recipe Options → `Recipe Options — NGI Forge`

Implemented via a small Elm port (`setTitle`) following the same pattern used by the existing Clipboard and SmoothScroll ports.
