### PR TITLE
Add rpki-client package and app recipes

### DIFF
--- a/recipes/apps/rpki-client/recipe.nix
+++ b/recipes/apps/rpki-client/recipe.nix
@@ -1,0 +1,59 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  apps.rpki-client = {
+    displayName = "RPKI Client";
+    description = "RPKI relying party software for validating internet routing security data.";
+    usage = ''
+      rpki-client validates Resource Public Key Infrastructure (RPKI) data,
+      helping Internet providers make correct and secure BGP routing decisions.
+
+      #### Show version
+
+      ```bash
+      rpki-client -V
+      ```
+
+      #### Validate RPKI data (requires TAL files and write access)
+
+      ```bash
+      rpki-client -d /var/cache/rpki-client -o /var/db/rpki-client
+      ```
+
+      #### Use a specific TAL file
+
+      ```bash
+      rpki-client -T /etc/rpki/arin.tal
+      ```
+    '';
+
+    links = {
+      website = "https://www.rpki-client.org";
+      source = "https://github.com/rpki-client/rpki-client-portable";
+    };
+
+    ngi.grants = {
+      Commons = [
+        "Erik-RPKI"
+      ];
+    };
+
+    programs = {
+      packages = [
+        pkgs.rpki-client
+      ];
+
+      runtimes.shell = {
+        enable = true;
+      };
+    };
+
+    test.programs.script = ''
+      rpki-client -V
+      rpki-client -n -d /tmp -o /tmp
+    '';
+  };
+}

--- a/recipes/packages/rpki-client/recipe.nix
+++ b/recipes/packages/rpki-client/recipe.nix
@@ -1,0 +1,59 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  packages.rpki-client = {
+    version = "9.8";
+    description = "Port of OpenBSD's rpki-client RPKI relying party validator to other operating systems.";
+    homePage = "https://www.rpki-client.org";
+    mainProgram = "rpki-client";
+    license = "isc";
+
+    source = {
+      git = "github:rpki-client/rpki-client-portable/15554f28842d7d9e6cc31eab5f95e36053b42f35";
+      hash = "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=";
+    };
+
+    build = {
+      extraAttrs = {
+        openbsdSrc = pkgs.fetchFromGitHub {
+          owner = "rpki-client";
+          repo = "rpki-client-openbsd";
+          rev = "027566b8e6827a9e280a0ef067464fc2336f0179";
+          hash = "sha256-lmyECC4uhBLJb89Gm+oqO4ClkkhFGqGm+cD7GivDqok=";
+        };
+        configureFlags = [
+          "--with-base-dir=/var/cache/rpki-client"
+          "--with-output-dir=/var/db/rpki-client"
+        ];
+        preConfigure = ''
+          cp -r $openbsdSrc openbsd
+          chmod -R +w openbsd
+          ./autogen.sh
+        '';
+      };
+      standardBuilder = {
+        enable = true;
+        packages.build = [
+          pkgs.pkg-config
+          pkgs.automake
+          pkgs.autoconf
+          pkgs.libtool
+        ];
+        packages.run = [
+          pkgs.expat
+          pkgs.libressl
+          pkgs.rsync
+          pkgs.zlib
+        ];
+      };
+    };
+
+    test.script = ''
+      rpki-client -V
+      rpki-client -n -d /tmp -o /tmp
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Adds a package recipe for rpki-client-portable v9.8 and an app recipe exposing it via shell runtime. rpki-client is a port of
OpenBSD's RPKI relying party validator to other operating systems, used by internet providers to validate BGP routing security data. Not currently in nixpkgs.

## How to test

- `git add recipes/packages/erik-rpki/recipe.nix recipes/apps/erik-rpki-app/recipe.nix`
- `nix build .#erik-rpki -L`
- `nix build .#erik-rpki.test -L`
- `nix build .#erik-rpki-app -L`

## Related Issue

ngi-nix/projects#351