### PR TITLE
ci: limit number of parallel Nix build jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
-        run: nix flake check --accept-flake-config --option sandbox relaxed
+        run: nix flake check --accept-flake-config --max-jobs 1 --option sandbox relaxed
 
   lint:
     name: Run format checks


### PR DESCRIPTION
Limit number of parallel Nix jobs to 1 to prevent CI builders from running
out of memory.
