### PR TITLE
 Add SocksTrace package and app recip

### DIFF
--- a/recipes/apps/sockstrace-app/recipe.nix
+++ b/recipes/apps/sockstrace-app/recipe.nix
@@ -1,7 +1,5 @@
 {
-  config,
   pkgs,
-  lib,
   ...
 }:
 {
@@ -19,8 +17,6 @@
       ```bash
       sockstrace -- curl https://example.com
       ```
-
-      _Available in: shell._
     '';
 
     links = {

--- a/recipes/apps/sockstrace-app/recipe.nix
+++ b/recipes/apps/sockstrace-app/recipe.nix
@@ -15,7 +15,7 @@
       Trace a command and detect any proxy leaks
 
       ```bash
-      sockstrace -- curl https://example.com
+      sockstrace -horklump.program ls
       ```
     '';
 

--- a/recipes/apps/sockstrace-app/recipe.nix
+++ b/recipes/apps/sockstrace-app/recipe.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  apps.sockstrace = {
+    displayName = "SocksTrace";
+    description = "Ptrace-based proxy leak detector that identifies network connections bypassing configured proxies.";
+    usage = ''
+      SocksTrace uses Linux ptrace to intercept socket syscalls and detect network
+      connections that bypass configured proxies such as Tor.
+
+      #### Example
+
+      Trace a command and detect any proxy leaks
+
+      ```bash
+      sockstrace -- curl https://example.com
+      ```
+
+      _Available in: shell._
+    '';
+
+    links = {
+      source = "https://github.com/namecoin/sockstrace";
+    };
+
+    ngi.grants = {
+      Core = [
+        "SocksTrace"
+      ];
+    };
+
+    programs = {
+      packages = [
+        pkgs.sockstrace
+      ];
+
+      runtimes.shell = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/recipes/apps/sockstrace-app/recipe.nix
+++ b/recipes/apps/sockstrace-app/recipe.nix
@@ -15,7 +15,7 @@
       Trace a command and detect any proxy leaks
 
       ```bash
-      sockstrace -horklump.program ls
+      sockstrace -horklump.program curl -horklump.args https://example.com
       ```
     '';
 

--- a/recipes/packages/sockstrace/add-go-deps.patch
+++ b/recipes/packages/sockstrace/add-go-deps.patch
@@ -1,0 +1,149 @@
+--- a/go.mod	2026-05-31 05:30:18.430034285 +0530
++++ b/go.mod	2026-05-31 05:30:18.430034285 +0530
+@@ -1,9 +1,39 @@
+ module main.go
+ 
+-go 1.22
++go 1.25.0
+ 
+ // Fix a bug in issue config
+ replace gopkg.in/alecthomas/kingpin.v2 => github.com/alecthomas/kingpin/v2 v2.4.0
+ 
+ // Use the latest u-root package with seccomp support
+ replace github.com/u-root/u-root => github.com/u-root/u-root v0.14.1-0.20241107071304-f908619d0238
++
++require (
++	github.com/hlandau/dexlogconfig v0.0.0-20220319061854-86a3fc314fe7
++	github.com/hlandau/xlog v1.0.0
++	github.com/oraoto/go-pidfd v0.1.1
++	github.com/robertmin1/socks5/v4 v4.0.0-20250206185213-550a852f61d6
++	github.com/seccomp/libseccomp-golang v0.11.1
++	github.com/u-root/u-root v0.0.0-00010101000000-000000000000
++	golang.org/x/sys v0.45.0
++	gopkg.in/hlandau/easyconfig.v1 v1.0.18
++)
++
++require (
++	github.com/BurntSushi/toml v1.6.0 // indirect
++	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
++	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
++	github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997 // indirect
++	github.com/mattn/go-isatty v0.0.20 // indirect
++	github.com/ogier/pflag v0.0.1 // indirect
++	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
++	github.com/shiena/ansicolor v0.0.0-20230509054315-a9deabde6e02 // indirect
++	github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf // indirect
++	github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e // indirect
++	github.com/txthinking/x v0.0.0-20210326105829-476fab902fbe // indirect
++	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
++	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
++	gopkg.in/alecthomas/kingpin.v2 v2.0.0-00010101000000-000000000000 // indirect
++	gopkg.in/hlandau/configurable.v1 v1.0.1 // indirect
++	gopkg.in/hlandau/svcutils.v1 v1.0.11 // indirect
++)
+--- a/go.sum	2026-05-31 05:30:18.430034285 +0530
++++ b/go.sum	2026-05-31 05:30:18.430034285 +0530
+@@ -0,0 +1,103 @@
++github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
++github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
++github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
++github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
++github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
++github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
++github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
++github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
++github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
++github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
++github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
++github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
++github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
++github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997 h1:pSU4Sj7AD5qh+4V5FRlpiw3DpuNQ459c3j8h2F38q74=
++github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997/go.mod h1:Oara+TmqGrvsLVEj5YkFe+PP9cSkp0kFD2PFQ5gjHok=
++github.com/hlandau/dexlogconfig v0.0.0-20220319061854-86a3fc314fe7 h1:AWQ1egvizT2zNK/duJwZBbXyx4pG3DmY2D/eg45IWfw=
++github.com/hlandau/dexlogconfig v0.0.0-20220319061854-86a3fc314fe7/go.mod h1:JpXGCMr2CULPTjnwD8PL9A7YipEitrd+xSHTIK8orHU=
++github.com/hlandau/xlog v1.0.0 h1:tcFGp86iK+v6NwbyuG9wyLB77SBkvAJUjOkRJo3H8C0=
++github.com/hlandau/xlog v1.0.0/go.mod h1:aZl5hrokGCtnAFcvft2givQmKZYVfHRvQJbjoqI2lm8=
++github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
++github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
++github.com/miekg/dns v1.1.51/go.mod h1:2Z9d3CP1LQWihRZUf29mQ19yDThaI4DAYzte2CaQW5c=
++github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
++github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
++github.com/oraoto/go-pidfd v0.1.1 h1:57gTETdUGYpFwRKoKph8ffgeps89DF2qlfxBFdfkHiA=
++github.com/oraoto/go-pidfd v0.1.1/go.mod h1:gPWelSU60MvzRX+ToMlKj9lZRkeqybg6qy8cy4+rZWE=
++github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
++github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
++github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
++github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
++github.com/robertmin1/socks5/v4 v4.0.0-20250206185213-550a852f61d6 h1:uMtleN98/3G7JrOblKZHJU4bY0KJpC08nsEEkDxvxNs=
++github.com/robertmin1/socks5/v4 v4.0.0-20250206185213-550a852f61d6/go.mod h1:+CWsQhd/aoxYSIeSoG3orNaR42aO+xodJgv+IcrTpOY=
++github.com/seccomp/libseccomp-golang v0.11.1 h1:wuk4ZjSx6kyQII4rj6G6fvVzRHQaSiPvccJazDagu4g=
++github.com/seccomp/libseccomp-golang v0.11.1/go.mod h1:5m1Lk8E9OwgZTTVz4bBOer7JuazaBa+xTkM895tDiWc=
++github.com/shiena/ansicolor v0.0.0-20230509054315-a9deabde6e02 h1:v9ezJDHA1XGxViAUSIoO/Id7Fl63u6d0YmsAm+/p2hs=
++github.com/shiena/ansicolor v0.0.0-20230509054315-a9deabde6e02/go.mod h1:RF16/A3L0xSa0oSERcnhd8Pu3IXSDZSK2gmGIMsttFE=
++github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
++github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
++github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
++github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
++github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf h1:7PflaKRtU4np/epFxRXlFhlzLXZzKFrH5/I4so5Ove0=
++github.com/txthinking/runnergroup v0.0.0-20210608031112-152c7c4432bf/go.mod h1:CLUSJbazqETbaR+i0YAhXBICV9TrKH93pziccMhmhpM=
++github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e h1:xA7GVlbz6teIF4FdvuqwbX6C4tiqNk2PH7FRPIDerao=
++github.com/txthinking/socks5 v0.0.0-20251011041537-5c31f201a10e/go.mod h1:ntmMHL/xPq1WLeKiw8p/eRATaae6PiVRNipHFJxI8PM=
++github.com/txthinking/x v0.0.0-20210326105829-476fab902fbe h1:gMWxZxBFRAXqoGkwkYlPX2zvyyKNWJpxOxCrjqJkm5A=
++github.com/txthinking/x v0.0.0-20210326105829-476fab902fbe/go.mod h1:WgqbSEmUYSjEV3B1qmee/PpP2NYEz4bL9/+mF1ma+s4=
++github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a h1:eg5FkNoQp76ZsswyGZ+TjYqA/rhKefxK8BW7XOlQsxo=
++github.com/u-root/gobusybox/src v0.0.0-20240225013946-a274a8d5d83a/go.mod h1:e/8TmrdreH0sZOw2DFKBaUV7bvDWRq6SeM9PzkuVM68=
++github.com/u-root/u-root v0.14.1-0.20241107071304-f908619d0238 h1:/59w2pLUXx3gONemwyehE3BhQySGem/qpVqCB0GxUpI=
++github.com/u-root/u-root v0.14.1-0.20241107071304-f908619d0238/go.mod h1:M72QPU7zREX+bKdTPGdxUMp56ei8FppyjpU2+A1UhC0=
++github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
++github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
++github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
++golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
++golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
++golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
++golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
++golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
++golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
++golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
++golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
++golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
++golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
++golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
++golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
++golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
++golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
++golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
++golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
++golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
++golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
++golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
++golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
++golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
++golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
++golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
++golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
++golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
++golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
++golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
++golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
++golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
++golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
++golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
++golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
++gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
++gopkg.in/hlandau/configurable.v1 v1.0.1 h1:rH8g/WXZu2b/eyLagvsqUf9q5mO66hfGHW5L4rm8ktk=
++gopkg.in/hlandau/configurable.v1 v1.0.1/go.mod h1:rlyQpcii/QkMGudMSMoe3jjHAgqLZuqg0hQkiUcNfF8=
++gopkg.in/hlandau/easyconfig.v1 v1.0.18 h1:8i8/X1+7bswm063Ypl1myeNy7BIXbI0sr0R0RsXEU+I=
++gopkg.in/hlandau/easyconfig.v1 v1.0.18/go.mod h1:fljDHM+/VAXpyEN/45q6RFtcOFnUaF1Wgr6p4LLICoU=
++gopkg.in/hlandau/svcutils.v1 v1.0.11 h1:F+BANbiBJ0YZIEW9f4Uy2+vaSwaEQO+uYgrlhBb10Ho=
++gopkg.in/hlandau/svcutils.v1 v1.0.11/go.mod h1:aAoYFMVAq2ck6z8av+FBxzX/qX1ehmUIc5PgGBf+P3I=
++gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
++gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
++gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/recipes/packages/sockstrace/recipe.nix
+++ b/recipes/packages/sockstrace/recipe.nix
@@ -1,5 +1,4 @@
 {
-  config,
   lib,
   pkgs,
   ...

--- a/recipes/packages/sockstrace/recipe.nix
+++ b/recipes/packages/sockstrace/recipe.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  packages.sockstrace = {
+    version = "1";
+    description = "Ptrace-based proxy leak detector that identifies network connections bypassing configured proxies.";
+    homePage = "https://github.com/namecoin/sockstrace";
+    mainProgram = "sockstrace";
+    license = lib.licenses.gpl3Only;
+
+    source = {
+      git = "github:namecoin/sockstrace/v1";
+      hash = "sha256-vUJSuazo5C23UacQGKxTXrLek6vEu9+S9PzfBjXa9Nc=";
+      patches = [
+        ./add-go-deps.patch
+      ];
+    };
+
+    build.goPackageBuilder = {
+      enable = true;
+      packages.build = [
+        pkgs.pkg-config
+      ];
+      packages.run = [
+        pkgs.libseccomp
+      ];
+      vendorHash = "sha256-EFHYvWYXvpB6QMk345wUgcx54W1yWzXuphq+8oDiVzE=";
+    };
+
+    build.extraAttrs = {
+      postInstall = ''
+        mv $out/bin/main.go $out/bin/sockstrace
+      '';
+    };
+
+    test.script = ''
+      sockstrace --help
+    '';
+  };
+}

--- a/recipes/packages/sockstrace/recipe.nix
+++ b/recipes/packages/sockstrace/recipe.nix
@@ -5,7 +5,7 @@
 }:
 {
   packages.sockstrace = {
-    version = "1";
+    version = "1.0.0";
     description = "Ptrace-based proxy leak detector that identifies network connections bypassing configured proxies.";
     homePage = "https://github.com/namecoin/sockstrace";
     mainProgram = "sockstrace";
@@ -37,7 +37,7 @@
     };
 
     test.script = ''
-      sockstrace --help
+      sockstrace -horklump.program ls
     '';
   };
 }

--- a/recipes/packages/sockstrace/recipe.nix
+++ b/recipes/packages/sockstrace/recipe.nix
@@ -36,8 +36,15 @@
       '';
     };
 
-    test.script = ''
-      sockstrace -horklump.program ls
-    '';
+    test = {
+      packages = [
+        pkgs.curl
+        pkgs.cacert
+      ];
+      script = ''
+        export CURL_CA_BUNDLE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+        sockstrace -horklump.program curl -horklump.args https://example.com
+      '';
+    };
   };
 }


### PR DESCRIPTION
## Summary

  - Adds a package recipe for SocksTrace (`recipes/packages/sockstrace/`) using `goPackageBuilder` (GPL-3.0-only, tag v1)
  - Adds an app recipe (`recipes/apps/sockstrace-app/`) as a shell bundle 
  - Includes `add-go-deps.patch` to supply the missing `go.sum` and `require` block that upstream intentionally omits from the v1 tag

  ## How to test
  
  ```bash
  git add recipes/packages/sockstrace/recipe.nix recipes/packages/sockstrace/add-go-deps.patch
  nix build .#sockstrace -L
  nix build .#sockstrace.test -L
  git add recipes/apps/sockstrace-app/recipe.nix
  nix build .#sockstrace-app -L
```
  ## Related Issue

  ngi-nix/projects#800

  **Notes**

  Upstream intentionally gitignores go.sum and ships an incomplete go.mod at the v1 tag (no require block). The patch adds both, generated with go mod   tidy using Go 1.22 (which resolves to Go 1.25.0 via golang.org/x/sys v0.45.0). The binary is installed by Go as main.go (matching the module name); postInstall renames it to sockstrace.

  ---
