### PR TITLE
dev: fix mock app name

### DIFF
--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -161,7 +161,7 @@ def main():
             f.write(generate_app_recipe(test_app_name, 0, is_test_app=True))
 
         for i in range(num_apps):
-            app_name = f"mock-app-{i}"
+            app_name = f"mock-{i}-app"
             (apps_dir / app_name).mkdir(parents=True)
             with open(apps_dir / app_name / "recipe.nix", "w") as f:
                 f.write(generate_app_recipe(app_name, i))


### PR DESCRIPTION
Without this fix, `dev-ui` is failing with 

```
error: A definition for option `perSystem.x86_64-linux.forge.apps."[definition 1-entry 1]".name' is not of type `string matching the pattern ^[a-zA-Z0-9-]+-app$'
```