### PR TITLE
Add Pnut package and app recipes

### DIFF
--- a/recipes/apps/pnut-app/recipe.nix
+++ b/recipes/apps/pnut-app/recipe.nix
@@ -1,0 +1,50 @@
+{
+  pkgs,
+  ...
+}:
+{
+  apps.pnut = {
+    displayName = "Pnut";
+    description = "C to POSIX shell transpiler for reproducible and auditable bootstrapping of GCC from a minimal seed.";
+    usage = ''
+      Pnut transpiles C source code to POSIX shell scripts, enabling
+      reproducible and auditable bootstrapping of GCC from a minimal seed.
+
+      #### Transpile a C file to shell
+
+      ```bash
+      pnut input.c > output.sh
+      chmod +x output.sh
+      ```
+
+      #### Bootstrap pnut itself
+
+      ```bash
+      pnut pnut.c > pnut-bootstrap.sh
+      chmod +x pnut-bootstrap.sh
+      ```
+
+      _Available in: shell._
+    '';
+
+    links = {
+      source = "https://github.com/udem-dlteam/pnut";
+    };
+
+    ngi.grants = {
+      Commons = [
+        "Pnut"
+      ];
+    };
+
+    programs = {
+      packages = [
+        pkgs.pnut
+      ];
+
+      runtimes.shell = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/recipes/apps/pnut-app/recipe.nix
+++ b/recipes/apps/pnut-app/recipe.nix
@@ -23,8 +23,6 @@
       pnut pnut.c > pnut-bootstrap.sh
       chmod +x pnut-bootstrap.sh
       ```
-
-      _Available in: shell._
     '';
 
     links = {

--- a/recipes/packages/pnut/recipe.nix
+++ b/recipes/packages/pnut/recipe.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  ...
+}:
+{
+  packages.pnut = {
+    version = "1.1";
+    description = "C to POSIX shell transpiler for reproducible and auditable bootstrapping of GCC from a minimal seed.";
+    homePage = "https://github.com/udem-dlteam/pnut";
+    mainProgram = "pnut";
+    license = lib.licenses.bsd2;
+
+    source = {
+      git = "github:udem-dlteam/pnut/pnut-1.1";
+      hash = "sha256-q0JoW8Tw25m+Hp9W/LxzC3yt78J1AmeV1G3h41RHIOI=";
+    };
+
+    build.standardBuilder = {
+      enable = true;
+    };
+
+    build.extraAttrs = {
+      installPhase = ''
+        mkdir -p $out/bin
+        make install PREFIX=$out
+      '';
+    };
+
+    test.script = ''
+      echo "int main(void) { return 0; }" > /tmp/test.c
+      pnut /tmp/test.c
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Adds a package recipe for pnut v1.1 and an app recipe exposing it via shell runtime. Pnut transpiles C source code to POSIX shell scripts, enabling reproducible and auditable bootstrapping of GCC from a minimal seed. Not currently in nixpkgs.

## How to test

- `git add recipes/packages/pnut/recipe.nix recipes/apps/pnut-app/recipe.nix`
- `nix build .#pnut -L`
- `nix build .#pnut.test -L`
- `nix build .#pnut-app -L`

## Related Issue

ngi-nix/projects#691