### PR TITLE
feat: build all Go subpackages by default

### DIFF
--- a/forge/modules/builders/go-builder/options.nix
+++ b/forge/modules/builders/go-builder/options.nix
@@ -73,7 +73,7 @@
     };
     subPackages = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "." ];
+      default = [ ];
       description = ''
         List of Go packages to build.
 

--- a/recipes/packages/offen/recipe.nix
+++ b/recipes/packages/offen/recipe.nix
@@ -20,7 +20,6 @@
     build.goPackageBuilder = {
       enable = true;
       vendorHash = "sha256-AeQa5oaOEB/50aPCRq702vMEtEctwP+jU5C6zB+3XR0=";
-      subPackages = [ "cmd/offen" ];
       ldflags = [
         "-s"
         "-w"


### PR DESCRIPTION
Not only does this save us the trouble of explicitly adding each sub-package, but this also ensures that package tests are running correctly.

We can see this through the following example.

Before the change:

```
offen> Running phase: buildPhase
offen> Building subPackage ./cmd/offen
offen> buildPhase completed in 50 seconds
offen> Running phase: checkPhase
offen> ?        github.com/offen/offen/server/cmd/offen [no test files]
offen> checkPhase completed in 51 seconds
offen> Running phase: installPhase
offen> Running phase: fixupPhase
```

After the change:

```
offen> Running phase: buildPhase
offen> Building subPackage ./cmd/extract-strings
offen> Building subPackage ./cmd/offen
offen> Building subPackage ./config
offen> Building subPackage ./css
offen> Building subPackage ./keys
offen> Building subPackage ./locales
offen> Building subPackage ./mailer
offen> Building subPackage ./mailer/localmailer
offen> Building subPackage ./mailer/sendmailmailer
offen> Building subPackage ./mailer/smtpmailer
offen> Building subPackage ./persistence
offen> Building subPackage ./persistence/relational
offen> Building subPackage ./public
offen> Building subPackage ./ratelimiter
offen> Building subPackage ./router
offen> buildPhase completed in 1 minutes 4 seconds
offen> Running phase: checkPhase
offen> ok       github.com/offen/offen/server/config    0.004s
offen> ok       github.com/offen/offen/server/css       0.005s
offen> ok       github.com/offen/offen/server/keys      0.717s
offen> ok       github.com/offen/offen/server/persistence       3.053s
offen> ok       github.com/offen/offen/server/persistence/relational
0.058s
offen> ok       github.com/offen/offen/server/public    0.004s
offen> ok       github.com/offen/offen/server/ratelimiter       7.004s
offen> ok       github.com/offen/offen/server/router    0.020s
offen> checkPhase completed in 1 minutes 10 seconds
offen> Running phase: installPhase
offen> Running phase: fixupPhase
```