### PR TITLE
Add WireGuard-RS package and app recipes

### DIFF
--- a/recipes/apps/wireguard-rs/recipe.nix
+++ b/recipes/apps/wireguard-rs/recipe.nix
@@ -1,0 +1,60 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  apps.wireguard-rs = {
+    displayName = "WireGuard-RS";
+    description = "Userspace WireGuard VPN implementation written in Rust.";
+    usage = ''
+      wireguard-rs is a userspace implementation of the WireGuard VPN protocol.
+      It creates a WireGuard tunnel on a named TUN interface.
+
+      #### Create a WireGuard tunnel interface
+
+      ```bash
+      wireguard-rs <interface-name>
+      ```
+
+      #### Configure the interface with wg(8)
+
+      ```bash
+      wg setconf <interface-name> /etc/wireguard/<interface-name>.conf
+      ```
+
+      _Available in: shell._
+    '';
+
+    links = {
+      website = "https://www.wireguard.com";
+      source = "https://github.com/WireGuard/wireguard-rs";
+    };
+
+    ngi.grants = {
+      Entrust = [
+        "WireGuard-SpinalHDL"
+        "Wireguard-Rust"
+      ];
+      Review = [
+        "WireGuard-upscale"
+        "wireguard-scaleup"
+      ];
+    };
+
+    programs = {
+      packages = [
+        pkgs.wireguard-rs
+      ];
+
+      runtimes.shell = {
+        enable = true;
+      };
+    };
+
+    test.programs.script = ''
+      output=$(wireguard-rs 2>&1 || true)
+      echo "$output" | grep -i "device"
+    '';
+  };
+}

--- a/recipes/packages/wireguard-rs/recipe.nix
+++ b/recipes/packages/wireguard-rs/recipe.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  packages.wireguard-rs = {
+    version = "0.1.4";
+    description = "Userspace WireGuard VPN implementation written in Rust.";
+    homePage = "https://www.wireguard.com";
+    mainProgram = "wireguard-rs";
+    license = "mit";
+
+    source = {
+      git = "github:WireGuard/wireguard-rs/7d84ef9064559a29b23ab86036f7ef62b450f90c";
+      hash = "sha256-UlT0c0J4oY+E1UM2ElueHECjrxErIBERwiF1huLvtds=";
+    };
+
+    build.rustPackageBuilder = {
+      enable = true;
+      cargoHash = "sha256-EBzHu0Es0wVWYwCB95AlEC3VF1YCe/wWC/nZxOwhez0=";
+    };
+
+    build.extraAttrs = {
+      doCheck = false;
+    };
+
+    test.script = ''
+      output=$(wireguard-rs 2>&1 || true)
+      echo "$output" | grep -i "device"
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Adds a package recipe for wireguard-rs v0.1.4 and an app recipe exposing it via shell runtime. wireguard-rs is a userspace
implementation of the WireGuard VPN protocol written in Rust. Not currently in nixpkgs.

`doCheck = false` — the `pnet` dev-dependency pulls in
`rustc-serialize` which fails to compile with Rust 1.65+.

## How to test

- `git add recipes/packages/wireguard-rs/recipe.nix recipes/apps/wireguard-rs-app/recipe.nix`
- `nix build .#wireguard-rs -L`
- `nix build .#wireguard-rs.test -L`
- `nix build .#wireguard-rs-app -L`

## Related Issue

ngi-nix/projects#912