### PR TITLE
fix: don't allow host env variables to leak to bubblewrap service env

### DIFF
--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -174,6 +174,7 @@
         settings.bubblewrap.environment = service.environment // {
           PATH = binPaths;
         };
+        settings.bubblewrap.prependFlags = [ "--clearenv" ];
         settings.bubblewrap.chdir = "/var/lib/${serviceName}";
         settings.bubblewrap.unshare.user = false;
         settings.bubblewrap.appendFlags = [


### PR DESCRIPTION
With this PR

```
nix run .#offen-app.services.offen
warning: Git tree '/home/imincik/Projects/ngi/forge/code' is dirty
[2026-06-05T11:42:51Z INFO  nimi::cli] Launching process manager...
[2026-06-05T11:42:51Z INFO  nimi::process_manager] Starting process manager...
[2026-06-05T11:42:51Z INFO  offen] Environment: OFFEN_DATABASE_CONNECTIONSTRING=/var/lib/offen/offen.db
[2026-06-05T11:42:51Z INFO  offen] Environment: OFFEN_DATABASE_DIALECT=sqlite3
[2026-06-05T11:42:51Z INFO  offen] Environment: OFFEN_SERVER_PORT=3000
[2026-06-05T11:42:51Z INFO  offen] Environment: PATH=/nix/store/yssab91xhfzc5q7g3xq08afrmirljpw4-nimi-0.1.0/bin:/nix/store/9ypz3flqsrl5xl495mm8h645gadjsxi1-coreutils-9.11/bin:/nix/store/cgjr3kj3hs7ngznyws5qfg16c8scpys0-bash-interactive-5.3p9/bin:/nix/store/9ypz3flqsrl5xl495mm8h645gadjsxi1-coreutils-9.11/bin:/nix/store/7d6hvpv2pd61mgs538qs6wk10gjf32l7-offen-0.0.0-unstable-2026-03-04/bin
[2026-06-05T11:42:51Z INFO  offen] Environment: PWD=/var/lib/offen
[2026-06-05T11:42:51Z INFO  offen] Environment: SHLVL=0
[2026-06-05T11:42:51Z INFO  offen] XDG_CONFIG_HOME=/tmp/nimi-config-44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
[2026-06-05T11:42:51Z INFO  offen] Running: /nix/store/7d6hvpv2pd61mgs538qs6wk10gjf32l7-offen-0.0.0-unstable-2026-03-04/bin/offen serve
[2026-06-05T11:42:51Z ERROR offen] time="2026-06-05T11:42:51Z" level=warning msg="SMTP for transactional email is not configured right now, mail delivery will be unreliable"
[2026-06-05T11:42:51Z ERROR offen] time="2026-06-05T11:42:51Z" level=warning msg="Refer to the documentation to find out how to configure SMTP"
[2026-06-05T11:42:51Z ERROR offen] time="2026-06-05T11:42:51Z" level=info msg="Successfully applied database migrations"
[2026-06-05T11:42:51Z ERROR offen] time="2026-06-05T11:42:51Z" level=info msg="Server now listening on port 3000"
[2026-06-05T11:42:51Z ERROR offen] time="2026-06-05T11:42:51Z" level=info msg="Cron successfully pruned expired events" removed=0
```