### PR TITLE
feat: add _forge-report package

### DIFF
--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -91,6 +91,33 @@ in
 
     _forge-docs = pkgs.callPackage ../flake/packages/forge-docs.nix { };
 
+    _forge-report =
+      let
+        reports = import ../maintainers/mk-report.nix { inherit forgeApps pkgs lib; };
+      in
+      pkgs.writeShellApplication {
+        name = "report-packaging";
+        passthru = reports;
+        text = ''
+          cat <<EOF
+          To generate a packaging report, use:
+
+          \`\`\`
+          nix run .#_forge-report.all      # all grants
+          nix run .#_forge-report.<GRANT>  # single grant
+          \`\`\`
+
+          Available grants:
+          ${lib.concatMapStringsSep "\n" (g: "- " + g) [
+            "Commons"
+            "Core"
+            "Entrust"
+            "Review"
+          ]}
+          EOF
+        '';
+      };
+
     _forge-announcement = pkgs.writeShellApplication {
       name = "announce-projects";
       passthru = import ../maintainers/mk-announcement.nix { inherit forgeApps pkgs lib; };

--- a/maintainers/mk-report.nix
+++ b/maintainers/mk-report.nix
@@ -1,0 +1,78 @@
+{
+  forgeApps,
+  pkgs,
+  lib,
+}:
+
+let
+  # Read the list of grants from grants option
+  grants = lib.attrNames (
+    (lib.evalModules {
+      modules = [ ../forge/modules/apps/ngi/grants.nix ];
+    }).options
+  );
+
+  mkReport =
+    grant:
+    let
+      # Example apps are excluded
+      baseList = lib.filter (app: app.name != "example") (lib.attrValues forgeApps);
+
+      appList =
+        if grant == null then
+          baseList
+        else
+          lib.filter (app: lib.hasAttr grant app.ngi.grants && app.ngi.grants.${grant} != [ ]) baseList;
+
+      grantCounts =
+        let
+          allGrants = lib.concatMap (
+            app: lib.attrNames (lib.filterAttrs (_: v: v != [ ]) app.ngi.grants)
+          ) appList;
+        in
+        lib.foldl' (acc: g: acc // { ${g} = (acc.${g} or 0) + 1; }) { } allGrants;
+
+      appLines = lib.concatMapStringsSep "\n" (
+        app:
+        let
+          appGrants = lib.pipe app.ngi.grants [
+            (lib.filterAttrs (_: v: v != [ ]))
+            lib.attrNames
+            (lib.concatStringsSep ", ")
+          ];
+          grantStr = if appGrants != "" then " (${appGrants})" else "";
+        in
+        "  - [${app.displayName}](https://ngi.nixos.org/app/${app.name})${grantStr}"
+      ) (lib.sortOn (app: app.displayName) appList);
+
+      grantHeader = if grant == null then "all grants" else grant;
+      countApps = toString (lib.length appList);
+      countCommons = toString (grantCounts.Commons or 0);
+      countCore = toString (grantCounts.Core or 0);
+      countEntrust = toString (grantCounts.Entrust or 0);
+      countReview = toString (grantCounts.Review or 0);
+
+      report = pkgs.writeText "report-packaging.md" ''
+        ## Summary - ${grantHeader} grant(s)
+
+        - Apps: ${countApps}
+
+        ${lib.optionalString (grant == null) ''
+          ### Grants
+
+          - Commons: ${countCommons}
+          - Core: ${countCore}
+          - Entrust: ${countEntrust}
+          - Review: ${countReview}
+        ''}
+        ## Apps
+
+        ${appLines}
+      '';
+    in
+    pkgs.writeShellApplication {
+      name = "report-packaging";
+      text = "cat ${report}";
+    };
+in
+lib.listToAttrs (map (g: lib.nameValuePair g (mkReport g)) grants) // { all = mkReport null; }


### PR DESCRIPTION
Closes [#426](https://github.com/ngi-nix/ngi/issues/426)

Script output will be used to provide information for NGI reports.

````
nix run .#_forge-report
To generate a packaging report, use:

```
nix run .#_forge-report.all      # all grants
nix run .#_forge-report.<GRANT>  # single grant
```

Available grants:
- Commons
- Core
- Entrust
- Review
````

```
nix run .#_forge-report.Commons
## Summary - Commons grant(s)

- Apps: 11


## Apps

  - [Collabora Office](https://ngi.nixos.org/app/collabora-desktop) (Commons, Entrust)
  - [Garage](https://ngi.nixos.org/app/garage) (Commons, Entrust)
  - [IronCalc](https://ngi.nixos.org/app/ironcalc) (Commons, Core)
  - [Kdenlive](https://ngi.nixos.org/app/kdenlive) (Commons)
  - [Kepler Formal](https://ngi.nixos.org/app/kepler-formal) (Commons)
  - [Pnut](https://ngi.nixos.org/app/pnut) (Commons)
  - [PyCM](https://ngi.nixos.org/app/pycm) (Commons, Review)
  - [Repath Studio](https://ngi.nixos.org/app/repath-studio) (Commons)
  - [Sequoia PQC](https://ngi.nixos.org/app/sequoia-pqc) (Commons)
  - [Ziplinter](https://ngi.nixos.org/app/ziplinter) (Commons)
  - [jaq](https://ngi.nixos.org/app/jaq) (Commons, Entrus
```