### PR TITLE
feat: add per-service packages option

### DIFF
--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -102,8 +102,6 @@
       default = "/var/lib/${name}";
       description = ''
         Path to the service state directory.
-
-        Defaults to `/var/lib/<service-name>`.
       '';
       example = "/var/lib/myservice";
     };

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -108,6 +108,15 @@
       example = "/var/lib/myservice";
     };
 
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        Additional packages available for the service.
+      '';
+      example = lib.literalExpression "[ pkgs.rsync pkgs.jq ]";
+    };
+
     ports = lib.mkOption {
       type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
       default = [ ];

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -47,7 +47,11 @@
                 packages = lib.mkOption {
                   type = lib.types.listOf lib.types.package;
                   default = [ ];
-                  description = "List of packages to add to the container.";
+                  description = ''
+                    List of packages available in the container.
+
+                    Use this option to add packages required by setup script.
+                  '';
                   example = lib.literalExpression "[ pkgs.curl ]";
                 };
 

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -136,7 +136,7 @@
         }
         // args
         // lib.optionalAttrs (config.components ? ${serviceName}) {
-          componentConfig = config.components.${serviceName};
+          runtimeConfig = config.components.${serviceName};
         }
       );
       services = import ../mkNimiImports.nix { inherit lib service serviceName; };

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -3,7 +3,7 @@
 
   service,
   serviceName,
-  componentConfig ? {
+  runtimeConfig ? {
     setup = "";
     packages = [ ];
     imageConfig = { };
@@ -33,7 +33,7 @@
       in
       pkgs.buildEnv {
         name = "runtime-bins";
-        paths = componentConfig.packages ++ service.packages ++ [ etcFiles ];
+        paths = service.packages ++ runtimeConfig.packages ++ [ etcFiles ];
         pathsToLink = [
           "/bin"
           "/etc"
@@ -44,9 +44,9 @@
       WorkingDir = service.stateDir;
       User = if service.user == "root" then "root" else serviceName;
     }
-    // componentConfig.imageConfig
+    // runtimeConfig.imageConfig
     // {
-      Volumes = (componentConfig.imageConfig.Volumes or { }) // {
+      Volumes = (runtimeConfig.imageConfig.Volumes or { }) // {
         "${service.stateDir}" = { };
       };
       Env =
@@ -65,7 +65,7 @@
                 name = lib.head parts;
                 value = lib.concatStringsSep "=" (lib.tail parts);
               }
-            ) (componentConfig.imageConfig.Env or [ ])
+            ) (runtimeConfig.imageConfig.Env or [ ])
           );
 
           # NOTE: we merge Attrs to remove duplicate keys
@@ -75,7 +75,7 @@
     };
   };
 
-  startup.runOnStartup = lib.mkIf (componentConfig.setup != "") (
-    pkgs.writeShellScript "container-setup" componentConfig.setup
+  startup.runOnStartup = lib.mkIf (runtimeConfig.setup != "") (
+    pkgs.writeShellScript "container-setup" runtimeConfig.setup
   );
 }

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -33,7 +33,7 @@
       in
       pkgs.buildEnv {
         name = "runtime-bins";
-        paths = componentConfig.packages ++ [ etcFiles ];
+        paths = componentConfig.packages ++ service.packages ++ [ etcFiles ];
         pathsToLink = [
           "/bin"
           "/etc"

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -27,7 +27,9 @@
       type = lib.types.listOf lib.types.package;
       default = [ ];
       description = ''
-        List of packages to add to the NixOS system.
+        List of packages available in the NixOS system.
+
+        Use this option to add packages required by setup script.
 
         This is a convenience option equivalent to setting
         `nixosConfig.environment.systemPackages`.

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -38,6 +38,7 @@
     in
     {
       environment = service.environment;
+      path = service.packages;
       serviceConfig = lib.mkMerge [
         {
           PassEnvironment = lib.attrNames service.environment;

--- a/forge/modules/apps/services/runtimes/nixos/modules/setup.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/setup.nix
@@ -15,6 +15,7 @@ in
     before = [ "multi-user.target" ] ++ serviceUnits;
     requiredBy = serviceUnits;
     after = [ "network.target" ];
+    path = config.packages;
     script = config.setup;
     serviceConfig = {
       Type = "oneshot";

--- a/recipes/apps/qlever-app/recipe.nix
+++ b/recipes/apps/qlever-app/recipe.nix
@@ -46,6 +46,10 @@
         preStart = ''
           qlever-ui-manage makemigrations --merge && qlever-ui-manage migrate
         '';
+        packages = with pkgs; [
+          qlever-ui
+          subversion
+        ];
         ports = [
           "8080:8080"
         ];
@@ -76,6 +80,12 @@
           "start"
           "--run-in-foreground"
         ];
+        packages = with pkgs; [
+          curl
+          qlever
+          qlever-control
+          unzip
+        ];
         ports = [
           "7019:7019"
         ];
@@ -85,11 +95,6 @@
         container = {
           enable = true;
           components.qlever-ui = {
-            packages = with pkgs; [
-              qlever-ui
-              rsync
-              subversion
-            ];
             setup =
               # bash
               ''
@@ -102,14 +107,15 @@
 
                 rsync -a --chmod=u=rwX,go=rX --exclude='/db/' ${pkgs.qlever-ui}/opt/ "$WORKDIR"
               '';
+            packages = with pkgs; [
+              rsync # required by setup
+            ];
           };
+
           components.qlever-server = {
             packages = with pkgs; [
-              bash
-              coreutils
-              curl
-              qlever
-              qlever-control
+              bash # required by qlever index
+              coreutils # required by qlever index
             ];
           };
         };
@@ -117,29 +123,9 @@
         nixos = {
           enable = true;
           setup = apps.qlever.services.runtimes.container.components.qlever-ui.setup;
-          nixosConfig = {
-            systemd.services."qlever-setup" = {
-              path = with pkgs; [
-                rsync
-              ];
-            };
-
-            systemd.services."qlever-ui" = {
-              path = with pkgs; [
-                qlever-ui
-                subversion
-              ];
-            };
-
-            systemd.services."qlever-server" = {
-              path = with pkgs; [
-                curl
-                qlever
-                qlever-control
-                unzip
-              ];
-            };
-          };
+          packages = with pkgs; [
+            rsync # required by setup
+          ];
         };
       };
     };


### PR DESCRIPTION
Add `apps.*.services.components.*.packages` option which allows adding other
additional packages which might be required by service. Also improve and clarify configuration of packages required by runtimes `setup` script. 

To see the difference, compare qlever-app recipe file which requires multiple additional per-service packages and few packages for setup script as well 

* [before this PR](https://github.com/ngi-nix/forge/blob/864b7cf79835889e0a37e1845e7fceaf0f590f57/recipes/apps/qlever-app/recipe.nix)

* [after this PR](https://github.com/ngi-nix/forge/blob/service-components-packages/recipes/apps/qlever-app/recipe.nix)

With this PR, it is much more clear which packages are needed where.


In 32f373ea2fcc6bf487ce63e853e927eb186b72d9 , I did simple attribute rename to fix naming confusion.

### TODOs

- [x] update all package opts docs to clarify their scope and purpose
