### PR TITLE
ci: skip cached builds in flake check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,15 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
-        run: nix flake check --accept-flake-config --max-jobs 1 --option sandbox relaxed
+        run: |
+          nix flake prefetch-inputs .
+          NIXPKGS="$(nix eval --raw --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.outPath' --impure)"
+          nix shell -L github:Mic92/nix-fast-build \
+            --override-input nixpkgs "$NIXPKGS" \
+            -c nix-fast-build -j 1 \
+              --no-nom --no-link \
+              --skip-cached --fail-fast \
+              --option sandbox relaxed
 
   lint:
     name: Run format checks

--- a/recipes/apps/badkeys/recipe.nix
+++ b/recipes/apps/badkeys/recipe.nix
@@ -57,6 +57,7 @@
     test.programs.script = ''
       set -x
       openssl genrsa -out file.key
+
       badkeys -c rsawarnings -v file.key | grep -q 'ok'
 
       cat <<EOF >smallkey.pub


### PR DESCRIPTION
The aim is to avoid downloading pre-built checks if they are already available in cachix.

There is [Mic92/nix-build-uncached](https://github.com/mic92/nix-build-uncached#nix-build-uncached) for this purpose, and it suggests using [nix-fast-build](https://github.com/Mic92/nix-fast-build) with `--skip-cached`.
