### PR TITLE
+dev@simplicity(forge): remove no longer required `nixpkgs-pkgs`

### DIFF
--- a/forge/modules/builders/standard-builder/options.nix
+++ b/forge/modules/builders/standard-builder/options.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  nixpkgs-pkgs,
+  pkgs,
   ...
 }:
 {
@@ -51,7 +51,7 @@
 
     stdenv = lib.mkOption {
       type = lib.types.package;
-      default = nixpkgs-pkgs.stdenv;
+      default = pkgs.stdenv;
       defaultText = lib.literalExpression "pkgs.stdenv";
       example = lib.literalExpression "pkgs.stdenvNoCC";
       description = ''

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -16,10 +16,6 @@
         inputs = flakeInputs;
         # Extend `pkgs` with the per-system `packages`.
         pkgs = pkgs.extend (final: prev: config.packages);
-        # In rare cases (eg. when used in the `default` of an option),
-        # the non-extended `pkgs` must be used to avoid an `infinite recursion`,
-        # it is provided as `nixpkgs-pkgs`.
-        nixpkgs-pkgs = pkgs;
       };
       modules = [
         {

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -147,8 +147,7 @@
 
       # Common builder options (available to all builders)
       extraAttrs = lib.mkOption {
-        # `lazyAttrsOf` enables to use `pkgs` instead of `nixpkgs-pkgs`
-        # inside `extraAttrs`.
+        # `lazyAttrsOf` enables to use `pkgs` inside `extraAttrs`.
         type = lib.types.lazyAttrsOf lib.types.anything;
         default = { };
         description = ''

--- a/recipes/packages/hello/recipe.nix
+++ b/recipes/packages/hello/recipe.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   ...
 }:
 
@@ -18,6 +19,7 @@
 
     build.standardBuilder = {
       enable = true;
+      stdenv = pkgs.stdenv;
     };
 
     test.script = ''


### PR DESCRIPTION
`nixpkgs-pkgs` was needed at some point to avoid an infinite recursion in a previous revision of https://github.com/ngi-nix/forge/pull/448
but no longer is required, even in options' `default`.

`build.extraAttrs` still requires `lib.types.lazyAttrsOf` to avoid an infinite recursion when using `pkgs`.