### PR TITLE
+forger@co-existence(forge&ui): do not assume all recipes share the same repository or URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,12 +93,6 @@ jobs:
         with:
           name: ngi-forge
 
-      - name: Encode version information
-        run: |
-          commit="${{ github.event.pull_request.head.sha || github.sha }}"
-          commit=${commit:-master}
-          sed -i "s/master/$commit/g" ui/src/Main/Config.elm
-
       - name: Configure the baseUrl
         run: |
           sed -i "s|:baseUrl|/forge/|g" ui/src/Main/Model/Route.elm

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Setup GitHub Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - name: Encode version information
-        run: |
-          commit="$(git rev-parse HEAD)"
-          commit=${commit:-master}
-          sed -i "s/master/$commit/g" ui/src/Main/Config.elm
-
       - name: Configure the baseUrl
         run: |
           set -x

--- a/flake.nix
+++ b/flake.nix
@@ -44,13 +44,7 @@
 
     flake-parts.lib.mkFlake
       {
-        inputs = inputs // {
-          # `flake.flakeModules` need to access some `inputs`
-          # that may not be declared in the `self` of users' `flake.nix` importing it,
-          # hence access those inputs through `inputs.ngi-forge.inputs`.
-          # This requires users to name the ngi-forge input `ngi-forge`.
-          ngi-forge = self;
-        };
+        inherit inputs;
       }
       (flakeArgs: {
         # Uncomment this to enable flake-parts debug.

--- a/flake.nix
+++ b/flake.nix
@@ -73,17 +73,6 @@
         # > warning: unknown flake output 'flakeConfig'
         # Issue: https://github.com/NixOS/nix/issues/6381
         flake.flakeConfig = flakeArgs.config;
-
-        perSystem =
-          { system, ... }:
-          {
-            forge = {
-              repositoryUrl = "github:ngi-nix/forge";
-              recipeDirs = {
-                packages = "recipes/packages";
-                apps = "recipes/apps";
-              };
-            };
-          };
+        flake.flakeOptions = flakeArgs.options;
       });
 }

--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ forge-inputs, ... }:
 {
   perSystem =
     {
@@ -9,8 +9,11 @@
     }:
 
     let
-      formatter = pkgs.callPackage ./formatter.nix { inherit inputs; };
-      devShell = pkgs.callPackage ./devshell.nix { inherit inputs formatter; };
+      formatter = pkgs.callPackage ./formatter.nix { inputs = forge-inputs; };
+      devShell = pkgs.callPackage ./devshell.nix {
+        inputs = forge-inputs;
+        inherit formatter;
+      };
 
       sphinxEnv = pkgs.python3.withPackages (pyPkgs: [
         pyPkgs.linkify-it-py
@@ -39,8 +42,8 @@
         pkgs.podman-compose
         pkgs.systemd-manager-tui
         pkgs.watchman
-        inputs.ngi-forge.packages.${system}.elm-watch
-        inputs.ngi-forge.packages.${system}.elm2nix
+        forge-inputs.self.packages.${system}.elm-watch
+        forge-inputs.self.packages.${system}.elm2nix
         sphinxEnv
       ];
     in

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ forge-inputs, ... }:
 {
   perSystem =
     {
@@ -13,7 +13,7 @@
     {
       packages = {
         elm-watch = pkgs.callPackage packages/elm-watch.nix { };
-        elm2nix = inputs.ngi-forge.inputs.elm2nix.packages.${system}.default;
+        elm2nix = forge-inputs.elm2nix.packages.${system}.default;
       };
     };
 }

--- a/forge/modules.nix
+++ b/forge/modules.nix
@@ -7,9 +7,17 @@
 let
   # A let-binding must be used to be able to both use and export `flakeModules`.
   flakeModules = {
-    base = {
+    base = flakeArgs: {
+      imports = [
+        {
+          # Expose the `inputs` from `ngi-forge`
+          # Note that this `inputs` is always `ngi-forge`'s,
+          # even when `flakeModules.base` has been imported in another `flake.nix`.
+          _module.args.forge-inputs = inputs;
+        }
+      ];
       options.perSystem = flake-parts-lib.mkPerSystemOption (
-        { system, ... }:
+        { system, forge-inputs, ... }:
         {
           imports = [
             # Definitions of options under `forge`.
@@ -20,13 +28,12 @@ let
             ./packages.nix
           ];
 
-          # Workaround flake-parts exposing only `inputs'`
-          # and forbidding `inputs` in `perSystem`,
-          # but we need access to `inputs.ngi-forge.inputs`.
-          _module.args.flakeInputs = inputs;
+          _module.args.self-inputs = flakeArgs.inputs;
+          _module.args.flake-parts-lib = flake-parts-lib;
+          _module.args.forge-inputs = inputs;
 
           # Do not require users to pin their own `inputs.nixpkgs`.
-          _module.args.pkgs = lib.mkDefault (inputs.ngi-forge.inputs.nixpkgs.legacyPackages.${system});
+          _module.args.pkgs = lib.mkDefault forge-inputs.nixpkgs.legacyPackages.${system};
         }
       );
     };

--- a/forge/modules.nix
+++ b/forge/modules.nix
@@ -14,6 +14,7 @@ let
           # Note that this `inputs` is always `ngi-forge`'s,
           # even when `flakeModules.base` has been imported in another `flake.nix`.
           _module.args.forge-inputs = inputs;
+          _module.args.self-inputs = flakeArgs.inputs;
         }
       ];
       options.perSystem = flake-parts-lib.mkPerSystemOption (
@@ -23,14 +24,16 @@ let
             # Definitions of options under `forge`.
             modules/apps
             modules/packages.nix
+            modules/repositories.nix
             modules/forge.nix
             # Packages building the forge.
             ./packages.nix
           ];
 
-          _module.args.self-inputs = flakeArgs.inputs;
           _module.args.flake-parts-lib = flake-parts-lib;
           _module.args.forge-inputs = inputs;
+          _module.args.ngi-forge-lib = forge-inputs.self.lib;
+          _module.args.self-inputs = flakeArgs.inputs;
 
           # Do not require users to pin their own `inputs.nixpkgs`.
           _module.args.pkgs = lib.mkDefault forge-inputs.nixpkgs.legacyPackages.${system};
@@ -55,6 +58,7 @@ in
     # `flake.flakeModules` :: lazyAttrsOf deferredModule
     # are modules to generate outputs of a flake.nix
     inputs.flake-parts.flakeModules.flakeModules
+    modules/lib.nix
     flakeModules.default
   ];
   flake = {

--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -1,7 +1,12 @@
 {
   config,
   lib,
+  self-inputs,
+  forge-inputs,
+  ngi-forge-lib,
+  repositories,
   name,
+  options,
   specialArgs,
   ...
 }:
@@ -118,13 +123,13 @@
       description = "Test configuration.";
     };
 
-    # Warning(correctness): this currently remains empty,
-    # as it's currently ill-defined: a recipe can be a merge of multiple files.
-    recipePath = lib.mkOption {
-      type = lib.types.str;
-      default = "";
+    recipeUrls = lib.mkOption {
+      type = lib.types.anything;
       internal = true;
-      description = "Path to the recipe.nix file relative to the flake root. Set automatically by the recipe loader.";
+      default = ngi-forge-lib.recipeUrls [ self-inputs forge-inputs ] repositories (
+        lib.removeAttrs options [ "recipeUrls" ]
+      );
+      description = "URLs to where the recipe's options have been defined.";
     };
 
     result = {
@@ -135,7 +140,7 @@
         internal = true;
         readOnly = true;
         type = with lib.types; functionTo str;
-        default = self: "nixos-vm-config";
+        default = self: "result";
       };
     };
   };

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -20,7 +20,9 @@
               description = "Applications indexed by their `name`.";
               type = lib.types.attrsOf (
                 lib.types.submoduleWith {
-                  inherit specialArgs;
+                  specialArgs = specialArgs // {
+                    inherit (forgeArgs.config) repositories;
+                  };
                   modules = [ ./app.nix ];
                 }
               );

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -1,6 +1,6 @@
 {
   name,
-  inputs,
+  forge-inputs,
   pkgs,
 
   lib,
@@ -8,7 +8,7 @@
 }:
 {
   imports = [
-    (lib.modules.importApply (inputs.ngi-forge.inputs.nixpkgs + "/lib/services/config-data.nix") {
+    (lib.modules.importApply (forge-inputs.nixpkgs + "/lib/services/config-data.nix") {
       inherit pkgs;
     })
   ];

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   config,
   lib,
   system,
@@ -151,14 +151,14 @@
 
     result.evals = lib.mapAttrs (
       name: value:
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.passthru.evalNimiModule {
+      forge-inputs.nimi.packages.${system}.nimi.passthru.evalNimiModule {
         config = config.result.modules.${name};
       }
     ) app.services.components;
 
     result.recipes = lib.mapAttrs (
       name: value:
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkContainerImage {
+      forge-inputs.nimi.packages.${system}.nimi.mkContainerImage {
         config = config.result.modules.${name};
       }
     ) app.services.components;
@@ -170,7 +170,7 @@
         runtimeComponentPackages = config.components.${serviceName}.packages or [ ];
         binPaths = lib.makeBinPath ([ pkgs.coreutils ] ++ componentPackages ++ runtimeComponentPackages);
       in
-      inputs.ngi-forge.inputs.nimi.packages.${system}.nimi.mkBwrap {
+      forge-inputs.nimi.packages.${system}.nimi.mkBwrap {
         settings.bubblewrap.environment = service.environment // {
           PATH = binPaths;
         };

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -215,7 +215,7 @@
           install -D ${effectiveComposeFile} $out/${app.name}/compose.yaml
         '';
 
-        cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${builtins.hashString "md5" specialArgs.forgeConfig.forge.repositoryUrl}/tmp";
+        cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${builtins.hashString "md5" specialArgs.forgeConfig.forge.repository.nixUrl}/tmp";
 
         run-podman = pkgs.writeShellScriptBin "run-podman" ''
           CACHE_DIR="${cacheDir}"

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  inputs,
+  forge-inputs,
   config,
   system,
   ...
@@ -137,7 +137,7 @@
       ];
     };
 
-    result.eval = inputs.ngi-forge.inputs.nixpkgs.lib.nixosSystem {
+    result.eval = forge-inputs.nixpkgs.lib.nixosSystem {
       inherit system;
       modules = lib.attrValues config.result.modules;
     };

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   app,
 
   lib,
@@ -8,7 +8,7 @@
 {
 
   imports = [
-    inputs.ngi-forge.inputs.nimi.nixosModules.default
+    forge-inputs.nimi.nixosModules.default
   ];
 
   nimi = lib.mapAttrs (serviceName: service: {

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -1,5 +1,5 @@
 {
-  inputs,
+  forge-inputs,
   lib,
   pkgs,
   ...
@@ -137,7 +137,7 @@
       };
 
       debugShellHookAttr = {
-        shellHook = "source ${inputs.ngi-forge.inputs.nix-utils}/nix-develop-interactive.bash";
+        shellHook = "source ${forge-inputs.nix-utils}/nix-develop-interactive.bash";
       };
     };
   };

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -2,7 +2,8 @@
   config,
   lib,
   pkgs,
-  flakeInputs,
+  self-inputs,
+  forge-inputs,
   system,
   ...
 }:
@@ -13,8 +14,9 @@
     type = lib.types.submoduleWith {
       specialArgs = {
         inherit system;
-        inputs = flakeInputs;
         forgeConfig = config;
+        inputs = self-inputs;
+        inherit forge-inputs;
         pkgs = pkgs.extend (
           finalPkgs: previousPkgs:
           # Extend `pkgs` with the `packages` from the forge.

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -2,9 +2,10 @@
   config,
   lib,
   pkgs,
+  system,
   self-inputs,
   forge-inputs,
-  system,
+  ngi-forge-lib,
   ...
 }:
 {
@@ -15,8 +16,9 @@
       specialArgs = {
         inherit system;
         forgeConfig = config;
-        inputs = self-inputs;
         inherit forge-inputs;
+        inherit ngi-forge-lib;
+        inherit self-inputs;
         pkgs = pkgs.extend (
           finalPkgs: previousPkgs:
           # Extend `pkgs` with the `packages` from the forge.
@@ -31,50 +33,7 @@
           }
         );
       };
-      modules = [
-        {
-          options = {
-
-            repositoryUrl = lib.mkOption {
-              type = lib.types.str;
-              default = "github:ngi-nix/forge";
-              description = ''
-                NGI Forge repository URL.
-              '';
-              example = "github:ngi-nix/forge";
-            };
-
-            recipeDirs = {
-              packages = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = "recipes/packages";
-                description = ''
-                  Directory containing package recipe files.
-                  Each recipe should be a recipe.nix file in a subdirectory
-                  (e.g., recipes/packages/hello/recipe.nix).
-
-                  Set to null to disable automatic package recipe loading.
-                '';
-                example = "recipes/packages";
-              };
-
-              apps = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = "recipes/apps";
-                description = ''
-                  Directory containing app recipe files.
-                  Each recipe should be a recipe.nix file in a subdirectory
-                  (e.g., recipes/apps/my-app/recipe.nix).
-
-                  Set to null to disable automatic app recipe loading.
-                '';
-                example = "recipes/apps";
-              };
-            };
-
-          };
-        }
-      ];
+      modules = [ ];
     };
   };
 }

--- a/forge/modules/lib.nix
+++ b/forge/modules/lib.nix
@@ -1,0 +1,65 @@
+{
+  forge-inputs,
+  lib,
+  config,
+  ...
+}:
+{
+  flake.lib = {
+    # recipeFiles :: Options -> listOf path
+    # `recipeFiles options` returns the paths used to define
+    # the given `options` and its sub-`options` recursively.
+    recipeFiles =
+      let
+        loop =
+          options:
+          lib.unique (
+            lib.concatMap (
+              v:
+              lib.optionals (v ? "files") v.files ++ lib.optionals (v ? "type") (loop (v.type.getSubOptions [ ]))
+            ) (lib.attrValues options)
+          );
+      in
+      loop;
+
+    # recipeInputs :: [{ [String] :: Inputs }] -> { [String] :: Repository } -> Options -> [URL]
+    # `recipeInputs inputs repositories options`
+    # returns URLs to the recipe files found in `options`'s `files`.
+    recipeUrls =
+      inputs: repositories: options:
+      let
+        inputPaths = lib.concatMap (lib.mapAttrsToList (n: v: v.outPath)) inputs;
+      in
+      lib.concatMap (
+        recipePath:
+        let
+          matchingInput = lib.findFirst (input: lib.hasPrefix input recipePath) null inputPaths;
+          file = lib.removePrefix "${matchingInput}/" recipePath;
+          inputString = lib.unsafeDiscardStringContext matchingInput;
+        in
+        lib.optional
+          (
+            matchingInput != null
+            && lib.hasAttr inputString repositories
+            # Remove files providing default definitions from ngi-forge
+            && (matchingInput != forge-inputs.self.outPath || !(lib.hasPrefix "forge/" file))
+          )
+          # Warning(portability): assume the file goes at the end of the URL
+          # to avoid using a function.
+          "${repositories.${inputString}.treeUrl}/${file}"
+      ) (config.flake.lib.recipeFiles options);
+
+    # `sourceInfoRef input` returns a commit reference of the given `input`
+    # or some approximation.
+    sourceInfoRef =
+      input:
+      if input.sourceInfo ? "shortRev" then
+        input.sourceInfo.shortRev
+      else if input.sourceInfo ? "dirtyShortRev" then
+        lib.removeSuffix "-dirty" input.sourceInfo.dirtyShortRev
+      else if input.sourceInfo ? "rev" then
+        input.sourceInfo.rev
+      else
+        "@";
+  };
+}

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -32,7 +32,9 @@
               '';
               type = lib.types.attrsOf (
                 lib.types.submoduleWith {
-                  inherit specialArgs;
+                  specialArgs = specialArgs // {
+                    inherit (forgeArgs.config) repositories;
+                  };
                   modules = [ packages/package.nix ];
                 }
               );

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -1,5 +1,10 @@
 {
   lib,
+  self-inputs,
+  forge-inputs,
+  ngi-forge-lib,
+  repositories,
+  options,
   name,
   ...
 }:
@@ -261,11 +266,13 @@
       };
     };
 
-    recipePath = lib.mkOption {
-      type = lib.types.str;
-      default = "";
+    recipeUrls = lib.mkOption {
+      type = lib.types.anything;
       internal = true;
-      description = "Path to the recipe.nix file relative to the flake root. Set automatically by the recipe loader.";
+      default = ngi-forge-lib.recipeUrls [ self-inputs forge-inputs ] repositories (
+        lib.removeAttrs options [ "recipeUrls" ]
+      );
+      description = "URLs to where the recipe's options have been defined.";
     };
   };
 }

--- a/forge/modules/repositories.nix
+++ b/forge/modules/repositories.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  forge-inputs,
+  self-inputs,
+  ...
+}:
+{
+  options.forge = lib.mkOption {
+    type = lib.types.submoduleWith {
+      modules = [
+        (
+          { specialArgs, ... }@forgeArgs:
+          {
+            options.repository = lib.mkOption {
+              type = lib.types.submoduleWith {
+                inherit specialArgs;
+                modules = [ repositories/repository.nix ];
+              };
+              internal = true;
+              readOnly = true;
+              default = forgeArgs.config.repositories.${lib.unsafeDiscardStringContext self-inputs.self};
+              defaultText = "forgeArgs.config.repositories.\${lib.unsafeDiscardStringContext self-inputs.self.outPath}";
+              description = ''
+                Metadata of the final repository (`inputs.self`)
+                Used in the Web interface to display nix commands.
+              '';
+            };
+
+            options.repositories = lib.mkOption {
+              default = { };
+              description = ''
+                Repositories' metadata indexed by their Nix store path.
+                Used to build link to recipe files (`{apps,packages}.''${name}.recipeUrls`).
+              '';
+              type = lib.types.attrsOf (
+                lib.types.submoduleWith {
+                  inherit specialArgs;
+                  modules = [
+                    repositories/repository.nix
+                  ];
+                }
+              );
+            };
+            config.repositories = {
+              ${lib.unsafeDiscardStringContext forge-inputs.self.outPath} =
+                { config, ... }:
+                {
+                  archiveUrl = config.homeUrl + "/archive/" + config.commitRef + ".tar.gz";
+                  commitRef = forge-inputs.self.lib.sourceInfoRef forge-inputs.self;
+                  gitUrl = config.homeUrl;
+                  homeUrl = "https://github.com/" + config.path;
+                  path = "ngi-nix/forge";
+                  nixUrl = "github:" + config.path + "/" + config.commitRef;
+                  nixUrlLatest = "github:" + config.path + "/" + "master";
+                  treeUrl = config.homeUrl + "/tree/" + config.commitRef;
+                };
+            };
+          }
+        )
+      ];
+    };
+  };
+}

--- a/forge/modules/repositories/repository.nix
+++ b/forge/modules/repositories/repository.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  self-inputs,
+  forge-inputs,
+  ...
+}:
+{
+  options = {
+    archiveUrl = lib.mkOption {
+      type = lib.types.str;
+      default = config.homeUrl + "/archive/" + config.commitRef + ".tar.gz";
+      defaultText = lib.literalExpression ''config.homeUrl + "/archive/" + forge-inputs.self.lib.sourceInfoRef + ".tar.gz"'';
+      description = ''
+        URL to get an archive of the repository.
+      '';
+    };
+    commitRef = lib.mkOption {
+      type = lib.types.str;
+      default = forge-inputs.self.lib.sourceInfoRef self-inputs.self;
+      defaultText = lib.literalExpression "forge-inputs.self.lib.sourceInfoRef inputs.self";
+      description = ''
+        Reference to the commit of the repository.
+      '';
+    };
+    gitUrl = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = config.homeUrl;
+      defaultText = lib.literalExpression "config.homeUrl";
+      description = ''
+        URL to git the repository.
+      '';
+      example = "https://github.com/ngi-nix/forge";
+    };
+    homeUrl = lib.mkOption {
+      type = lib.types.str;
+      defaultText = lib.literalExpression ''"https://github.com/" + config.path'';
+      description = ''
+        URL to the home of the repository.
+      '';
+      example = "https://github.com/my-user/my-repo";
+    };
+    path = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        Name of the repository.
+      '';
+      example = "ngi-nix/forge";
+    };
+    nixUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "github:" + config.path + "/" + config.commitRef;
+      defaultText = lib.literalExpression ''"github:" + config.path + "/" + config.commitRef'';
+      description = ''
+        URL to fetch the repository using `nix flake`.
+      '';
+      example = "github:ngi-nix/forge";
+    };
+    nixUrlLatest = lib.mkOption {
+      type = lib.types.str;
+      default = "github:" + config.path + "/" + "main";
+      defaultText = lib.literalExpression ''"github:" + config.path + "/" + "main"'';
+      description = ''
+        URL to fetch the latest revision of the repository using `nix flake`.
+      '';
+      example = "github:ngi-nix/forge";
+    };
+    treeUrl = lib.mkOption {
+      type = lib.types.str;
+      default = config.homeUrl + "/tree/" + config.commitRef;
+      defaultText = lib.literalExpression ''config.homeUrl + "/tree/" + config.commitRef'';
+      description = ''
+        URL to browse the tree of the repository.
+      '';
+    };
+  };
+}

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -2,18 +2,17 @@
   config,
   lib,
   pkgs,
-  flakeInputs,
+  forge-inputs,
+  flake-parts-lib,
   ...
 }:
 
 let
-  inputs = flakeInputs;
   evalForgeModules =
     modules:
-    lib.evalModules {
-      modules = modules;
-      specialArgs = { inherit inputs; };
-    };
+    flake-parts-lib.evalFlakeModule {
+      inputs = forge-inputs;
+    } { imports = modules; };
 
   forgeOptionsDoc =
     modules:
@@ -32,7 +31,7 @@ let
 
   forgeApps = config.forge.apps;
   forgeOptions = forgeOptionsDoc [
-    inputs.ngi-forge.flakeModules.base
+    forge-inputs.self.flakeModules.base
   ];
 
   # Collect app icons into a derivation
@@ -77,7 +76,7 @@ in
         _forge-options
         ;
       inherit appIcons;
-      buildElmApplication = (inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
+      buildElmApplication = (forge-inputs.elm2nix.lib.elm2nix pkgs).buildElmApplication;
       highlight-js = pkgs.callPackage ../flake/packages/highlight-js.nix { };
     };
 

--- a/templates/consumer/flake.nix
+++ b/templates/consumer/flake.nix
@@ -14,18 +14,28 @@
 
   outputs =
     inputs:
-    inputs.ngi-forge.inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    inputs.ngi-forge.inputs.flake-parts.lib.mkFlake { inherit inputs; } (flakeArgs: {
       systems = [ "x86_64-linux" ];
       imports = [ inputs.ngi-forge.flakeModules.default ];
 
-      debug = true;
+      # To access the toplevel `config` while debugging in `nix repl .`
+      flake.flakeConfig = flakeArgs.config;
 
       perSystem =
-        { system, pkgs, ... }:
+        {
+          system,
+          pkgs,
+          lib,
+          ...
+        }:
         {
           forge = {
             imports = [ (inputs.ngi-forge.inputs.import-tree ./recipes) ];
+            repositories.${lib.unsafeDiscardStringContext inputs.self} = repo: {
+              homeUrl = "https://github.com/" + repo.config.path;
+              path = "my-user/my-repository";
+            };
           };
         };
-    };
+    });
 }

--- a/templates/provider/flake.nix
+++ b/templates/provider/flake.nix
@@ -14,16 +14,23 @@
 
   outputs =
     inputs:
-    inputs.ngi-forge.inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    inputs.ngi-forge.inputs.flake-parts.lib.mkFlake { inherit inputs; } (flakeArgs: {
       systems = [ "x86_64-linux" ];
       imports = [ inputs.ngi-forge.flakeModules.base ];
 
+      # To access the toplevel `config` while debugging in `nix repl .`
+      flake.flakeConfig = flakeArgs.config;
+
       perSystem =
-        { system, ... }:
+        { system, lib, ... }:
         {
           forge = {
             imports = [ (inputs.ngi-forge.inputs.import-tree ./recipes) ];
+            repositories.${lib.unsafeDiscardStringContext inputs.self} = repo: {
+              homeUrl = "https://github.com/" + repo.config.path;
+              path = "my-user/my-repository";
+            };
           };
         };
-    };
+    });
 }

--- a/ui/src/Main/Config.elm
+++ b/ui/src/Main/Config.elm
@@ -4,73 +4,32 @@ import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
 import Main.Config.App as Config exposing (..)
 import Main.Config.Package as Config exposing (..)
+import Main.Config.Repository as Config exposing (..)
 import Main.Helpers.Nix exposing (..)
 import Main.Model.Error exposing (..)
-import Url exposing (Url)
-
-
-commit : String
-commit =
-    "master"
-
-
-{-| Note: master is < 8 chars
--}
-shortCommit : String
-shortCommit =
-    String.left 8 commit
-
-
-{-| Warning(portability): `Url` only supports HTTP(s) protocol.
--}
-type alias UrlHttp =
-    Url
 
 
 type alias Config =
-    { config_repository : NixUrl
-    , config_recipe : ConfigRecipe
-    , config_apps : Dict AppName App
+    { config_apps : Dict AppName App
     , config_packages : Dict PackageName Package
+    , config_repository : Repository
     }
 
 
 initConfig : Config
 initConfig =
-    { config_repository = "github:ngi-nix/forge"
-    , config_recipe = initRecipe
-    , config_apps = Dict.empty
+    { config_apps = Dict.empty
     , config_packages = Dict.empty
+    , config_repository = Config.initRepository
     }
 
 
 decodeConfig : Decoder Config
 decodeConfig =
-    Decode.map4 Config
-        (Decode.field "repositoryUrl" Decode.string)
-        (Decode.field "recipeDirs" decodeConfigRecipe)
+    Decode.map3 Config
         (Decode.field "apps" (Decode.dict Config.decodeApp))
         (Decode.field "packages" (Decode.dict Config.decodePackage))
-
-
-type alias ConfigRecipe =
-    { configRecipe_apps : Directory
-    , configRecipe_packages : Directory
-    }
-
-
-initRecipe : ConfigRecipe
-initRecipe =
-    { configRecipe_apps = ""
-    , configRecipe_packages = ""
-    }
-
-
-decodeConfigRecipe : Decoder ConfigRecipe
-decodeConfigRecipe =
-    Decode.map2 ConfigRecipe
-        (Decode.field "apps" decodeDirectory)
-        (Decode.field "packages" decodeDirectory)
+        (Decode.field "repository" decodeRepository)
 
 
 type alias Path =

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -15,7 +15,7 @@ type alias App =
     , app_services : AppServices
     , app_ngi : Ngi
     , app_links : AppLinks
-    , app_recipePath : String
+    , app_recipeUrls : List String
     }
 
 
@@ -31,7 +31,7 @@ decodeApp =
         |> Decode.andMap (Decode.field "services" decodeAppServices)
         |> Decode.andMap (Decode.field "ngi" decodeNgi)
         |> Decode.andMap (Decode.field "links" decodeAppLinks)
-        |> Decode.andMap (Decode.field "recipePath" Decode.string)
+        |> Decode.andMap (Decode.field "recipeUrls" (Decode.list Decode.string))
 
 
 type alias AppName =

--- a/ui/src/Main/Config/Package.elm
+++ b/ui/src/Main/Config/Package.elm
@@ -12,7 +12,7 @@ type alias Package =
     , package_mainProgram : String
     , package_licenses : List PackageLicense
     , package_source : PackageSource
-    , package_recipePath : String
+    , package_recipeUrls : List String
     }
 
 
@@ -26,7 +26,7 @@ decodePackage =
         (Decode.field "mainProgram" Decode.string)
         (Decode.field "license" decodeLicenses)
         (Decode.field "source" decodeSource)
-        (Decode.field "recipePath" Decode.string)
+        (Decode.field "recipeUrls" (Decode.list Decode.string))
 
 
 type alias PackageName =

--- a/ui/src/Main/Config/Repository.elm
+++ b/ui/src/Main/Config/Repository.elm
@@ -1,0 +1,42 @@
+module Main.Config.Repository exposing (..)
+
+import Json.Decode as Decode exposing (Decoder)
+import Main.Helpers.String exposing (..)
+
+
+type alias Repository =
+    { repository_archiveUrl : String
+    , repository_commitRef : String
+    , repository_gitUrl : String
+    , repository_homeUrl : String
+    , repository_nixUrl : String
+    , repository_nixUrlLatest : String
+    , repository_path : String
+    , repository_treeUrl : String
+    }
+
+
+initRepository : Repository
+initRepository =
+    { repository_archiveUrl = ""
+    , repository_commitRef = ""
+    , repository_gitUrl = ""
+    , repository_homeUrl = ""
+    , repository_nixUrl = ""
+    , repository_nixUrlLatest = ""
+    , repository_path = ""
+    , repository_treeUrl = ""
+    }
+
+
+decodeRepository : Decoder Repository
+decodeRepository =
+    Decode.map8 Repository
+        (Decode.field "archiveUrl" Decode.string)
+        (Decode.field "commitRef" Decode.string)
+        (Decode.field "gitUrl" Decode.string)
+        (Decode.field "homeUrl" Decode.string)
+        (Decode.field "nixUrl" Decode.string)
+        (Decode.field "nixUrlLatest" Decode.string)
+        (Decode.field "path" Decode.string)
+        (Decode.field "treeUrl" Decode.string)

--- a/ui/src/Main/Helpers/Html.elm
+++ b/ui/src/Main/Helpers/Html.elm
@@ -1,6 +1,6 @@
 module Main.Helpers.Html exposing (..)
 
-import Html exposing (Attribute, Html, button, code, div, node, pre, text)
+import Html exposing (Attribute, Html, button, div, node)
 import Html.Attributes exposing (attribute, class)
 import Html.Events
 import Json.Decode

--- a/ui/src/Main/Helpers/Nix.elm
+++ b/ui/src/Main/Helpers/Nix.elm
@@ -9,27 +9,6 @@ import String
 import Tree
 
 
-type alias NixUrl =
-    String
-
-
-showNixUrl : NixUrl -> String
-showNixUrl url =
-    if String.startsWith "github:" url then
-        "https://github.com/" ++ String.dropLeft 7 url
-
-    else if String.startsWith "path:" url then
-        "#"
-
-    else
-        url
-
-
-showGithubRepoSlug : NixUrl -> String
-showGithubRepoSlug url =
-    String.dropLeft 7 url
-
-
 {-| Eg. `"apps.*.services"`
 -}
 type alias NixAttrId =

--- a/ui/src/Main/View.elm
+++ b/ui/src/Main/View.elm
@@ -246,19 +246,19 @@ viewPoweredBy model =
         , span []
             [ text " Contribute or report issues at "
             , a
-                [ href (model.model_config.config_repository |> showNixUrl)
+                [ href model.model_config.config_repository.repository_homeUrl
                 , target "_blank"
                 ]
-                [ text (model.model_config.config_repository |> showGithubRepoSlug) ]
+                [ text model.model_config.config_repository.repository_path ]
             , text "."
             ]
         , span []
             [ text " Version "
             , a
-                [ href ((model.model_config.config_repository |> showNixUrl) ++ "/tree/" ++ commit)
+                [ href model.model_config.config_repository.repository_treeUrl
                 , target "_blank"
                 ]
-                [ text shortCommit ]
+                [ text model.model_config.config_repository.repository_commitRef ]
             , text "."
             ]
         ]

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -16,6 +16,7 @@ import Main.Model.Route exposing (..)
 import Main.Update exposing (..)
 import Main.Update.Types exposing (..)
 import Main.View.Page.App.Run exposing (..)
+import Maybe.Extra as Maybe
 
 
 viewPageApp : Model -> PageApp -> Html Update
@@ -217,23 +218,20 @@ viewPageAppResources model pageApp =
             ]
         , ul [ class "", style "padding-left" "10px" ]
             (List.concat
-                [ viewPageAppResourcesItem "Homepage" pageApp.pageApp_app.app_links.appLinks_website
-                , viewPageAppResourcesItem "Documentation" pageApp.pageApp_app.app_links.appLinks_docs
-                , viewPageAppResourcesItem "Source Repository" pageApp.pageApp_app.app_links.appLinks_source
-                , viewPageAppResourcesItem "Forge Recipe" (Just (showAppRecipeLink model pageApp.pageApp_app))
+                [ viewPageAppResourcesItem "Homepage" (pageApp.pageApp_app.app_links.appLinks_website |> Maybe.toList)
+                , viewPageAppResourcesItem "Documentation" (pageApp.pageApp_app.app_links.appLinks_docs |> Maybe.toList)
+                , viewPageAppResourcesItem "Source Repository" (pageApp.pageApp_app.app_links.appLinks_source |> Maybe.toList)
+                , viewPageAppResourcesItem "Forge Recipe" pageApp.pageApp_app.app_recipeUrls
                 ]
             )
         ]
 
 
-viewPageAppResourcesItem : String -> Maybe String -> List (Html msg)
-viewPageAppResourcesItem name value =
-    case value of
-        Nothing ->
-            []
-
-        Just url ->
-            [ li [ class "list-group-item bg-transparent px-0 mb-3" ]
+viewPageAppResourcesItem : String -> List String -> List (Html msg)
+viewPageAppResourcesItem name =
+    List.map
+        (\url ->
+            li [ class "list-group-item bg-transparent px-0 mb-3" ]
                 [ a
                     [ href url
                     , target "_blank"
@@ -241,16 +239,7 @@ viewPageAppResourcesItem name value =
                     ]
                     [ text name ]
                 ]
-            ]
-
-
-showAppRecipeLink : Model -> App -> String
-showAppRecipeLink model app =
-    String.join "/"
-        [ model.model_config.config_repository |> showNixUrl
-        , "blob/" ++ commit
-        , app.app_recipePath
-        ]
+        )
 
 
 viewPageAppNgiGrants : Model -> PageApp -> Html msg

--- a/ui/src/Main/View/Page/App/Run.elm
+++ b/ui/src/Main/View/Page/App/Run.elm
@@ -271,7 +271,7 @@ viewPageAppRunProgram model pageApp =
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
                         [ "nix run "
-                        , showForgeInputFlakes model
+                        , model.model_config.config_repository.repository_nixUrl
                         , "#"
                         , pageApp.pageApp_app.app_pname
                         , ".program"
@@ -279,7 +279,7 @@ viewPageAppRunProgram model pageApp =
 
                     PreferencesInstall_NixTraditional ->
                         [ "nix-shell \\\n"
-                        , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                        , "  -I forge='" ++ model.model_config.config_repository.repository_archiveUrl ++ "' \\\n"
                         , "  -p '(import <forge> {})"
                         , "."
                         , pageApp.pageApp_app.app_pname
@@ -311,14 +311,14 @@ viewPageAppRunShell model pageApp =
                 (case model.model_preferences.preferences_install of
                     PreferencesInstall_NixFlakes ->
                         [ "nix shell "
-                        , showForgeInputFlakes model
+                        , model.model_config.config_repository.repository_nixUrl
                         , "#"
                         , pageApp.pageApp_app.app_pname
                         ]
 
                     PreferencesInstall_NixTraditional ->
                         [ "nix-shell \\\n"
-                        , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                        , "  -I forge='" ++ model.model_config.config_repository.repository_archiveUrl ++ "' \\\n"
                         , "  -p '(import <forge> {})"
                         , "."
                         , pageApp.pageApp_app.app_pname
@@ -339,7 +339,7 @@ viewPageAppRunContainer model pageApp =
                     PreferencesInstall_NixFlakes ->
                         String.concat
                             [ "nix run "
-                            , showForgeInputFlakes model
+                            , model.model_config.config_repository.repository_nixUrl
                             , "#"
                             , pageApp.pageApp_app.app_pname
                             , ".container"
@@ -348,7 +348,7 @@ viewPageAppRunContainer model pageApp =
                     PreferencesInstall_NixTraditional ->
                         String.concat
                             [ "nix-build \\\n"
-                            , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                            , "  -I forge='" ++ model.model_config.config_repository.repository_archiveUrl ++ "' \\\n"
                             , "  -E '(import <forge> {})"
                             , "."
                             , pageApp.pageApp_app.app_pname
@@ -374,7 +374,7 @@ viewPageAppRunContainerBuildOCI model pageApp =
                     String.join "\n"
                         [ String.concat
                             [ "nix build "
-                            , showForgeInputFlakes model
+                            , model.model_config.config_repository.repository_nixUrl
                             , "#"
                             , pageApp.pageApp_app.app_pname
                             , ".container"
@@ -386,7 +386,7 @@ viewPageAppRunContainerBuildOCI model pageApp =
                 PreferencesInstall_NixTraditional ->
                     String.concat
                         [ "nix-build \\\n"
-                        , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                        , "  -I forge='" ++ model.model_config.config_repository.repository_archiveUrl ++ "' \\\n"
                         , "  -E '(import <forge> {})"
                         , "."
                         , pageApp.pageApp_app.app_pname
@@ -408,7 +408,7 @@ viewPageAppRunNixOS model pageApp =
                 PreferencesInstall_NixFlakes ->
                     String.concat
                         [ "nix run "
-                        , showForgeInputFlakes model
+                        , model.model_config.config_repository.repository_nixUrl
                         , "#"
                         , pageApp.pageApp_app.app_pname
                         , ".vm"
@@ -418,7 +418,7 @@ viewPageAppRunNixOS model pageApp =
                     String.join "\n"
                         [ String.concat
                             [ "nix-build \\\n"
-                            , "  -I forge=\"" ++ showForgeInputTraditional model ++ " \\\n"
+                            , "  -I forge='" ++ model.model_config.config_repository.repository_archiveUrl ++ "' \\\n"
                             , "  -E '(import <forge> {})"
                             , "."
                             , pageApp.pageApp_app.app_pname
@@ -447,7 +447,7 @@ viewPageAppRunNixOSModule model pageApp =
                 PreferencesInstall_NixFlakes ->
                     String.join "\n"
                         [ "{"
-                        , "  inputs.forge.url = \"" ++ showForgeInputFlakesLatest model ++ "\";"
+                        , "  inputs.forge.url = \"" ++ model.model_config.config_repository.repository_nixUrlLatest ++ "\";"
                         , ""
                         , "  outputs = { nixpkgs, forge, ... }: {"
                         , "    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {"
@@ -461,15 +461,11 @@ viewPageAppRunNixOSModule model pageApp =
                         ]
 
                 PreferencesInstall_NixTraditional ->
-                    let
-                        forgeUrl =
-                            (model.model_config.config_repository |> showNixUrl) ++ "/archive/" ++ commit ++ ".tar.gz"
-                    in
                     String.join "\n"
                         [ "{ config, pkgs, ... }:"
                         , ""
                         , "let"
-                        , "  forge-url = \"" ++ forgeUrl ++ "\";"
+                        , "  forge-url = \"" ++ model.model_config.config_repository.repository_archiveUrl ++ "\";"
                         , "  forge = import \"${builtins.fetchTarball forge-url}\" { inherit pkgs; };"
                         , "in {"
                         , "  imports = ["
@@ -478,35 +474,4 @@ viewPageAppRunNixOSModule model pageApp =
                         , "  # ..."
                         , "}"
                         ]
-        ]
-
-
-showForgeInputTraditional : Model -> String
-showForgeInputTraditional model =
-    String.concat
-        [ model.model_config.config_repository |> showNixUrl
-        , "/archive/"
-        , shortCommit
-        , ".tar.gz\""
-        ]
-
-
-showForgeInputFlakes : Model -> String
-showForgeInputFlakes model =
-    String.concat
-        [ model.model_config.config_repository
-        , case commit of
-            "master" ->
-                ""
-
-            _ ->
-                "/" ++ shortCommit
-        ]
-
-
-showForgeInputFlakesLatest : Model -> String
-showForgeInputFlakesLatest model =
-    String.concat
-        [ model.model_config.config_repository
-        , "/master"
         ]

--- a/ui/src/Main/View/Page/Packages.elm
+++ b/ui/src/Main/View/Page/Packages.elm
@@ -99,14 +99,18 @@ viewPagePackagesItem model pagePackages package =
         , div [ class "d-flex gap-3" ]
             (List.append
                 (package.package_licenses |> List.map viewLicense)
-                [ a
-                    [ href <| showPackageRecipeLink model package
-                    , target "_blank"
-                    , rel "noopener"
-                    , onClickStopPropagation
-                    ]
-                    [ text "Forge Recipe" ]
-                ]
+                (package.package_recipeUrls
+                    |> List.map
+                        (\recipeUrl ->
+                            a
+                                [ href recipeUrl
+                                , target "_blank"
+                                , rel "noopener"
+                                , onClickStopPropagation
+                                ]
+                                [ text "Forge Recipe" ]
+                        )
+                )
             )
         ]
 
@@ -130,12 +134,3 @@ viewLicense obj =
 
         Nothing ->
             span [] [ text label ]
-
-
-showPackageRecipeLink : Model -> Package -> String
-showPackageRecipeLink model package =
-    String.join "/"
-        [ model.model_config.config_repository |> showNixUrl
-        , "blob/" ++ commit
-        , package.package_recipePath
-        ]


### PR DESCRIPTION
Based-upon https://github.com/ngi-nix/forge/pull/547
### Results
In the `ngi-forge` flake:
```console
$ nix repl .
nix-repl> :p flakeConfig.allSystems.x86_64-linux.forge.repositories
{
  "/nix/store/ai2wv3b769y5dd93966x7zhxzra4bqf4-source" = {
    archiveUrl = "https://github.com/ngi-nix/forge/archive/29a7d85.tar.gz";
    commitRef = "29a7d85";
    gitUrl = "https://github.com/ngi-nix/forge";
    homeUrl = "https://github.com/ngi-nix/forge";
    nixUrl = "github:ngi-nix/forge/29a7d85";
    nixUrlLatest = "github:ngi-nix/forge/master";
    path = "ngi-nix/forge";
    treeUrl = "https://github.com/ngi-nix/forge/tree/29a7d85";
  };
}

nix-repl> :p flakeConfig.allSystems.x86_64-linux.forge.apps.python-web.recipeUrls
[ "https://github.com/ngi-nix/forge/tree/29a7d85/recipes/apps/python-web-app/recipe.nix" ]

```

In the `consumer` flake:
```console
$ (rm -rf /tmp/template-test/ && mkdir /tmp/template-test && cd /tmp/template-test && nix flake init -t $OLDPWD#consumer && git init && git add . && sed -i "s|ngi-forge.url = .*;|ngi-forge.url = \"git+file://$OLDPWD\";|g" flake.nix && nix -L repl . )
nix-repl> :p flakeConfig.allSystems.x86_64-linux.forge.repositories
{
  "/nix/store/7pj68n91h2rsw6bmlxpv63z55kmcn2hy-source" = {
    archiveUrl = "https://github.com/my-user/my-repository/archive/@.tar.gz";
    commitRef = "@";
    gitUrl = "https://github.com/my-user/my-repository";
    homeUrl = "https://github.com/my-user/my-repository";
    nixUrl = "github:my-user/my-repository/@";
    nixUrlLatest = "github:my-user/my-repository/main";
    path = "my-user/my-repository";
    treeUrl = "https://github.com/my-user/my-repository/tree/@";
  };
  "/nix/store/ai2wv3b769y5dd93966x7zhxzra4bqf4-source" = {
    archiveUrl = "https://github.com/ngi-nix/forge/archive/29a7d85.tar.gz";
    commitRef = "29a7d85";
    gitUrl = "https://github.com/ngi-nix/forge";
    homeUrl = "https://github.com/ngi-nix/forge";
    nixUrl = "github:ngi-nix/forge/29a7d85";
    nixUrlLatest = "github:ngi-nix/forge/master";
    path = "ngi-nix/forge";
    treeUrl = "https://github.com/ngi-nix/forge/tree/29a7d85";
  };
}

nix-repl> :p flakeConfig.allSystems.x86_64-linux.forge.apps.python-web.recipeUrls
[
  "https://github.com/my-user/my-repository/tree/@/recipes/apps/python-web-app/recipe.nix"
  "https://github.com/ngi-nix/forge/tree/29a7d85/recipes/apps/python-web-app/recipe.nix"
]
```

### Done
- [X] Introduce `ngi-forge-lib`, see the code for the types and descriptions of each function.
  - [X] `ngi-forge-lib.recipeFiles`
  - [X] `ngi-forge-lib.recipeUrls`
  - [X] `ngi-forge-lib.sourceInfoRef`
- [X] Introduce `forge.repositories` to map `inputs` to various kind of URLs
- [X] Introduce `forge.repository` to select the repository used for `nix` commands.
- [X] Adapt the UI to use `{apps,packages}.${name}.recipeUrls` instead of `{apps,packages}.${name}.recipePath`. The display of multiple recipe URLs is not perfect, but that can be improved later if need be.
The `forge` backend is now in charge of giving all the URLs through `forge-config.json`, because it has more knowledge and flexibility than the UI. The UI only displays.