### PR TITLE
+forger@co-existence(forge): pin `inputs.ngi-forge.inputs` as `forge-inputs`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,7 @@
 
     flake-parts.lib.mkFlake
       {
-        inputs = inputs // {
-          # `flake.flakeModules` need to access some `inputs`
-          # that may not be declared in the `self` of users' `flake.nix` importing it,
-          # hence access those inputs through `inputs.ngi-forge.inputs`.
-          # This requires users to name the ngi-forge input `ngi-forge`.
-          ngi-forge = self;
-        };
+        inherit inputs;
       }
       (flakeArgs: {
         # Uncomment this to enable flake-parts debug.

--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ forge-inputs, ... }:
 {
   perSystem =
     {
@@ -9,8 +9,11 @@
     }:
 
     let
-      formatter = pkgs.callPackage ./formatter.nix { inherit inputs; };
-      devShell = pkgs.callPackage ./devshell.nix { inherit inputs formatter; };
+      formatter = pkgs.callPackage ./formatter.nix { inputs = forge-inputs; };
+      devShell = pkgs.callPackage ./devshell.nix {
+        inputs = forge-inputs;
+        inherit formatter;
+      };
 
       sphinxEnv = pkgs.python3.withPackages (pyPkgs: [
         pyPkgs.linkify-it-py
@@ -39,8 +42,8 @@
         pkgs.podman-compose
         pkgs.systemd-manager-tui
         pkgs.watchman
-        inputs.ngi-forge.packages.${system}.elm-watch
-        inputs.ngi-forge.packages.${system}.elm2nix
+        forge-inputs.self.packages.${system}.elm-watch
+        forge-inputs.self.packages.${system}.elm2nix
         sphinxEnv
       ];
     in

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ forge-inputs, ... }:
 {
   perSystem =
     {
@@ -13,7 +13,7 @@
     {
       packages = {
         elm-watch = pkgs.callPackage packages/elm-watch.nix { };
-        elm2nix = inputs.ngi-forge.inputs.elm2nix.packages.${system}.default;
+        elm2nix = forge-inputs.elm2nix.packages.${system}.default;
       };
     };
 }

--- a/forge/modules.nix
+++ b/forge/modules.nix
@@ -7,9 +7,17 @@
 let
   # A let-binding must be used to be able to both use and export `flakeModules`.
   flakeModules = {
-    base = {
+    base = flakeArgs: {
+      imports = [
+        {
+          # Expose the `inputs` from `ngi-forge`
+          # Note that this `inputs` is always `ngi-forge`'s,
+          # even when `flakeModules.base` has been imported in another `flake.nix`.
+          _module.args.forge-inputs = inputs;
+        }
+      ];
       options.perSystem = flake-parts-lib.mkPerSystemOption (
-        { system, ... }:
+        { system, forge-inputs, ... }:
         {
           imports = [
             # Definitions of options under `forge`.
@@ -20,13 +28,12 @@ let
             ./packages.nix
           ];
 
-          # Workaround flake-parts exposing only `inputs'`
-          # and forbidding `inputs` in `perSystem`,
-          # but we need access to `inputs.ngi-forge.inputs`.
-          _module.args.flakeInputs = inputs;
+          _module.args.self-inputs = flakeArgs.inputs;
+          _module.args.flake-parts-lib = flake-parts-lib;
+          _module.args.forge-inputs = inputs;
 
           # Do not require users to pin their own `inputs.nixpkgs`.
-          _module.args.pkgs = lib.mkDefault (inputs.ngi-forge.inputs.nixpkgs.legacyPackages.${system});
+          _module.args.pkgs = lib.mkDefault forge-inputs.nixpkgs.legacyPackages.${system};
         }
       );
     };

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -1,6 +1,6 @@
 {
   name,
-  inputs,
+  forge-inputs,
   pkgs,
 
   lib,
@@ -8,7 +8,7 @@
 }:
 {
   imports = [
-    (lib.modules.importApply (inputs.ngi-forge.inputs.nixpkgs + "/lib/services/config-data.nix") {
+    (lib.modules.importApply (forge-inputs.nixpkgs + "/lib/services/config-data.nix") {
       inherit pkgs;
     })
   ];

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   config,
   lib,
   system,
@@ -151,14 +151,14 @@
 
     result.evals = lib.mapAttrs (
       name: value:
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.passthru.evalNimiModule {
+      forge-inputs.nimi.packages.${system}.nimi.passthru.evalNimiModule {
         config = config.result.modules.${name};
       }
     ) app.services.components;
 
     result.recipes = lib.mapAttrs (
       name: value:
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkContainerImage {
+      forge-inputs.nimi.packages.${system}.nimi.mkContainerImage {
         config = config.result.modules.${name};
       }
     ) app.services.components;
@@ -170,7 +170,7 @@
         runtimeComponentPackages = config.components.${serviceName}.packages or [ ];
         binPaths = lib.makeBinPath ([ pkgs.coreutils ] ++ componentPackages ++ runtimeComponentPackages);
       in
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkBwrap {
+      forge-inputs.nimi.packages.${system}.nimi.mkBwrap {
         settings.bubblewrap.environment = service.environment // {
           PATH = binPaths;
         };

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  inputs,
+  forge-inputs,
   config,
   system,
   ...
@@ -137,7 +137,7 @@
       ];
     };
 
-    result.eval = inputs.ngi-forge.inputs.nixpkgs.lib.nixosSystem {
+    result.eval = forge-inputs.nixpkgs.lib.nixosSystem {
       inherit system;
       modules = lib.attrValues config.result.modules;
     };

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   app,
 
   lib,
@@ -8,7 +8,7 @@
 {
 
   imports = [
-    inputs.ngi-forge.inputs.nimi.nixosModules.default
+    forge-inputs.nimi.nixosModules.default
   ];
 
   nimi = lib.mapAttrs (serviceName: service: {

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   lib,
   pkgs,
   ...
@@ -137,7 +137,7 @@
       };
 
       debugShellHookAttr = {
-        shellHook = "source ${inputs.ngi-forge.inputs.nix-utils}/nix-develop-interactive.bash";
+        shellHook = "source ${forge-inputs.nix-utils}/nix-develop-interactive.bash";
       };
     };
   };

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -2,7 +2,8 @@
   config,
   lib,
   pkgs,
-  flakeInputs,
+  self-inputs,
+  forge-inputs,
   system,
   ...
 }:
@@ -13,8 +14,9 @@
     type = lib.types.submoduleWith {
       specialArgs = {
         inherit system;
-        inputs = flakeInputs;
         forgeConfig = config;
+        inputs = self-inputs;
+        inherit forge-inputs;
         pkgs = pkgs.extend (
           finalPkgs: previousPkgs:
           # Extend `pkgs` with the `packages` from the forge.

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -2,18 +2,17 @@
   config,
   lib,
   pkgs,
-  flakeInputs,
+  forge-inputs,
+  flake-parts-lib,
   ...
 }:
 
 let
-  inputs = flakeInputs;
   evalForgeModules =
     modules:
-    lib.evalModules {
-      modules = modules;
-      specialArgs = { inherit inputs; };
-    };
+    flake-parts-lib.evalFlakeModule {
+      inputs = forge-inputs;
+    } { imports = modules; };
 
   forgeOptionsDoc =
     modules:
@@ -32,7 +31,7 @@ let
 
   forgeApps = config.forge.apps;
   forgeOptions = forgeOptionsDoc [
-    inputs.ngi-forge.flakeModules.base
+    forge-inputs.self.flakeModules.base
   ];
 
   # Collect app icons into a derivation
@@ -77,7 +76,7 @@ in
         _forge-options
         ;
       inherit appIcons;
-      buildElmApplication = (inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
+      buildElmApplication = (forge-inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
       highlight-js = pkgs.callPackage ../flake/packages/highlight-js.nix { };
     };
 


### PR DESCRIPTION
A better understanding of how `inputs` is set enables to pin `ngi-forge`'s `inputs` as `forge-inputs` even in consumers' `flake.nix`.
So there's no more need to require them to use the specific `inputs.ngi-forge` name to pin `ngi-forge`.