### PR TITLE
refactor: rename app.devenv attribute

### DIFF
--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -38,7 +38,7 @@
       // allPackages
 
       # All packages passthru attributes
-      // (passthruAttr "devenv")
+      // (passthruAttr "env")
       // (passthruAttr "test")
 
       # All apps passthru attributes

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -115,12 +115,12 @@
           buildInputs = [ finalPkg ] ++ pkg.test.packages;
           script = pkg.test.script + "\ntouch $out";
         };
-        devenv = pkgs.mkShell {
+        env = pkgs.mkShell {
           dontBuild = true;
           phases = [ "installPhase" ];
           installPhase = "touch $out";
-          env.DEVENV_PACKAGE_NAME = "${pkg.pname}";
-          env.DEVENV_PACKAGE_SOURCE = "${finalPkg.src}";
+          env.ENV_PACKAGE_NAME = "${pkg.pname}";
+          env.ENV_PACKAGE_SOURCE = "${finalPkg.src}";
           inputsFrom = [
             finalPkg
           ];

--- a/forge/modules/packages/package.nix
+++ b/forge/modules/packages/package.nix
@@ -240,9 +240,9 @@
         type = lib.types.str;
         default = ''
           echo -e "\nWelcome. This environment contains all dependencies required"
-          echo "to build $DEVENV_PACKAGE_NAME from source."
+          echo "to build $ENV_PACKAGE_NAME from source."
           echo
-          echo "Grab the source code from $DEVENV_PACKAGE_SOURCE"
+          echo "Grab the source code from $ENV_PACKAGE_SOURCE"
           echo "or from the upstream repository and you are all set to start hacking."
         '';
         description = ''
@@ -251,7 +251,7 @@
           Enter with:
 
           ```
-          nix develop .#<package>.devenv
+          nix develop .#<package>.env
           ```
         '';
         example = ''


### PR DESCRIPTION
Rename app.devenv attribute to env to avoid confusion with [devenv.sh](https://devenv.sh/) .

We have started to have requests for this feature. Rename it until it is used.