### PR TITLE
flake: nixpkgs update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
-        run: nix flake check --accept-flake-config --option sandbox relaxed
+        run: nix flake check --accept-flake-config --max-jobs 1 --option sandbox relaxed
 
   lint:
     name: Run format checks

--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/forge/modules/builders/pnpm-package-builder/default.nix
+++ b/forge/modules/builders/pnpm-package-builder/default.nix
@@ -17,7 +17,7 @@
           {
             inherit (package) pname version;
             inherit src;
-            inherit (builderCfg) fetcherVersion;
+            inherit (builderCfg) pnpm fetcherVersion;
             hash = builderCfg.pnpmDepsHash;
           }
           // lib.optionalAttrs (builderCfg.sourceRoot != null) {
@@ -33,8 +33,8 @@
           patches = package.source.patches or [ ];
 
           nativeBuildInputs = [
+            builderCfg.pnpm
             pkgs.pnpmConfigHook
-            pkgs.pnpm
             pkgs.nodejs
           ]
           ++ builderCfg.packages.build;

--- a/forge/modules/builders/pnpm-package-builder/options.nix
+++ b/forge/modules/builders/pnpm-package-builder/options.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   ...
 }:
 {
@@ -49,6 +50,21 @@
         '';
         example = lib.literalExpression "[ pkgs.chromium ]";
       };
+    };
+
+    pnpm = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.pnpm_10;
+      defaultText = lib.literalExpression "pkgs.pnpm_10";
+      description = ''
+        pnpm package used for fetching and building.
+
+        Pin pnpm to a specific package to avoid hash mismatch when the
+        pnpm version in nixpkgs changes.
+
+        Mapped to `pnpm`.
+      '';
+      example = lib.literalExpression "pkgs.pnpm_9";
     };
 
     fetcherVersion = lib.mkOption {


### PR DESCRIPTION
- **fix(pnpmPackageBuilder): add option to pin pnpm version**
- **flake: nixpkgs update**

Also

- ci: limit number of parallel Nix build jobs

Limit number of parallel Nix jobs to 1 to prevent CI builders running
out of memory.
