### PR TITLE
feat(ui): implement feedback banner dismissal preference

### DIFF
--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -36,18 +36,19 @@ main =
 init : Flags -> ( Model, Cmd Update )
 init flags =
     let
+        prefs =
+            flags.flags_preferences
+                |> Json.Decode.decodeValue decodePreferences
+                |> Result.withDefault defaultPreferences
         model =
             { model_config = Main.Config.initConfig
             , model_search = defaultSearch
             , model_page = defaultPage
             , model_errors = []
-            , model_preferences =
-                flags.flags_preferences
-                    |> Json.Decode.decodeValue decodePreferences
-                    |> Result.withDefault defaultPreferences
+            , model_preferences = prefs
             , model_navbarExpanded = False
             , model_RecipeOptions = defaultRecipeOptions
-            , model_askFeedback = True
+            , model_askFeedback = not prefs.preferences_feedbackDismissed
             }
     in
     case flags.href |> Url.fromString of

--- a/ui/src/Main/Model/Preferences.elm
+++ b/ui/src/Main/Model/Preferences.elm
@@ -7,6 +7,7 @@ import Json.Encode as Encode exposing (Value)
 type alias Preferences =
     { preferences_install : PreferencesInstall
     , preferences_theme : PreferencesTheme
+    , preferences_feedbackDismissed : Bool
     }
 
 
@@ -14,12 +15,13 @@ defaultPreferences : Preferences
 defaultPreferences =
     { preferences_install = PreferencesInstall_NixFlakes
     , preferences_theme = PreferencesTheme_Light
+    , preferences_feedbackDismissed = False
     }
 
 
 decodePreferences : Decoder Preferences
 decodePreferences =
-    Decode.map2
+    Decode.map3
         Preferences
         (Decode.field "install"
             (Decode.oneOf
@@ -35,6 +37,13 @@ decodePreferences =
                 ]
             )
         )
+        (Decode.field "feedbackDismissed"
+            (Decode.oneOf
+                [ Decode.bool
+                , Decode.succeed defaultPreferences.preferences_feedbackDismissed
+                ]
+            )
+        )
 
 
 encodePreferences : Preferences -> Value
@@ -42,6 +51,7 @@ encodePreferences preferences =
     Encode.object
         [ ( "install", preferences.preferences_install |> encodePreferencesInstall )
         , ( "theme", preferences.preferences_theme |> encodePreferencesTheme )
+        , ( "feedbackDismissed", Encode.bool preferences.preferences_feedbackDismissed )
         ]
 
 

--- a/ui/src/Main/Update.elm
+++ b/ui/src/Main/Update.elm
@@ -84,7 +84,15 @@ update upd modelInit =
             )
 
         Update_DismissFeedback ->
-            ( { model | model_askFeedback = False }, Cmd.none )
+            let
+                updatedModel =
+                    { model | model_askFeedback = False }
+                updatedPrefs =
+                    { updatedModel.model_preferences | preferences_feedbackDismissed = True }
+            in
+            ( { updatedModel | model_preferences = updatedPrefs }
+                , setPreferences updatedPrefs
+            )
 
         Update_CycleTheme ->
             let

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -88,7 +88,7 @@ viewPageAppHeader _ pageApp =
 
 viewPageAppFeedback : Model -> Html Update
 viewPageAppFeedback model =
-    if not model.model_askFeedback then
+    if model.model_preferences.preferences_feedbackDismissed then
         text ""
 
     else


### PR DESCRIPTION
This PR implements a preference to remember when a user dismisses the feedback banner, so it doesn't appear on every app page visit.

Changes:
- Added preferences_feedbackDismissed field to track dismissal state
- Initialize preferences_feedbackDismissed to false by default
- Updated model initialization to set model_askFeedback based on preferences
- Modified Update_DismissFeedback to update preferences and persist them via setPreferences
- Changed viewPageAppFeedback to check preferences_feedbackDismissed instead of model_askFeedback
- 
This allows the feedback banner to remain dismissed across sessions, addressing issue #506 in ngi-nix/forge