### PR TITLE
recipes: fix name of sequoia-pgp package and app

### DIFF
--- a/recipes/apps/sequoia-pgp/recipe.nix
+++ b/recipes/apps/sequoia-pgp/recipe.nix
@@ -4,11 +4,11 @@
 }:
 
 {
-  apps.sequoia-pqc = {
-    displayName = "Sequoia PQC";
+  apps.sequoia-pgp = {
+    displayName = "Sequoia PGP";
     description = "Command-line OpenPGP tool with post-quantum cryptography support.";
     usage = ''
-      Sequoia PQC (`sq`) is a command-line OpenPGP tool with post-quantum
+      Sequoia PGP (`sq`) is a command-line OpenPGP tool with post-quantum
       cryptography support, implementing draft-ietf-openpgp-pqc.
 
       #### Generate a key
@@ -49,7 +49,7 @@
 
     programs = {
       packages = [
-        pkgs.sequoia-pqc
+        pkgs.sequoia-pgp
       ];
 
       runtimes.shell = {

--- a/recipes/packages/sequoia-pgp/recipe.nix
+++ b/recipes/packages/sequoia-pgp/recipe.nix
@@ -5,7 +5,7 @@
 }:
 
 {
-  packages.sequoia-pqc = {
+  packages.sequoia-pgp = {
     version = "1.4.0-pqc.1";
     description = "Command-line OpenPGP tool with post-quantum cryptography support.";
     homePage = "https://sequoia-pgp.org";
@@ -37,7 +37,7 @@
     };
 
     test.script = ''
-      sq version 2>&1 | grep 'sq ${packages.sequoia-pqc.version}'
+      sq version 2>&1 | grep 'sq ${packages.sequoia-pgp.version}'
     '';
   };
 }


### PR DESCRIPTION
Correct name of the software is [Sequoia PGP](https://sequoia-pgp.org/) .