### PR TITLE
Add maintainer information for packages and apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           {
             forge = {
               repositoryUrl = "github:ngi-nix/forge";
+              maintainerList = ./maintainers/maintainer-list.nix;
               recipeDirs = {
                 packages = "recipes/packages";
                 apps = "recipes/apps";

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -80,6 +80,17 @@
       default = { };
       description = "NGI specific options.";
     };
+    maintainers = lib.mkOption {
+      type = lib.types.listOf lib.types.anything;
+      default = [ ];
+      description = ''
+        A list of the maintainers of this application.
+
+        Maintainers needs to be either a Nixpkgs maintainer or a NGI Forge
+        maintainer defined in `maintainers/maintainer-list.nix` file.
+      '';
+      example = lib.literalExpression "with lib.maintainers; [ ngi-nix ]";
+    };
 
     # Portable services configuration
     # https://nixos.org/manual/nixos/unstable/#modular-services

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -33,7 +33,7 @@
         lib = lib // {
           maintainers =
             (import "${forge-inputs.nixpkgs}/maintainers/maintainer-list.nix")
-            // (if config.forge.maintainerList != null then import config.forge.maintainerList else { });
+            // lib.optionalAttrs (config.forge.maintainerList != null) (import config.forge.maintainerList);
         };
       };
       modules = [

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -30,10 +30,22 @@
             pkgsOriginal = previousPkgs;
           }
         );
+        lib = lib // {
+          maintainers =
+            (import "${forge-inputs.nixpkgs}/maintainers/maintainer-list.nix")
+            // (if config.forge.maintainerList != null then import config.forge.maintainerList else { });
+        };
       };
       modules = [
         {
           options = {
+
+            maintainerList = lib.mkOption {
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              description = "Path to a maintainer list file in the format of Nixpkgs maintainer-list.nix.";
+              example = "./maintainers/maintainer-list.nix";
+            };
 
             repositoryUrl = lib.mkOption {
               type = lib.types.str;

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -63,6 +63,17 @@
       '';
       example = lib.literalExpression "[ lib.licenses.mit lib.licenses.asl20 ]";
     };
+    maintainers = lib.mkOption {
+      type = lib.types.listOf lib.types.anything;
+      default = [ ];
+      description = ''
+        A list of the maintainers of this package.
+
+        Maintainers needs to be either a Nixpkgs maintainer or a NGI Forge
+        maintainer defined in `maintainers/maintainer-list.nix` file.
+      '';
+      example = lib.literalExpression "with lib.maintainers; [ ngi-nix ]";
+    };
 
     # Source configuration
     source = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,0 +1,11 @@
+# NGI Forge maintainer list.
+# Add yourself here if you are not yet in the Nixpkgs maintainer list.
+# Format matches lib.maintainers in Nixpkgs, an example is provided below.
+# Usage in recipes: { lib, ... }: { maintainers = [ lib.maintainers.<handle> ]; }
+{
+  ngi-team = {
+    name = "Nix@NGI Team";
+    github = "ngi-nix";
+    email = "ngi@nixos.org";
+  };
+}

--- a/recipes/apps/mox/recipe.nix
+++ b/recipes/apps/mox/recipe.nix
@@ -35,6 +35,9 @@
       * Webmail interface: [http://localhost:8082](http://localhost:8082)
 
     '';
+    maintainers = with lib.maintainers; [
+      ngi-team
+    ];
 
     links = {
       website = "https://www.xmox.nl/";

--- a/templates/provider/flake.nix
+++ b/templates/provider/flake.nix
@@ -23,6 +23,7 @@
         {
           forge = {
             imports = [ (inputs.ngi-forge.inputs.import-tree ./recipes) ];
+            maintainerList = ./maintainers/maintainer-list.nix;
           };
         };
     };

--- a/templates/provider/maintainers/maintainer-list.nix
+++ b/templates/provider/maintainers/maintainer-list.nix
@@ -1,0 +1,11 @@
+# NGI Forge maintainer list.
+# Add yourself here if you are not yet in the Nixpkgs maintainer list.
+# Format matches lib.maintainers in Nixpkgs, an example is provided below.
+# Usage in recipes: { lib, ... }: { maintainers = [ lib.maintainers.<handle> ]; }
+{
+  # example-maintainer = {
+  #   name = "Example Maintainer";
+  #   github = "example";
+  #   email = "example@example.com";
+  # };
+}

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -16,6 +16,7 @@ type alias App =
     , app_ngi : Ngi
     , app_links : AppLinks
     , app_recipePath : String
+    , app_maintainers : List Maintainer
     }
 
 
@@ -32,6 +33,7 @@ decodeApp =
         |> Decode.andMap (Decode.field "ngi" decodeNgi)
         |> Decode.andMap (Decode.field "links" decodeAppLinks)
         |> Decode.andMap (Decode.field "recipePath" Decode.string)
+        |> Decode.andMap (Decode.field "maintainers" (Decode.list decodeMaintainer))
 
 
 type alias AppName =
@@ -283,3 +285,18 @@ getAppServicesPorts services =
     services.appServices_components
         |> Dict.toList
         |> List.concatMap (Tuple.second >> .appComponent_ports)
+
+
+type alias Maintainer =
+    { maintainer_name : String
+    , maintainer_github : Maybe String
+    , maintainer_email : Maybe String
+    }
+
+
+decodeMaintainer : Decoder Maintainer
+decodeMaintainer =
+    Decode.map3 Maintainer
+        (Decode.field "name" Decode.string)
+        (Decode.maybe (Decode.field "github" Decode.string))
+        (Decode.maybe (Decode.field "email" Decode.string))

--- a/ui/src/Main/Config/Package.elm
+++ b/ui/src/Main/Config/Package.elm
@@ -1,6 +1,8 @@
 module Main.Config.Package exposing (..)
 
 import Json.Decode as Decode exposing (Decoder)
+import Main.Config.App exposing (Maintainer, decodeMaintainer)
+import Main.Helpers.Json.Decode as Decode
 import Main.Helpers.String exposing (..)
 
 
@@ -13,20 +15,22 @@ type alias Package =
     , package_licenses : List PackageLicense
     , package_source : PackageSource
     , package_recipePath : String
+    , package_maintainers : List Maintainer
     }
 
 
 decodePackage : Decoder Package
 decodePackage =
-    Decode.map8 Package
-        (Decode.field "pname" Decode.string)
-        (Decode.field "description" Decode.string)
-        (Decode.field "version" Decode.string)
-        (Decode.field "homePage" Decode.string)
-        (Decode.field "mainProgram" Decode.string)
-        (Decode.field "license" decodeLicenses)
-        (Decode.field "source" decodeSource)
-        (Decode.field "recipePath" Decode.string)
+    Package
+        |> Decode.flipMap (Decode.field "pname" Decode.string)
+        |> Decode.andMap (Decode.field "description" Decode.string)
+        |> Decode.andMap (Decode.field "version" Decode.string)
+        |> Decode.andMap (Decode.field "homePage" Decode.string)
+        |> Decode.andMap (Decode.field "mainProgram" Decode.string)
+        |> Decode.andMap (Decode.field "license" decodeLicenses)
+        |> Decode.andMap (Decode.field "source" decodeSource)
+        |> Decode.andMap (Decode.field "recipePath" Decode.string)
+        |> Decode.andMap (Decode.field "maintainers" (Decode.list decodeMaintainer))
 
 
 type alias PackageName =

--- a/ui/src/Main/Model/Route.elm
+++ b/ui/src/Main/Model/Route.elm
@@ -50,6 +50,7 @@ type RouteAppFocus
     = RouteAppFocus_Resources
     | RouteAppFocus_Grants
     | RouteAppFocus_Configuration
+    | RouteAppFocus_Maintainers
 
 
 showRouteAppFocus : RouteAppFocus -> String
@@ -63,6 +64,9 @@ showRouteAppFocus x =
 
         RouteAppFocus_Configuration ->
             "configuration"
+
+        RouteAppFocus_Maintainers ->
+            "maintainers"
 
 
 type alias RouteApps =
@@ -281,6 +285,9 @@ appUrlToRoute url =
 
                                         "configuration" ->
                                             Just RouteAppFocus_Configuration
+
+                                        "maintainers" ->
+                                            Just RouteAppFocus_Maintainers
 
                                         _ ->
                                             Nothing

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -34,6 +34,7 @@ viewPageApp model pageApp =
                 [ viewPageAppResources model pageApp
                 , viewPageAppNgiGrants model pageApp
                 , viewPageAppConfiguration model pageApp
+                , viewPageAppMaintainers model pageApp
                 ]
             ]
         ]
@@ -215,7 +216,7 @@ viewPageAppResources model pageApp =
                 ]
                 []
             ]
-        , ul [ class "", style "padding-left" "10px" ]
+        , ul [ style "padding-left" "10px" ]
             (List.concat
                 [ viewPageAppResourcesItem "Homepage" pageApp.pageApp_app.app_links.appLinks_website
                 , viewPageAppResourcesItem "Documentation" pageApp.pageApp_app.app_links.appLinks_docs
@@ -223,6 +224,62 @@ viewPageAppResources model pageApp =
                 , viewPageAppResourcesItem "Forge Recipe" (Just (showAppRecipeLink model pageApp.pageApp_app))
                 ]
             )
+        ]
+
+
+viewPageAppMaintainers : Model -> PageApp -> Html msg
+viewPageAppMaintainers _ pageApp =
+    let
+        routeApp =
+            pageApp.pageApp_route
+    in
+    if List.isEmpty pageApp.pageApp_app.app_maintainers then
+        text ""
+
+    else
+        div
+            [ class "box-container target-highlight mb-3"
+            , id (showRouteAppFocus RouteAppFocus_Maintainers)
+            , tabindex -1
+            ]
+            [ h6
+                [ class "mt-3 mb-3 ms-2"
+                ]
+                [ text "Maintainers"
+                , a
+                    [ class "anchor-link"
+                    , href
+                        ({ routeApp | routeApp_focus = Just RouteAppFocus_Maintainers }
+                            |> Route_App
+                            |> routeToString
+                        )
+                    ]
+                    []
+                ]
+            , ul [ style "padding-left" "10px" ]
+                (List.map viewMaintainerItem pageApp.pageApp_app.app_maintainers)
+            ]
+
+
+maintainerGithubUrl : String -> String
+maintainerGithubUrl handle =
+    "https://github.com/" ++ handle
+
+
+viewMaintainerItem : Maintainer -> Html msg
+viewMaintainerItem m =
+    li [ class "list-group-item bg-transparent px-0 mb-1" ]
+        [ case m.maintainer_github of
+            Just handle ->
+                a
+                    [ href (maintainerGithubUrl handle)
+                    , target "_blank"
+                    , rel "noopener"
+                    ]
+                    [ text m.maintainer_name ]
+
+            Nothing ->
+                text m.maintainer_name
         ]
 
 


### PR DESCRIPTION
Closes https://github.com/ngi-nix/forge/issues/240.

- Add `maintainer` option for packages and apps
- Add `maintainer-list.nix` file
- Show maintainer information in application detail page
- Add Nix@NGI team as Mox app maintainer