### PR TITLE
feat: add forge-update script for updating package recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ ui/src/options.js
 *.qcow2
 *.tar
 .envrc
+
+###------------------###
+###  GitHub: Python  ###
+###------------------###
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -15,7 +15,6 @@ let
   srcDir = toString ./.;
   script = writers.writePython3Bin "forge-update" {
     libraries = with python3Packages; [
-      packaging
     ];
     flakeIgnore = [
       # sys.path.insert before import triggers "import not at top"

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -1,29 +1,16 @@
 {
   lib,
-  writers,
   writeShellApplication,
   gitMinimal,
   nix-prefetch-git,
   nix,
-  python3Packages,
+  python3,
 }:
 let
-  # Inject the store path of this directory so the script can locate the
-  # sibling forge_update/ package at runtime.  We read + replace instead of
-  # passing a path to writePython3Bin because the latter does not bundle
-  # sub-directories alongside the resulting wrapper.
   srcDir = toString ./.;
-  script = writers.writePython3Bin "forge-update" {
-    libraries = with python3Packages; [
-      colorama
-    ];
-    flakeIgnore = [
-      # sys.path.insert before import triggers "import not at top"
-      "E402"
-      # long replaceStrings line / error-message strings
-      "E501"
-    ];
-  } (lib.replaceStrings [ "@forgeUpdateDir@" ] [ srcDir ] (lib.readFile ./forge-update.py));
+  pythonEnv = python3.withPackages (ps: [
+    ps.colorama
+  ]);
 in
 writeShellApplication {
   name = "forge-update";
@@ -31,9 +18,11 @@ writeShellApplication {
     gitMinimal
     nix-prefetch-git
     nix
+    pythonEnv
   ];
   text = ''
-    ${lib.getExe script} "$@"
+    export PYTHONPATH="${srcDir}:''${PYTHONPATH-}"
+    exec python3 -m forge_update "$@"
   '';
   meta.description = "Update forge package recipes to latest upstream versions";
 }

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -5,6 +5,7 @@
   gitMinimal,
   nix-prefetch-git,
   nix,
+  python3Packages,
 }:
 let
   # Inject the store path of this directory so the script can locate the
@@ -13,7 +14,9 @@ let
   # sub-directories alongside the resulting wrapper.
   srcDir = toString ./.;
   script = writers.writePython3Bin "forge-update" {
-    libraries = [ ];
+    libraries = with python3Packages; [
+      packaging
+    ];
     flakeIgnore = [
       # sys.path.insert before import triggers "import not at top"
       "E402"

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -15,6 +15,7 @@ let
   srcDir = toString ./.;
   script = writers.writePython3Bin "forge-update" {
     libraries = with python3Packages; [
+      colorama
     ];
     flakeIgnore = [
       # sys.path.insert before import triggers "import not at top"

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -7,11 +7,17 @@
   nix,
 }:
 let
+  # Inject the store path of this directory so the script can locate the
+  # sibling forge_update/ package at runtime.  We read + replace instead of
+  # passing a path to writePython3Bin because the latter does not bundle
+  # sub-directories alongside the resulting wrapper.
   srcDir = toString ./.;
   script = writers.writePython3Bin "forge-update" {
     libraries = [ ];
     flakeIgnore = [
+      # sys.path.insert before import triggers "import not at top"
       "E402"
+      # long replaceStrings line / error-message strings
       "E501"
     ];
   } (lib.replaceStrings [ "@forgeUpdateDir@" ] [ srcDir ] (lib.readFile ./forge-update.py));

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  writers,
+  writeShellApplication,
+  gitMinimal,
+  nix-prefetch-git,
+  nix,
+}:
+let
+  script = writers.writePython3Bin "forge-update" {
+    libraries = [ ];
+    flakeIgnore = [
+      "E402"
+      "E501"
+    ];
+  } (lib.readFile ./forge-update.py);
+in
+writeShellApplication {
+  name = "forge-update";
+  runtimeInputs = [
+    gitMinimal
+    nix-prefetch-git
+    nix
+  ];
+  text = ''
+    ${lib.getExe script} "$@"
+  '';
+  meta.description = "Update forge package recipes to latest upstream versions";
+}

--- a/flake/develop/commands/dev/update/default.nix
+++ b/flake/develop/commands/dev/update/default.nix
@@ -7,13 +7,14 @@
   nix,
 }:
 let
+  srcDir = toString ./.;
   script = writers.writePython3Bin "forge-update" {
     libraries = [ ];
     flakeIgnore = [
       "E402"
       "E501"
     ];
-  } (lib.readFile ./forge-update.py);
+  } (lib.replaceStrings [ "@forgeUpdateDir@" ] [ srcDir ] (lib.readFile ./forge-update.py));
 in
 writeShellApplication {
   name = "forge-update";

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -14,6 +14,7 @@ from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImpor
 )
 from forge_update.version import (  # pyright: ignore[reportImplicitRelativeImport]
     VersionDetector,
+    VersionResult,
 )
 
 
@@ -78,14 +79,17 @@ def main() -> None:
                 print(f"    pnpmDepsHash:{h.pnpm_deps_hash}")
 
         if args.version:
-            new_version = args.version
+            result = VersionResult(version=args.version, rev="")
+            print(f"  \u2192 set: {result.version}")
         else:
-            new_version = detector.detect(recipe)
-            print(f"  \u2192 latest: {new_version}")
+            result = detector.detect(recipe)
+            print(f"  \u2192 detected: {result.version} (rev: {result.rev})")
 
         if recipe.packages:
             pkg = recipe.packages[0]
-            writer.update_version(recipe, pkg.pname, new_version)
+            writer.update_version(recipe, pkg.pname, result.version)
+            if result.rev:
+                writer.update_git_rev(recipe, pkg.pname, result.rev)
             writer.apply(recipe)
 
 

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -49,48 +49,43 @@ def parse_args(argv: list[str] | None = None) -> Args:
 def main() -> None:
     args = parse_args()
     parser = RecipeParser(args.recipes_root)
-    writer = RecipeWriter(dry_run=args.dry_run)
     detector = VersionDetector()
 
-    for name in args.recipe:
+    for i, name in enumerate(args.recipe):
+        if i > 0:
+            print()
+
         path = parser.find(name)
         recipe = parser.parse(path)
-        print(f"{name} ({path.parent.resolve()}/recipe.nix):")
-        for pkg in recipe.packages:
-            btype = pkg.builder_type.name
-            print(f"  packages.{pkg.pname}")
-            print(f"    version:     {pkg.version}")
-            print(f"    builder:     {btype}")
-            if pkg.source.type.name == "GIT":
-                g = pkg.source.git
-                if g:
-                    print(f"    git:         {g.host.value}:{g.owner}/{g.repo}@{g.rev}")
-                    if g.remote_url:
-                        print(f"    remote:      {g.remote_url}")
-            print(f"    source hash: {pkg.source.hash or '(none)'}")
-            h = pkg.builder_hashes
-            if h.cargo_hash:
-                print(f"    cargoHash:   {h.cargo_hash}")
-            if h.vendor_hash:
-                print(f"    vendorHash:  {h.vendor_hash}")
-            if h.npm_deps_hash:
-                print(f"    npmDepsHash: {h.npm_deps_hash}")
-            if h.pnpm_deps_hash:
-                print(f"    pnpmDepsHash:{h.pnpm_deps_hash}")
+        pkg = recipe.packages[0]
+        writer = RecipeWriter(dry_run=args.dry_run)
 
         if args.version:
             result = VersionResult(version=args.version, rev="")
-            print(f"  \u2192 set: {result.version}")
         else:
             result = detector.detect(recipe)
-            print(f"  \u2192 detected: {result.version} (rev: {result.rev})")
 
-        if recipe.packages:
-            pkg = recipe.packages[0]
-            writer.update_version(recipe, pkg.pname, result.version)
-            if result.rev:
-                writer.update_git_rev(recipe, pkg.pname, result.rev)
-            writer.apply(recipe)
+        g = pkg.source.git
+        current_rev = g.rev if g else ""
+        rev_changed = bool(result.rev) and result.rev != current_rev
+        version_changed = pkg.version != result.version
+
+        print(name)
+
+        if not version_changed and not rev_changed:
+            print(f"  already at {pkg.version}")
+            continue
+
+        writer.update_version(recipe, pkg.pname, result.version)
+        if result.rev:
+            writer.update_git_rev(recipe, pkg.pname, result.rev)
+
+        for field, old, new in writer.pending_changes:
+            print(f"  {field}")
+            print(f"    {old}  ->")
+            print(f"    {new}")
+
+        writer.apply(recipe)
 
 
 if __name__ == "__main__":

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -3,6 +3,11 @@
 import argparse
 from pathlib import Path
 
+from .forge_update.recipe import (
+    RecipeParser,
+    RecipeWriter,
+)
+
 
 class Args(argparse.Namespace):
     recipe: list[str] = []
@@ -34,13 +39,37 @@ def parse_args(argv: list[str] | None = None) -> Args:
 
 def main() -> None:
     args = parse_args()
+    parser = RecipeParser(args.recipes_root)
+    writer = RecipeWriter(dry_run=args.dry_run)
 
-    print(f"Recipes to update: {args.recipe}")
-    print(f"  recipes-root: {args.recipes_root}")
-    if args.version:
-        print(f"  explicit version: {args.version}")
-    if args.dry_run:
-        print("  dry-run: enabled")
+    for name in args.recipe:
+        path = parser.find(name)
+        recipe = parser.parse(path)
+        print(f"{name} ({path.parent.resolve()}/recipe.nix):")
+        for pkg in recipe.packages:
+            btype = pkg.builder_type.name
+            print(f"  packages.{pkg.pname}")
+            print(f"    version:     {pkg.version}")
+            print(f"    builder:     {btype}")
+            if pkg.source.type.name == "GIT":
+                g = pkg.source.git
+                if g:
+                    print(f"    git:         {g.host.value}:{g.owner}/{g.repo}@{g.rev}")
+            print(f"    source hash: {pkg.source.hash or '(none)'}")
+            h = pkg.builder_hashes
+            if h.cargo_hash:
+                print(f"    cargoHash:   {h.cargo_hash}")
+            if h.vendor_hash:
+                print(f"    vendorHash:  {h.vendor_hash}")
+            if h.npm_deps_hash:
+                print(f"    npmDepsHash: {h.npm_deps_hash}")
+            if h.pnpm_deps_hash:
+                print(f"    pnpmDepsHash:{h.pnpm_deps_hash}")
+
+        if args.version and recipe.packages:
+            pkg = recipe.packages[0]
+            writer.update_version(recipe, pkg.pname, args.version)
+            writer.apply(recipe)
 
 
 if __name__ == "__main__":

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -133,7 +133,7 @@ def main() -> None:
     parser = RecipeParser(args.recipes_root)
     detector = VersionDetector()
     prefetcher = HashPrefetcher(timeout=args.prefetch_timeout)
-    builder_hash = BuilderHashUpdater()
+    builder_hash = BuilderHashUpdater(dry_run=args.dry_run)
 
     for i, name in enumerate(names):
         if i > 0:

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -12,6 +12,9 @@ from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImpor
     RecipeParser,
     RecipeWriter,
 )
+from forge_update.version import (  # pyright: ignore[reportImplicitRelativeImport]
+    VersionDetector,
+)
 
 
 class Args(argparse.Namespace):
@@ -46,6 +49,7 @@ def main() -> None:
     args = parse_args()
     parser = RecipeParser(args.recipes_root)
     writer = RecipeWriter(dry_run=args.dry_run)
+    detector = VersionDetector()
 
     for name in args.recipe:
         path = parser.find(name)
@@ -60,6 +64,8 @@ def main() -> None:
                 g = pkg.source.git
                 if g:
                     print(f"    git:         {g.host.value}:{g.owner}/{g.repo}@{g.rev}")
+                    if g.remote_url:
+                        print(f"    remote:      {g.remote_url}")
             print(f"    source hash: {pkg.source.hash or '(none)'}")
             h = pkg.builder_hashes
             if h.cargo_hash:
@@ -71,9 +77,15 @@ def main() -> None:
             if h.pnpm_deps_hash:
                 print(f"    pnpmDepsHash:{h.pnpm_deps_hash}")
 
-        if args.version and recipe.packages:
+        if args.version:
+            new_version = args.version
+        else:
+            new_version = detector.detect(recipe)
+            print(f"  \u2192 latest: {new_version}")
+
+        if recipe.packages:
             pkg = recipe.packages[0]
-            writer.update_version(recipe, pkg.pname, args.version)
+            writer.update_version(recipe, pkg.pname, new_version)
             writer.apply(recipe)
 
 

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -1,8 +1,12 @@
 """forge-update: Update forge package recipes to latest upstream versions."""
 
 import argparse
+import os
 import sys
 from pathlib import Path
+
+from colorama import Fore, Style
+from colorama import init as colorama_init
 
 # At build time default.nix replaces @forgeUpdateDir@ with the Nix-store
 # path of this directory, making the sibling forge_update/ package
@@ -16,6 +20,14 @@ from forge_update.version import (  # pyright: ignore[reportImplicitRelativeImpo
     VersionDetector,
     VersionResult,
 )
+
+colorama_init()
+
+
+def style(text: str, *parts: str) -> str:
+    if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
+        return text
+    return "".join(parts) + text + Style.RESET_ALL
 
 
 class Args(argparse.Namespace):
@@ -70,10 +82,10 @@ def main() -> None:
         rev_changed = bool(result.rev) and result.rev != current_rev
         version_changed = pkg.version != result.version
 
-        print(name)
+        print(style(name, Fore.YELLOW + Style.BRIGHT))
 
         if not version_changed and not rev_changed:
-            print(f"  already at {pkg.version}")
+            print(f"  {style('already at ' + pkg.version, Fore.YELLOW)}")
             continue
 
         writer.update_version(recipe, pkg.pname, result.version)
@@ -81,9 +93,9 @@ def main() -> None:
             writer.update_git_rev(recipe, pkg.pname, result.rev)
 
         for field, old, new in writer.pending_changes:
-            print(f"  {field}")
-            print(f"    {old}  ->")
-            print(f"    {new}")
+            print(f"  {style(field, Style.BRIGHT)}")
+            print(f"    {style(f'-{old}', Fore.RED)}")
+            print(f"    {style(f'+{new}', Fore.GREEN)}")
 
         writer.apply(recipe)
 

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 from colorama import Fore, Style
@@ -41,6 +42,15 @@ def _print_changes(writer, before: int) -> None:
         print(f"  {style(field, Style.BRIGHT)}")
         print(f"    {style(f'-{old}', Fore.RED)}")
         print(f"    {style(f'+{new}', Fore.GREEN)}")
+
+
+@contextmanager
+def _progress(label: str):
+    print(f"  {style(label, Style.BRIGHT)} (in progress)", end="\r", flush=True)
+    try:
+        yield
+    finally:
+        _ = sys.stdout.write("\r\033[K")
 
 
 class Args(argparse.Namespace):
@@ -122,13 +132,19 @@ def main() -> None:
 
         if g is not None and not args.dry_run and not args.skip_prefetch:
             before = len(writer.pending_changes)
-            new_hash = prefetcher.prefetch_git(g.remote_url, result.rev, g.submodules)
+            with _progress("source.hash"):
+                new_hash = prefetcher.prefetch_git(
+                    g.remote_url, result.rev, g.submodules
+                )
             writer.update_source_hash(recipe, pkg.pname, new_hash)
             _print_changes(writer, before)
 
-            before = len(writer.pending_changes)
-            builder_hash.update(recipe, writer, pkg)
-            _print_changes(writer, before)
+            field = builder_hash.field_name(pkg)
+            if field:
+                before = len(writer.pending_changes)
+                with _progress(field):
+                    builder_hash.update(recipe, writer, pkg)
+                _print_changes(writer, before)
 
         writer.apply(recipe)
 

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -12,6 +12,9 @@ from colorama import init as colorama_init
 # path of this directory, making the sibling forge_update/ package
 # importable when this script runs inside its Nix wrapper.
 sys.path.insert(0, "@forgeUpdateDir@")
+from forge_update.builder import (  # pyright: ignore[reportImplicitRelativeImport]
+    BuilderHashUpdater,
+)
 from forge_update.hasher import (  # pyright: ignore[reportImplicitRelativeImport]
     HashPrefetcher,
 )
@@ -75,6 +78,7 @@ def main() -> None:
     parser = RecipeParser(args.recipes_root)
     detector = VersionDetector()
     prefetcher = HashPrefetcher(timeout=args.prefetch_timeout)
+    builder_hash = BuilderHashUpdater()
 
     for i, name in enumerate(args.recipe):
         if i > 0:
@@ -108,6 +112,7 @@ def main() -> None:
         if g is not None and not args.dry_run and not args.skip_prefetch:
             new_hash = prefetcher.prefetch_git(g.remote_url, result.rev, g.submodules)
             writer.update_source_hash(recipe, pkg.pname, new_hash)
+            builder_hash.update(recipe, writer, pkg)
 
         for field, old, new in writer.pending_changes:
             print(f"  {style(field, Style.BRIGHT)}")

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import subprocess
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -53,10 +54,20 @@ def _progress(label: str):
         _ = sys.stdout.write("\r\033[K")
 
 
+def _commit_recipe(recipe, pkg, result) -> None:
+    msg = f"feat({pkg.pname}): {pkg.version} -> {result.version}"
+    _ = subprocess.run(
+        ["git", "add", str(recipe.abs_path)], check=True, capture_output=True
+    )
+    _ = subprocess.run(["git", "commit", "-m", msg], check=True, capture_output=True)
+    print(f"  {style('committed', Style.DIM)}")
+
+
 class Args(argparse.Namespace):
     recipe: list[str] = []
     version: str | None = None
     dry_run: bool = False
+    commit: bool = False
     skip_prefetch: bool = False
     prefetch_timeout: int = 180
     recipes_root: Path = Path("recipes/packages")
@@ -70,6 +81,12 @@ def build_parser() -> argparse.ArgumentParser:
     _ = parser.add_argument("recipe", nargs="+")
     _ = parser.add_argument("--version")
     _ = parser.add_argument("--dry-run", action="store_true")
+    _ = parser.add_argument(
+        "--commit",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Commit recipe changes to git",
+    )
     _ = parser.add_argument("--skip-prefetch", action="store_true")
     _ = parser.add_argument(
         "--prefetch-timeout",
@@ -147,6 +164,9 @@ def main() -> None:
                 _print_changes(writer, before)
 
         writer.apply(recipe)
+
+        if args.commit and not args.dry_run:
+            _commit_recipe(recipe, pkg, result)
 
 
 if __name__ == "__main__":

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -36,6 +36,13 @@ def style(text: str, *parts: str) -> str:
     return "".join(parts) + text + Style.RESET_ALL
 
 
+def _print_changes(writer, before: int) -> None:
+    for field, old, new in writer.pending_changes[before:]:
+        print(f"  {style(field, Style.BRIGHT)}")
+        print(f"    {style(f'-{old}', Fore.RED)}")
+        print(f"    {style(f'+{new}', Fore.GREEN)}")
+
+
 class Args(argparse.Namespace):
     recipe: list[str] = []
     version: str | None = None
@@ -106,18 +113,22 @@ def main() -> None:
             continue
 
         writer.update_version(recipe, pkg.pname, result.version)
+        _print_changes(writer, 0)
+
         if result.rev:
+            before = len(writer.pending_changes)
             writer.update_git_rev(recipe, pkg.pname, result.rev)
+            _print_changes(writer, before)
 
         if g is not None and not args.dry_run and not args.skip_prefetch:
+            before = len(writer.pending_changes)
             new_hash = prefetcher.prefetch_git(g.remote_url, result.rev, g.submodules)
             writer.update_source_hash(recipe, pkg.pname, new_hash)
-            builder_hash.update(recipe, writer, pkg)
+            _print_changes(writer, before)
 
-        for field, old, new in writer.pending_changes:
-            print(f"  {style(field, Style.BRIGHT)}")
-            print(f"    {style(f'-{old}', Fore.RED)}")
-            print(f"    {style(f'+{new}', Fore.GREEN)}")
+            before = len(writer.pending_changes)
+            builder_hash.update(recipe, writer, pkg)
+            _print_changes(writer, before)
 
         writer.apply(recipe)
 

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -1,9 +1,11 @@
 """forge-update: Update forge package recipes to latest upstream versions."""
 
 import argparse
+import sys
 from pathlib import Path
 
-from .forge_update.recipe import (
+sys.path.insert(0, "@forgeUpdateDir@")
+from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImport]
     RecipeParser,
     RecipeWriter,
 )

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -12,6 +12,9 @@ from colorama import init as colorama_init
 # path of this directory, making the sibling forge_update/ package
 # importable when this script runs inside its Nix wrapper.
 sys.path.insert(0, "@forgeUpdateDir@")
+from forge_update.hasher import (  # pyright: ignore[reportImplicitRelativeImport]
+    HashPrefetcher,
+)
 from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImport]
     RecipeParser,
     RecipeWriter,
@@ -34,6 +37,8 @@ class Args(argparse.Namespace):
     recipe: list[str] = []
     version: str | None = None
     dry_run: bool = False
+    skip_prefetch: bool = False
+    prefetch_timeout: int = 180
     recipes_root: Path = Path("recipes/packages")
 
 
@@ -45,6 +50,13 @@ def build_parser() -> argparse.ArgumentParser:
     _ = parser.add_argument("recipe", nargs="+")
     _ = parser.add_argument("--version")
     _ = parser.add_argument("--dry-run", action="store_true")
+    _ = parser.add_argument("--skip-prefetch", action="store_true")
+    _ = parser.add_argument(
+        "--prefetch-timeout",
+        type=int,
+        default=180,
+        help="Timeout in seconds for each hash prefetch (default: 180)",
+    )
     _ = parser.add_argument(
         "--recipes-root",
         type=Path,
@@ -62,6 +74,7 @@ def main() -> None:
     args = parse_args()
     parser = RecipeParser(args.recipes_root)
     detector = VersionDetector()
+    prefetcher = HashPrefetcher(timeout=args.prefetch_timeout)
 
     for i, name in enumerate(args.recipe):
         if i > 0:
@@ -91,6 +104,10 @@ def main() -> None:
         writer.update_version(recipe, pkg.pname, result.version)
         if result.rev:
             writer.update_git_rev(recipe, pkg.pname, result.rev)
+
+        if g is not None and not args.dry_run and not args.skip_prefetch:
+            new_hash = prefetcher.prefetch_git(g.remote_url, result.rev, g.submodules)
+            writer.update_source_hash(recipe, pkg.pname, new_hash)
 
         for field, old, new in writer.pending_changes:
             print(f"  {style(field, Style.BRIGHT)}")

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -1,0 +1,47 @@
+"""forge-update: Update forge package recipes to latest upstream versions."""
+
+import argparse
+from pathlib import Path
+
+
+class Args(argparse.Namespace):
+    recipe: list[str] = []
+    version: str | None = None
+    dry_run: bool = False
+    recipes_root: Path = Path("recipes/packages")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Update forge package recipes to latest upstream versions",
+    )
+
+    _ = parser.add_argument("recipe", nargs="+")
+    _ = parser.add_argument("--version")
+    _ = parser.add_argument("--dry-run", action="store_true")
+    _ = parser.add_argument(
+        "--recipes-root",
+        type=Path,
+        default=Path("recipes/packages"),
+    )
+
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> Args:
+    return build_parser().parse_args(argv, namespace=Args())
+
+
+def main() -> None:
+    args = parse_args()
+
+    print(f"Recipes to update: {args.recipe}")
+    print(f"  recipes-root: {args.recipes_root}")
+    if args.version:
+        print(f"  explicit version: {args.version}")
+    if args.dry_run:
+        print("  dry-run: enabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -168,7 +168,14 @@ def main() -> None:
                 writer.update_git_rev(recipe, pkg.pname, result.rev)
                 _print_changes(writer, before)
 
-            if g is not None and not args.dry_run and not args.skip_prefetch:
+            should_prefetch = (
+                g is not None
+                and result.rev
+                and not args.dry_run
+                and not args.skip_prefetch
+            )
+            if should_prefetch:
+                assert g is not None
                 before = len(writer.pending_changes)
                 with _progress("source.hash"):
                     new_hash = prefetcher.prefetch_git(

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -4,6 +4,9 @@ import argparse
 import sys
 from pathlib import Path
 
+# At build time default.nix replaces @forgeUpdateDir@ with the Nix-store
+# path of this directory, making the sibling forge_update/ package
+# importable when this script runs inside its Nix wrapper.
 sys.path.insert(0, "@forgeUpdateDir@")
 from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImport]
     RecipeParser,

--- a/flake/develop/commands/dev/update/forge-update.py
+++ b/flake/develop/commands/dev/update/forge-update.py
@@ -17,6 +17,9 @@ sys.path.insert(0, "@forgeUpdateDir@")
 from forge_update.builder import (  # pyright: ignore[reportImplicitRelativeImport]
     BuilderHashUpdater,
 )
+from forge_update.errors import (  # pyright: ignore[reportImplicitRelativeImport]
+    ForgeUpdateError,
+)
 from forge_update.hasher import (  # pyright: ignore[reportImplicitRelativeImport]
     HashPrefetcher,
 )
@@ -65,6 +68,7 @@ def _commit_recipe(recipe, pkg, result) -> None:
 
 class Args(argparse.Namespace):
     recipe: list[str] = []
+    all: bool = False
     version: str | None = None
     dry_run: bool = False
     commit: bool = False
@@ -78,7 +82,12 @@ def build_parser() -> argparse.ArgumentParser:
         description="Update forge package recipes to latest upstream versions",
     )
 
-    _ = parser.add_argument("recipe", nargs="+")
+    _ = parser.add_argument("recipe", nargs="*", default=[], metavar="RECIPE")
+    _ = parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Update all recipes in --recipes-root",
+    )
     _ = parser.add_argument("--version")
     _ = parser.add_argument("--dry-run", action="store_true")
     _ = parser.add_argument(
@@ -109,64 +118,80 @@ def parse_args(argv: list[str] | None = None) -> Args:
 
 def main() -> None:
     args = parse_args()
+
+    if not args.recipe and not args.all:
+        build_parser().print_help()
+        sys.exit(0)
+
+    if args.all and args.recipe:
+        build_parser().error("--all cannot be used with recipe names")
+
+    names = (
+        sorted(p.name for p in args.recipes_root.iterdir()) if args.all else args.recipe
+    )
+
     parser = RecipeParser(args.recipes_root)
     detector = VersionDetector()
     prefetcher = HashPrefetcher(timeout=args.prefetch_timeout)
     builder_hash = BuilderHashUpdater()
 
-    for i, name in enumerate(args.recipe):
+    for i, name in enumerate(names):
         if i > 0:
             print()
+        try:
+            path = parser.find(name)
+            recipe = parser.parse(path)
+            pkg = recipe.packages[0]
+            writer = RecipeWriter(dry_run=args.dry_run)
 
-        path = parser.find(name)
-        recipe = parser.parse(path)
-        pkg = recipe.packages[0]
-        writer = RecipeWriter(dry_run=args.dry_run)
+            if args.version:
+                result = VersionResult(version=args.version, rev="")
+            else:
+                result = detector.detect(recipe)
 
-        if args.version:
-            result = VersionResult(version=args.version, rev="")
-        else:
-            result = detector.detect(recipe)
+            g = pkg.source.git
+            current_rev = g.rev if g else ""
+            rev_changed = bool(result.rev) and result.rev != current_rev
+            version_changed = pkg.version != result.version
 
-        g = pkg.source.git
-        current_rev = g.rev if g else ""
-        rev_changed = bool(result.rev) and result.rev != current_rev
-        version_changed = pkg.version != result.version
+            print(style(name, Fore.YELLOW + Style.BRIGHT))
 
-        print(style(name, Fore.YELLOW + Style.BRIGHT))
+            if not version_changed and not rev_changed:
+                print(f"  {style('already at ' + pkg.version, Fore.YELLOW)}")
+                continue
 
-        if not version_changed and not rev_changed:
-            print(f"  {style('already at ' + pkg.version, Fore.YELLOW)}")
-            continue
+            writer.update_version(recipe, pkg.pname, result.version)
+            _print_changes(writer, 0)
 
-        writer.update_version(recipe, pkg.pname, result.version)
-        _print_changes(writer, 0)
-
-        if result.rev:
-            before = len(writer.pending_changes)
-            writer.update_git_rev(recipe, pkg.pname, result.rev)
-            _print_changes(writer, before)
-
-        if g is not None and not args.dry_run and not args.skip_prefetch:
-            before = len(writer.pending_changes)
-            with _progress("source.hash"):
-                new_hash = prefetcher.prefetch_git(
-                    g.remote_url, result.rev, g.submodules
-                )
-            writer.update_source_hash(recipe, pkg.pname, new_hash)
-            _print_changes(writer, before)
-
-            field = builder_hash.field_name(pkg)
-            if field:
+            if result.rev:
                 before = len(writer.pending_changes)
-                with _progress(field):
-                    builder_hash.update(recipe, writer, pkg)
+                writer.update_git_rev(recipe, pkg.pname, result.rev)
                 _print_changes(writer, before)
 
-        writer.apply(recipe)
+            if g is not None and not args.dry_run and not args.skip_prefetch:
+                before = len(writer.pending_changes)
+                with _progress("source.hash"):
+                    new_hash = prefetcher.prefetch_git(
+                        g.remote_url, result.rev, g.submodules
+                    )
+                writer.update_source_hash(recipe, pkg.pname, new_hash)
+                _print_changes(writer, before)
 
-        if args.commit and not args.dry_run:
-            _commit_recipe(recipe, pkg, result)
+                field = builder_hash.field_name(pkg)
+                if field:
+                    before = len(writer.pending_changes)
+                    with _progress(field):
+                        builder_hash.update(recipe, writer, pkg)
+                    _print_changes(writer, before)
+
+            writer.apply(recipe)
+
+            if args.commit and not args.dry_run:
+                _commit_recipe(recipe, pkg, result)
+        except ForgeUpdateError as e:
+            print(style(name, Fore.YELLOW + Style.BRIGHT))
+            print(f"  {style(str(e), Fore.RED)}")
+            continue
 
 
 if __name__ == "__main__":

--- a/flake/develop/commands/dev/update/forge_update/__main__.py
+++ b/flake/develop/commands/dev/update/forge_update/__main__.py
@@ -4,33 +4,19 @@ import argparse
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 from colorama import Fore, Style
 from colorama import init as colorama_init
 
-# At build time default.nix replaces @forgeUpdateDir@ with the Nix-store
-# path of this directory, making the sibling forge_update/ package
-# importable when this script runs inside its Nix wrapper.
-sys.path.insert(0, "@forgeUpdateDir@")
-from forge_update.builder import (  # pyright: ignore[reportImplicitRelativeImport]
-    BuilderHashUpdater,
-)
-from forge_update.errors import (  # pyright: ignore[reportImplicitRelativeImport]
-    ForgeUpdateError,
-)
-from forge_update.hasher import (  # pyright: ignore[reportImplicitRelativeImport]
-    HashPrefetcher,
-)
-from forge_update.recipe import (  # pyright: ignore[reportImplicitRelativeImport]
-    RecipeParser,
-    RecipeWriter,
-)
-from forge_update.version import (  # pyright: ignore[reportImplicitRelativeImport]
-    VersionDetector,
-    VersionResult,
-)
+from .builder import BuilderHashUpdater
+from .errors import ForgeUpdateError
+from .hasher import HashPrefetcher
+from .recipe import RecipeParser, RecipeWriter
+from .types import PackageEntry, Recipe
+from .version import VersionDetector, VersionResult
 
 colorama_init()
 
@@ -41,7 +27,7 @@ def style(text: str, *parts: str) -> str:
     return "".join(parts) + text + Style.RESET_ALL
 
 
-def _print_changes(writer, before: int) -> None:
+def _print_changes(writer: RecipeWriter, before: int) -> None:
     for field, old, new in writer.pending_changes[before:]:
         print(f"  {style(field, Style.BRIGHT)}")
         print(f"    {style(f'-{old}', Fore.RED)}")
@@ -49,7 +35,7 @@ def _print_changes(writer, before: int) -> None:
 
 
 @contextmanager
-def _progress(label: str):
+def _progress(label: str) -> Iterator[None]:
     print(f"  {style(label, Style.BRIGHT)} (in progress)", end="\r", flush=True)
     try:
         yield
@@ -57,7 +43,7 @@ def _progress(label: str):
         _ = sys.stdout.write("\r\033[K")
 
 
-def _commit_recipe(recipe, pkg, result) -> None:
+def _commit_recipe(recipe: Recipe, pkg: PackageEntry, result: VersionResult) -> None:
     msg = f"feat({pkg.pname}): {pkg.version} -> {result.version}"
     _ = subprocess.run(
         ["git", "add", str(recipe.abs_path)], check=True, capture_output=True

--- a/flake/develop/commands/dev/update/forge_update/__main__.py
+++ b/flake/develop/commands/dev/update/forge_update/__main__.py
@@ -44,7 +44,7 @@ def _progress(label: str) -> Iterator[None]:
 
 
 def _commit_recipe(recipe: Recipe, pkg: PackageEntry, result: VersionResult) -> None:
-    msg = f"feat({pkg.pname}): {pkg.version} -> {result.version}"
+    msg = f"recipes({pkg.pname}): {pkg.version} -> {result.version}"
     _ = subprocess.run(
         ["git", "add", str(recipe.abs_path)], check=True, capture_output=True
     )

--- a/flake/develop/commands/dev/update/forge_update/builder.py
+++ b/flake/develop/commands/dev/update/forge_update/builder.py
@@ -1,16 +1,30 @@
 import re
 import subprocess
 
-from . import regexes as _
+from . import regexes
 from .errors import BuildError
 from .types import BuilderType
 
-
-_HASH_MISMATCH_RE = re.compile(_.NIX_BUILD_GOT_HASH)
+HASH_MISMATCH_RE = re.compile(regexes.NIX_BUILD_GOT_HASH)
 
 
 class BuilderHashUpdater:
     build_timeout: int = 300
+
+    def field_name(self, pkg) -> str | None:
+        bt = pkg.builder_type
+        if bt is None or bt == BuilderType.STANDARD:
+            return None
+        if bt == BuilderType.GO:
+            bh = pkg.builder_hashes
+            if bh is not None and bh.vendor_hash is not None:
+                return "vendorHash"
+            return None
+        return {
+            BuilderType.RUST: "cargoHash",
+            BuilderType.NPM: "npmDepsHash",
+            BuilderType.PNPM: "pnpmDepsHash",
+        }[bt]
 
     def update(self, recipe, writer, pkg) -> None:
         bt = pkg.builder_type
@@ -57,7 +71,7 @@ class BuilderHashUpdater:
             raise BuildError(pname, -1, f"nix build timed out ({self.build_timeout}s)")
 
         stderr = result.stderr or ""
-        match = _HASH_MISMATCH_RE.search(stderr)
+        match = HASH_MISMATCH_RE.search(stderr)
         if not match:
             raise BuildError(pname, result.returncode, stderr)
 

--- a/flake/develop/commands/dev/update/forge_update/builder.py
+++ b/flake/develop/commands/dev/update/forge_update/builder.py
@@ -11,6 +11,9 @@ HASH_MISMATCH_RE = re.compile(regexes.NIX_BUILD_GOT_HASH)
 class BuilderHashUpdater:
     build_timeout: int = 300
 
+    def __init__(self, dry_run: bool = False) -> None:
+        self.dry_run = dry_run
+
     def field_name(self, pkg) -> str | None:
         match pkg.builder_type:
             case BuilderType.GO:
@@ -65,6 +68,9 @@ class BuilderHashUpdater:
     def _update_single(
         self, recipe, pname: str, writer, field_name: str, updater
     ) -> None:
+        if self.dry_run:
+            return
+
         before = len(writer.pending_changes)
 
         recipe.abs_path.write_text("".join(recipe.raw_lines))

--- a/flake/develop/commands/dev/update/forge_update/builder.py
+++ b/flake/develop/commands/dev/update/forge_update/builder.py
@@ -1,0 +1,74 @@
+import re
+import subprocess
+
+from . import regexes as _
+from .errors import BuildError
+from .types import BuilderType
+
+
+_HASH_MISMATCH_RE = re.compile(_.NIX_BUILD_GOT_HASH)
+
+
+class BuilderHashUpdater:
+    build_timeout: int = 300
+
+    def update(self, recipe, writer, pkg) -> None:
+        bt = pkg.builder_type
+        if bt is None or bt == BuilderType.STANDARD:
+            return
+
+        if bt == BuilderType.RUST:
+            self._update_single(
+                recipe, pkg.pname, writer, "cargoHash", writer.update_cargo_hash
+            )
+        elif bt == BuilderType.GO:
+            bh = pkg.builder_hashes
+            if bh is not None and bh.vendor_hash is not None:
+                self._update_single(
+                    recipe, pkg.pname, writer, "vendorHash", writer.update_vendor_hash
+                )
+        elif bt == BuilderType.NPM:
+            self._update_single(
+                recipe, pkg.pname, writer, "npmDepsHash", writer.update_npm_deps_hash
+            )
+        elif bt == BuilderType.PNPM:
+            self._update_single(
+                recipe, pkg.pname, writer, "pnpmDepsHash", writer.update_pnpm_deps_hash
+            )
+
+    def _update_single(
+        self, recipe, pname: str, writer, field_name: str, updater
+    ) -> None:
+        before = len(writer.pending_changes)
+
+        recipe.abs_path.write_text("".join(recipe.raw_lines))
+
+        updater(recipe, pname, "")
+        recipe.abs_path.write_text("".join(recipe.raw_lines))
+
+        try:
+            result = subprocess.run(
+                ["nix", "build", f".#{pname}"],
+                capture_output=True,
+                text=True,
+                timeout=self.build_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            raise BuildError(pname, -1, f"nix build timed out ({self.build_timeout}s)")
+
+        stderr = result.stderr or ""
+        match = _HASH_MISMATCH_RE.search(stderr)
+        if not match:
+            raise BuildError(pname, result.returncode, stderr)
+
+        new_hash = match.group(1)
+        updater(recipe, pname, new_hash)
+
+        if len(writer.pending_changes) >= before + 2:
+            old_val = writer.pending_changes[before][1]
+            writer.pending_changes[before] = (
+                field_name,
+                old_val,
+                new_hash,
+            )
+            del writer.pending_changes[before + 1]

--- a/flake/develop/commands/dev/update/forge_update/builder.py
+++ b/flake/develop/commands/dev/update/forge_update/builder.py
@@ -12,43 +12,55 @@ class BuilderHashUpdater:
     build_timeout: int = 300
 
     def field_name(self, pkg) -> str | None:
-        bt = pkg.builder_type
-        if bt is None or bt == BuilderType.STANDARD:
-            return None
-        if bt == BuilderType.GO:
-            bh = pkg.builder_hashes
-            if bh is not None and bh.vendor_hash is not None:
-                return "vendorHash"
-            return None
-        return {
-            BuilderType.RUST: "cargoHash",
-            BuilderType.NPM: "npmDepsHash",
-            BuilderType.PNPM: "pnpmDepsHash",
-        }[bt]
+        match pkg.builder_type:
+            case BuilderType.GO:
+                bh = pkg.builder_hashes
+                if bh is not None and bh.vendor_hash is not None:
+                    return "vendorHash"
+                return None
+            case BuilderType.RUST:
+                return "cargoHash"
+            case BuilderType.NPM:
+                return "npmDepsHash"
+            case BuilderType.PNPM:
+                return "pnpmDepsHash"
+            case _:
+                return None
 
     def update(self, recipe, writer, pkg) -> None:
-        bt = pkg.builder_type
-        if bt is None or bt == BuilderType.STANDARD:
-            return
-
-        if bt == BuilderType.RUST:
-            self._update_single(
-                recipe, pkg.pname, writer, "cargoHash", writer.update_cargo_hash
-            )
-        elif bt == BuilderType.GO:
-            bh = pkg.builder_hashes
-            if bh is not None and bh.vendor_hash is not None:
+        match pkg.builder_type:
+            case BuilderType.RUST:
                 self._update_single(
-                    recipe, pkg.pname, writer, "vendorHash", writer.update_vendor_hash
+                    recipe, pkg.pname, writer, "cargoHash", writer.update_cargo_hash
                 )
-        elif bt == BuilderType.NPM:
-            self._update_single(
-                recipe, pkg.pname, writer, "npmDepsHash", writer.update_npm_deps_hash
-            )
-        elif bt == BuilderType.PNPM:
-            self._update_single(
-                recipe, pkg.pname, writer, "pnpmDepsHash", writer.update_pnpm_deps_hash
-            )
+            case BuilderType.GO:
+                bh = pkg.builder_hashes
+                if bh is not None and bh.vendor_hash is not None:
+                    self._update_single(
+                        recipe,
+                        pkg.pname,
+                        writer,
+                        "vendorHash",
+                        writer.update_vendor_hash,
+                    )
+            case BuilderType.NPM:
+                self._update_single(
+                    recipe,
+                    pkg.pname,
+                    writer,
+                    "npmDepsHash",
+                    writer.update_npm_deps_hash,
+                )
+            case BuilderType.PNPM:
+                self._update_single(
+                    recipe,
+                    pkg.pname,
+                    writer,
+                    "pnpmDepsHash",
+                    writer.update_pnpm_deps_hash,
+                )
+            case _:
+                return
 
     def _update_single(
         self, recipe, pname: str, writer, field_name: str, updater

--- a/flake/develop/commands/dev/update/forge_update/builder.py
+++ b/flake/develop/commands/dev/update/forge_update/builder.py
@@ -1,9 +1,12 @@
 import re
 import subprocess
 
+from typing import Callable
+
 from . import regexes
 from .errors import BuildError
-from .types import BuilderType
+from .recipe import Recipe, RecipeWriter
+from .types import BuilderType, PackageEntry
 
 HASH_MISMATCH_RE = re.compile(regexes.NIX_BUILD_GOT_HASH)
 
@@ -14,7 +17,7 @@ class BuilderHashUpdater:
     def __init__(self, dry_run: bool = False) -> None:
         self.dry_run = dry_run
 
-    def field_name(self, pkg) -> str | None:
+    def field_name(self, pkg: PackageEntry) -> str | None:
         match pkg.builder_type:
             case BuilderType.GO:
                 bh = pkg.builder_hashes
@@ -30,7 +33,7 @@ class BuilderHashUpdater:
             case _:
                 return None
 
-    def update(self, recipe, writer, pkg) -> None:
+    def update(self, recipe: Recipe, writer: RecipeWriter, pkg: PackageEntry) -> None:
         match pkg.builder_type:
             case BuilderType.RUST:
                 self._update_single(
@@ -66,7 +69,12 @@ class BuilderHashUpdater:
                 return
 
     def _update_single(
-        self, recipe, pname: str, writer, field_name: str, updater
+        self,
+        recipe: Recipe,
+        pname: str,
+        writer: RecipeWriter,
+        field_name: str,
+        updater: Callable[..., None],
     ) -> None:
         if self.dry_run:
             return

--- a/flake/develop/commands/dev/update/forge_update/errors.py
+++ b/flake/develop/commands/dev/update/forge_update/errors.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from .types import Source
+
+
+class ForgeUpdateError(Exception):
+    """Base for all forge-update errors."""
+
+
+class RecipeNotFoundError(ForgeUpdateError):
+    def __init__(self, name: str, search_dir: Path) -> None:
+        super().__init__(f"Recipe '{name}' not found in {search_dir}")
+
+
+class RecipeParseError(ForgeUpdateError):
+    def __init__(self, path: Path, detail: str) -> None:
+        super().__init__(f"Failed to parse {path}: {detail}")
+
+
+class VersionDetectionError(ForgeUpdateError):
+    def __init__(self, source: Source, detail: str) -> None:
+        super().__init__(f"Cannot detect version from {source.type.name}: {detail}")
+
+
+class PrefetchError(ForgeUpdateError):
+    def __init__(self, detail: str) -> None:
+        super().__init__(f"Prefetch failed: {detail}")
+
+
+class BuildError(ForgeUpdateError):
+    exit_code: int
+    stderr: str
+
+    def __init__(self, pname: str, exit_code: int, stderr: str) -> None:
+        super().__init__(f"Build of '{pname}' failed (exit {exit_code})")
+        self.exit_code = exit_code
+        self.stderr = stderr
+
+
+class HashExtractionError(ForgeUpdateError):
+    def __init__(self, pname: str, detail: str) -> None:
+        super().__init__(f"Cannot extract hash for '{pname}': {detail}")
+
+
+class NoUpdateNeeded(ForgeUpdateError):
+    def __init__(self, pname: str, version: str) -> None:
+        super().__init__(f"'{pname}' already at latest ({version})")
+
+
+class UnsupportedRecipeError(ForgeUpdateError):
+    def __init__(self, pname: str, reason: str) -> None:
+        super().__init__(f"'{pname}' cannot be auto-updated: {reason}")

--- a/flake/develop/commands/dev/update/forge_update/errors.py
+++ b/flake/develop/commands/dev/update/forge_update/errors.py
@@ -37,16 +37,6 @@ class BuildError(ForgeUpdateError):
         self.stderr = stderr
 
 
-class HashExtractionError(ForgeUpdateError):
-    def __init__(self, pname: str, detail: str) -> None:
-        super().__init__(f"Cannot extract hash for '{pname}': {detail}")
-
-
-class NoUpdateNeeded(ForgeUpdateError):
-    def __init__(self, pname: str, version: str) -> None:
-        super().__init__(f"'{pname}' already at latest ({version})")
-
-
 class UnsupportedRecipeError(ForgeUpdateError):
     def __init__(self, pname: str, reason: str) -> None:
         super().__init__(f"'{pname}' cannot be auto-updated: {reason}")

--- a/flake/develop/commands/dev/update/forge_update/hasher.py
+++ b/flake/develop/commands/dev/update/forge_update/hasher.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+
+from .errors import PrefetchError
+
+
+class HashPrefetcher:
+    prefetch_timeout: int
+
+    def __init__(self, timeout: int = 180) -> None:
+        self.prefetch_timeout = timeout
+
+    def prefetch_git(self, remote_url: str, rev: str, submodules: bool = False) -> str:
+        cmd = ["nix-prefetch-git", remote_url, "--rev", rev]
+        if submodules:
+            cmd.append("--fetch-submodules")
+
+        stdout, stderr, returncode = self._run(cmd)
+        if returncode != 0:
+            raise PrefetchError(
+                f"nix-prefetch-git failed (exit {returncode}): {stderr}"
+            )
+
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            raise PrefetchError(f"failed to parse nix-prefetch-git output: {e}")
+
+        hash_val = data.get("hash")
+        if not hash_val:
+            raise PrefetchError("nix-prefetch-git output missing 'hash' field")
+        return hash_val
+
+    def prefetch_url(self, url: str) -> str:
+        stdout, stderr, returncode = self._run(["nix-prefetch-url", url])
+        if returncode != 0:
+            raise PrefetchError(
+                f"nix-prefetch-url failed (exit {returncode}): {stderr}"
+            )
+
+        base32_hash = stdout.strip()
+        if not base32_hash:
+            raise PrefetchError("nix-prefetch-url produced empty output")
+
+        sri_stdout, sri_stderr, sri_returncode = self._run(
+            ["nix", "hash", "to-sri", "--type", "sha256"],
+            input=base32_hash,
+        )
+        if sri_returncode != 0:
+            raise PrefetchError(
+                f"nix hash to-sri failed (exit {sri_returncode}): {sri_stderr}"
+            )
+        return sri_stdout.strip()
+
+    def _run(self, cmd: list[str], input: str | None = None) -> tuple[str, str, int]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.prefetch_timeout,
+                input=input,
+            )
+            return result.stdout, result.stderr, result.returncode
+        except subprocess.TimeoutExpired:
+            cmd_str = " ".join(cmd[:2]) + "..."
+            raise PrefetchError(f"{cmd_str} timed out ({self.prefetch_timeout}s)")
+        except FileNotFoundError as e:
+            raise PrefetchError(f"{e.filename} not found")

--- a/flake/develop/commands/dev/update/forge_update/hasher.py
+++ b/flake/develop/commands/dev/update/forge_update/hasher.py
@@ -31,35 +31,13 @@ class HashPrefetcher:
             raise PrefetchError("nix-prefetch-git output missing 'hash' field")
         return hash_val
 
-    def prefetch_url(self, url: str) -> str:
-        stdout, stderr, returncode = self._run(["nix-prefetch-url", url])
-        if returncode != 0:
-            raise PrefetchError(
-                f"nix-prefetch-url failed (exit {returncode}): {stderr}"
-            )
-
-        base32_hash = stdout.strip()
-        if not base32_hash:
-            raise PrefetchError("nix-prefetch-url produced empty output")
-
-        sri_stdout, sri_stderr, sri_returncode = self._run(
-            ["nix", "hash", "to-sri", "--type", "sha256"],
-            input=base32_hash,
-        )
-        if sri_returncode != 0:
-            raise PrefetchError(
-                f"nix hash to-sri failed (exit {sri_returncode}): {sri_stderr}"
-            )
-        return sri_stdout.strip()
-
-    def _run(self, cmd: list[str], input: str | None = None) -> tuple[str, str, int]:
+    def _run(self, cmd: list[str]) -> tuple[str, str, int]:
         try:
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 timeout=self.prefetch_timeout,
-                input=input,
             )
             return result.stdout, result.stderr, result.returncode
         except subprocess.TimeoutExpired:

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -86,9 +86,15 @@ class RecipeParser:
         return match.group(1)
 
     def _parse_source(self, text: str, path: Path) -> Source:
+        """Parse source fields from a scoped package block.
+
+        Within a `packages.<name> = { ... }` block each source field
+        (git/url/path) appears at most once, so plain word-boundary
+        matching is sufficient.
+        """
         source_hash = self._extract_source_hash(text)
 
-        git_match = re.search(r'(?<!\w)git\s*=\s*"([^"]*)"', text)
+        git_match = re.search(r'\bgit\s*=\s*"([^"]*)"', text)
         if git_match:
             return Source(
                 type=SourceType.GIT,
@@ -96,7 +102,7 @@ class RecipeParser:
                 hash=source_hash,
             )
 
-        url_match = re.search(r'(?<!\w)url\s*=\s*"([^"]*)"', text)
+        url_match = re.search(r'\burl\s*=\s*"([^"]*)"', text)
         if url_match:
             return Source(
                 type=SourceType.URL,
@@ -104,7 +110,7 @@ class RecipeParser:
                 hash=source_hash,
             )
 
-        path_match = re.search(r"(?<!\w)path\s*=\s*(\./[\w./-]+)", text)
+        path_match = re.search(r'\bpath\s*=\s*(\./[\w./-]+)', text)
         if path_match:
             return Source(
                 type=SourceType.PATH,

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -41,13 +41,15 @@ class RecipeParser:
             version = self._extract_version(block_text, path)
             source = self._parse_source(block_text, path)
             builder_type, builder_hashes = self._parse_builder(block_text)
-            packages.append(PackageEntry(
-                pname=pname,
-                version=version,
-                source=source,
-                builder_type=builder_type,
-                builder_hashes=builder_hashes,
-            ))
+            packages.append(
+                PackageEntry(
+                    pname=pname,
+                    version=version,
+                    source=source,
+                    builder_type=builder_type,
+                    builder_hashes=builder_hashes,
+                )
+            )
 
         return Recipe(
             rel_path=path.parent,
@@ -58,7 +60,7 @@ class RecipeParser:
 
     def _extract_package_blocks(self, text: str) -> list[tuple[str, str]]:
         blocks: list[tuple[str, str]] = []
-        for match in re.finditer(r'packages\.([\w-]+)\s*=\s*\{', text):
+        for match in re.finditer(r"packages\.([\w-]+)\s*=\s*\{", text):
             pname = match.group(1)
             start = match.start()
             depth = 1
@@ -203,19 +205,26 @@ class RecipeWriter:
 
     def update_version(self, recipe: Recipe, pname: str, new_version: str) -> None:
         self._replace(
-            recipe, pname, r'version\s*=\s*"([^"]*)"',
-            f'version = "{new_version}"', "version",
+            recipe,
+            pname,
+            r'version\s*=\s*"([^"]*)"',
+            f'version = "{new_version}"',
+            "version",
         )
 
     def update_source_git(self, recipe: Recipe, pname: str, new_git: str) -> None:
         self._replace(
-            recipe, pname, r'git\s*=\s*"([^"]*)"',
-            f'git = "{new_git}"', "source.git",
+            recipe,
+            pname,
+            r'git\s*=\s*"([^"]*)"',
+            f'git = "{new_git}"',
+            "source.git",
         )
 
     def update_source_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
         self._replace(
-            recipe, pname,
+            recipe,
+            pname,
             r'(?<!cargo)(?<!vendor)(?<!\w)hash\s*=\s*"([^"]*)"',
             f'hash = "{new_hash}"',
             "source.hash",
@@ -223,7 +232,8 @@ class RecipeWriter:
 
     def update_cargo_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
         self._replace(
-            recipe, pname,
+            recipe,
+            pname,
             r'cargoHash\s*=\s*"([^"]*)"',
             f'cargoHash = "{new_hash}"',
             "cargoHash",
@@ -231,7 +241,8 @@ class RecipeWriter:
 
     def update_vendor_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
         self._replace(
-            recipe, pname,
+            recipe,
+            pname,
             r'vendorHash\s*=\s*"([^"]*)"',
             f'vendorHash = "{new_hash}"',
             "vendorHash",
@@ -266,9 +277,7 @@ class RecipeWriter:
 
         new_block, count = re.subn(pattern, replacement, block_text, count=1)
         if count == 0:
-            raise RecipeParseError(
-                recipe.abs_path, f"cannot find {field} for {pname}"
-            )
+            raise RecipeParseError(recipe.abs_path, f"cannot find {field} for {pname}")
 
         new_text = text[:block_start] + new_block + text[block_end:]
         recipe.raw_lines = new_text.splitlines(keepends=True)

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -59,6 +59,11 @@ class RecipeParser:
         )
 
     def _extract_package_blocks(self, text: str) -> list[tuple[str, str]]:
+        """Find each packages.<name> = { ... } block via brace-counting.
+
+        Pure regex cannot match balanced braces, so we scan
+        character-by-character counting depth instead.
+        """
         blocks: list[tuple[str, str]] = []
         for match in re.finditer(r"packages\.([\w-]+)\s*=\s*\{", text):
             pname = match.group(1)
@@ -166,6 +171,8 @@ class RecipeParser:
             "pythonPackage": BuilderType.PYTHON_PACKAGE,
         }
 
+        # re.DOTALL lets `.' span newlines. We need this because
+        # the builder name and `enable = true' are on separate lines.
         builder_match = re.search(
             r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true", text, re.DOTALL
         )
@@ -251,9 +258,12 @@ class RecipeWriter:
     def _find_package_block(
         self, text: str, pname: str, abs_path: Path
     ) -> tuple[int, int, str]:
-        for match in re.finditer(
-            rf'packages\.{re.escape(pname)}\s*=\s*\{{', text
-        ):
+        """Return (start, end, block-text) for a `packages.<pname>` block.
+
+        Uses the same brace-counting approach as `_extract_package_blocks`
+        so that nested { } inside builder configs don't confuse the scan.
+        """
+        for match in re.finditer(rf"packages\.{re.escape(pname)}\s*=\s*\{{", text):
             start = match.start()
             depth = 1
             pos = match.end()

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -149,13 +149,30 @@ class RecipeParser:
 
         submodules = bool(re.search(regexes.SUBMODULES, text))
 
+        remote_url = self._forge_remote_url(host, owner, repo)
+
         return GitSource(
-            host=host, owner=owner, repo=repo, rev=rev, submodules=submodules
+            host=host,
+            owner=owner,
+            repo=repo,
+            rev=rev,
+            remote_url=remote_url,
+            submodules=submodules,
         )
+
+    @staticmethod
+    def _forge_remote_url(host: ForgeHost, owner: str, repo: str) -> str:
+        match host:
+            case ForgeHost.CODEBERG | ForgeHost.FORGEJO:
+                return f"https://{host.value}.org/{owner}/{repo}"
+            case _:
+                return f"https://{host.value}.com/{owner}/{repo}"
 
     def _parse_generic_git(self, rest: str, text: str) -> GitSource:
         rev_match = re.search(regexes.GIT_REV, rest)
         rev = rev_match.group(1) if rev_match else "HEAD"
+
+        remote_url = rest.split("?")[0] if "?" in rest else rest
 
         submodules = bool(re.search(regexes.SUBMODULES, text))
 
@@ -164,6 +181,7 @@ class RecipeParser:
             owner="",
             repo="",
             rev=rev,
+            remote_url=remote_url,
             submodules=submodules,
         )
 

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -109,7 +109,7 @@ class RecipeParser:
         raise RecipeParseError(path, "no source (git/url/path) found")
 
     def _extract_source_hash(self, text: str) -> str:
-        match = re.search(r'(?<!cargo)(?<!vendor)(?<!\w)hash\s*=\s*"([^"]*)"', text)
+        match = re.search(r'\bhash\s*=\s*"([^"]*)"', text)
         return match.group(1) if match else ""
 
     def _parse_git(self, spec: str, text: str, path: Path) -> GitSource:
@@ -225,7 +225,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'(?<!cargo)(?<!vendor)(?<!\w)hash\s*=\s*"([^"]*)"',
+            r'\bhash\s*=\s*"([^"]*)"',
             f'hash = "{new_hash}"',
             "source.hash",
         )

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -17,6 +17,19 @@ from .types import (
 )
 
 
+def _extract_braced_block(text: str, brace_start: int) -> tuple[int, str]:
+    """Return (end_pos, block_text) for the balanced brace pair at brace_start."""
+    depth = 1
+    pos = brace_start + 1
+    while pos < len(text) and depth > 0:
+        if text[pos] == "{":
+            depth += 1
+        elif text[pos] == "}":
+            depth -= 1
+        pos += 1
+    return pos, text[brace_start:pos]
+
+
 class RecipeParser:
     recipes_root: Path
 
@@ -76,15 +89,8 @@ class RecipeParser:
         for match in re.finditer(regexes.PACKAGE_BLOCK, text):
             pname = match.group(1)
             start = match.start()
-            depth = 1
-            pos = match.end()
-            while pos < len(text) and depth > 0:
-                if text[pos] == "{":
-                    depth += 1
-                elif text[pos] == "}":
-                    depth -= 1
-                pos += 1
-            blocks.append((pname, text[start:pos]))
+            end_pos, _ = _extract_braced_block(text, match.end() - 1)
+            blocks.append((pname, text[start:end_pos]))
         return blocks
 
     def _extract_version(self, text: str, path: Path) -> str:
@@ -203,33 +209,29 @@ class RecipeParser:
             "pythonPackage": BuilderType.PYTHON_PACKAGE,
         }
 
-        # re.DOTALL lets `.' span newlines. We need this because
-        # the builder name and `enable = true' are on separate lines.
-        builder_match = re.search(regexes.ENABLED_BUILDER, text, re.DOTALL)
-        if not builder_match:
-            return BuilderType.STANDARD, BuilderHashes()
+        for match in re.finditer(regexes.BUILDER_DECL, text):
+            _, block_text = _extract_braced_block(text, match.end() - 1)
+            if re.search(r"\benable\b\s*=\s*true", block_text):
+                builder_key = match.group(1)
+                builder_type = builder_map.get(builder_key, BuilderType.STANDARD)
 
-        builder_key = builder_match.group(1)
-        builder_type = builder_map.get(builder_key, BuilderType.STANDARD)
+                hashes = BuilderHashes()
+                cargo = re.search(regexes.FIELD_CARGO_HASH, text)
+                if cargo:
+                    hashes.cargo_hash = cargo.group(1)
+                vendor = re.search(regexes.FIELD_VENDOR_HASH, text)
+                if vendor:
+                    hashes.vendor_hash = vendor.group(1)
+                npm = re.search(regexes.FIELD_NPM_DEPS_HASH, text)
+                if npm:
+                    hashes.npm_deps_hash = npm.group(1)
+                pnpm = re.search(regexes.FIELD_PNPM_DEPS_HASH, text)
+                if pnpm:
+                    hashes.pnpm_deps_hash = pnpm.group(1)
 
-        hashes = BuilderHashes()
-        cargo = re.search(regexes.FIELD_CARGO_HASH, text)
-        if cargo:
-            hashes.cargo_hash = cargo.group(1)
+                return builder_type, hashes
 
-        vendor = re.search(regexes.FIELD_VENDOR_HASH, text)
-        if vendor:
-            hashes.vendor_hash = vendor.group(1)
-
-        npm = re.search(regexes.FIELD_NPM_DEPS_HASH, text)
-        if npm:
-            hashes.npm_deps_hash = npm.group(1)
-
-        pnpm = re.search(regexes.FIELD_PNPM_DEPS_HASH, text)
-        if pnpm:
-            hashes.pnpm_deps_hash = pnpm.group(1)
-
-        return builder_type, hashes
+        return BuilderType.STANDARD, BuilderHashes()
 
 
 class RecipeWriter:
@@ -332,15 +334,8 @@ class RecipeWriter:
         """
         for match in re.finditer(rf"packages\.{re.escape(pname)}\s*=\s*\{{", text):
             start = match.start()
-            depth = 1
-            pos = match.end()
-            while pos < len(text) and depth > 0:
-                if text[pos] == "{":
-                    depth += 1
-                elif text[pos] == "}":
-                    depth -= 1
-                pos += 1
-            return start, pos, text[start:pos]
+            end_pos, block_text = _extract_braced_block(text, match.end() - 1)
+            return start, end_pos, text[start:end_pos]
         raise RecipeParseError(abs_path, f"package '{pname}' not found for replacement")
 
     def _replace(

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 
 from . import regexes
-from .errors import RecipeNotFoundError, RecipeParseError
+from .errors import RecipeNotFoundError, RecipeParseError, UnsupportedRecipeError
 from .types import (
     BuilderHashes,
     BuilderType,
@@ -39,8 +39,15 @@ class RecipeParser:
 
         packages: list[PackageEntry] = []
         for pname, block_text in blocks:
-            version = self._extract_version(block_text, path)
-            source = self._parse_source(block_text, path)
+            try:
+                version = self._extract_version(block_text, path)
+                source = self._parse_source(block_text, path)
+            except RecipeParseError:
+                if re.search(r"\binherit\b", block_text):
+                    raise UnsupportedRecipeError(
+                        pname, "package is inherited from another recipe"
+                    ) from None
+                raise
             builder_type, builder_hashes = self._parse_builder(block_text)
             packages.append(
                 PackageEntry(

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -251,15 +251,6 @@ class RecipeWriter:
             "version",
         )
 
-    def update_source_git(self, recipe: Recipe, pname: str, new_git: str) -> None:
-        self._replace(
-            recipe,
-            pname,
-            regexes.FIELD_GIT,
-            f'git = "{new_git}"',
-            "source.git",
-        )
-
     def update_source_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
         self._replace(
             recipe,

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -278,6 +278,25 @@ class RecipeWriter:
             "vendorHash",
         )
 
+    def update_git_rev(self, recipe: Recipe, pname: str, new_rev: str) -> None:
+        text = "".join(recipe.raw_lines)
+        _, _, block_text = self._find_package_block(text, pname, recipe.abs_path)
+
+        match = re.search(regexes.FIELD_GIT, block_text)
+        if not match:
+            raise RecipeParseError(recipe.abs_path, f"cannot find git spec for {pname}")
+        old_git = match.group(1)
+
+        if old_git.startswith("git:"):
+            # Generic git: replace tag= or rev= query-param value
+            # e.g. git:https://example.com/repo?tag=0.3.0 → ?tag=<new>
+            new_git = re.sub(r"(tag|rev)=([^&\"]*)", rf"\1={new_rev}", old_git, count=1)
+        else:
+            # Forge-host: replace last /-separated component
+            new_git = old_git.rsplit("/", 1)[0] + "/" + new_rev
+
+        self._replace(recipe, pname, regexes.FIELD_GIT, f'git = "{new_git}"', "git")
+
     def _find_package_block(
         self, text: str, pname: str, abs_path: Path
     ) -> tuple[int, int, str]:

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -1,0 +1,292 @@
+import re
+from pathlib import Path
+
+from .errors import RecipeNotFoundError, RecipeParseError
+from .types import (
+    BuilderHashes,
+    BuilderType,
+    ForgeHost,
+    GitSource,
+    PackageEntry,
+    PathSource,
+    Recipe,
+    Source,
+    SourceType,
+    UrlSource,
+)
+
+
+class RecipeParser:
+    recipes_root: Path
+
+    def __init__(self, recipes_root: Path) -> None:
+        self.recipes_root = recipes_root
+
+    def find(self, name: str) -> Path:
+        path = self.recipes_root / name / "recipe.nix"
+        if not path.exists():
+            raise RecipeNotFoundError(name, self.recipes_root)
+        return path
+
+    def parse(self, path: Path) -> Recipe:
+        lines = path.read_text().splitlines(keepends=True)
+        text = "".join(lines)
+
+        blocks = self._extract_package_blocks(text)
+        if not blocks:
+            raise RecipeParseError(path, "no package declarations found")
+
+        packages: list[PackageEntry] = []
+        for pname, block_text in blocks:
+            version = self._extract_version(block_text, path)
+            source = self._parse_source(block_text, path)
+            builder_type, builder_hashes = self._parse_builder(block_text)
+            packages.append(PackageEntry(
+                pname=pname,
+                version=version,
+                source=source,
+                builder_type=builder_type,
+                builder_hashes=builder_hashes,
+            ))
+
+        return Recipe(
+            rel_path=path.parent,
+            abs_path=path,
+            raw_lines=lines,
+            packages=packages,
+        )
+
+    def _extract_package_blocks(self, text: str) -> list[tuple[str, str]]:
+        blocks: list[tuple[str, str]] = []
+        for match in re.finditer(r'packages\.([\w-]+)\s*=\s*\{', text):
+            pname = match.group(1)
+            start = match.start()
+            depth = 1
+            pos = match.end()
+            while pos < len(text) and depth > 0:
+                if text[pos] == "{":
+                    depth += 1
+                elif text[pos] == "}":
+                    depth -= 1
+                pos += 1
+            blocks.append((pname, text[start:pos]))
+        return blocks
+
+    def _extract_version(self, text: str, path: Path) -> str:
+        match = re.search(r'version\s*=\s*"([^"]*)"', text)
+        if not match:
+            raise RecipeParseError(path, "version field not found")
+        return match.group(1)
+
+    def _parse_source(self, text: str, path: Path) -> Source:
+        source_hash = self._extract_source_hash(text)
+
+        git_match = re.search(r'(?<!\w)git\s*=\s*"([^"]*)"', text)
+        if git_match:
+            return Source(
+                type=SourceType.GIT,
+                git=self._parse_git(git_match.group(1), text, path),
+                hash=source_hash,
+            )
+
+        url_match = re.search(r'(?<!\w)url\s*=\s*"([^"]*)"', text)
+        if url_match:
+            return Source(
+                type=SourceType.URL,
+                url=UrlSource(url=url_match.group(1)),
+                hash=source_hash,
+            )
+
+        path_match = re.search(r"(?<!\w)path\s*=\s*(\./[\w./-]+)", text)
+        if path_match:
+            return Source(
+                type=SourceType.PATH,
+                path=PathSource(path=Path(path_match.group(1))),
+            )
+
+        raise RecipeParseError(path, "no source (git/url/path) found")
+
+    def _extract_source_hash(self, text: str) -> str:
+        match = re.search(r'(?<!cargo)(?<!vendor)(?<!\w)hash\s*=\s*"([^"]*)"', text)
+        return match.group(1) if match else ""
+
+    def _parse_git(self, spec: str, text: str, path: Path) -> GitSource:
+        parts = spec.split(":")
+        forge_str = parts[0]
+        rest = ":".join(parts[1:])
+
+        try:
+            host = ForgeHost(forge_str)
+        except ValueError:
+            raise RecipeParseError(path, f"unknown forge host in git spec: {forge_str}")
+
+        if host == ForgeHost.GENERIC_GIT:
+            return self._parse_generic_git(rest, text)
+
+        path_parts = rest.split("/")
+        path_len = len(path_parts)
+
+        if path_len == 3:
+            owner, repo, rev = path_parts
+        elif path_len == 4:
+            _, owner, repo, rev = path_parts
+        else:
+            raise RecipeParseError(path, f"cannot parse git spec: {spec}")
+
+        submodules = bool(re.search(r"submodules\s*=\s*true", text))
+
+        return GitSource(
+            host=host, owner=owner, repo=repo, rev=rev, submodules=submodules
+        )
+
+    def _parse_generic_git(self, rest: str, text: str) -> GitSource:
+        rev_match = re.search(r"rev=([^&]+)", rest)
+        rev = rev_match.group(1) if rev_match else "HEAD"
+
+        submodules = bool(re.search(r"submodules\s*=\s*true", text))
+
+        return GitSource(
+            host=ForgeHost.GENERIC_GIT,
+            owner="",
+            repo="",
+            rev=rev,
+            submodules=submodules,
+        )
+
+    def _parse_builder(self, text: str) -> tuple[BuilderType, BuilderHashes]:
+        builder_map: dict[str, BuilderType] = {
+            "standard": BuilderType.STANDARD,
+            "rustPackage": BuilderType.RUST,
+            "goPackage": BuilderType.GO,
+            "npm": BuilderType.NPM,
+            "pnpm": BuilderType.PNPM,
+            "pythonApp": BuilderType.PYTHON_APP,
+            "pythonPackage": BuilderType.PYTHON_PACKAGE,
+        }
+
+        builder_match = re.search(
+            r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true", text, re.DOTALL
+        )
+        if not builder_match:
+            return BuilderType.STANDARD, BuilderHashes()
+
+        builder_key = builder_match.group(1)
+        builder_type = builder_map.get(builder_key, BuilderType.STANDARD)
+
+        hashes = BuilderHashes()
+        cargo = re.search(r'cargoHash\s*=\s*"([^"]*)"', text)
+        if cargo:
+            hashes.cargo_hash = cargo.group(1)
+
+        vendor = re.search(r'vendorHash\s*=\s*"([^"]*)"', text)
+        if vendor:
+            hashes.vendor_hash = vendor.group(1)
+
+        npm = re.search(r'npmDepsHash\s*=\s*"([^"]*)"', text)
+        if npm:
+            hashes.npm_deps_hash = npm.group(1)
+
+        pnpm = re.search(r'pnpmDepsHash\s*=\s*"([^"]*)"', text)
+        if pnpm:
+            hashes.pnpm_deps_hash = pnpm.group(1)
+
+        return builder_type, hashes
+
+
+class RecipeWriter:
+    dry_run: bool
+    pending_changes: list[tuple[str, str, str]]
+
+    def __init__(self, dry_run: bool = False) -> None:
+        self.dry_run = dry_run
+        self.pending_changes = []
+
+    def update_version(self, recipe: Recipe, pname: str, new_version: str) -> None:
+        self._replace(
+            recipe, pname, r'version\s*=\s*"([^"]*)"',
+            f'version = "{new_version}"', "version",
+        )
+
+    def update_source_git(self, recipe: Recipe, pname: str, new_git: str) -> None:
+        self._replace(
+            recipe, pname, r'git\s*=\s*"([^"]*)"',
+            f'git = "{new_git}"', "source.git",
+        )
+
+    def update_source_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
+        self._replace(
+            recipe, pname,
+            r'(?<!cargo)(?<!vendor)(?<!\w)hash\s*=\s*"([^"]*)"',
+            f'hash = "{new_hash}"',
+            "source.hash",
+        )
+
+    def update_cargo_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
+        self._replace(
+            recipe, pname,
+            r'cargoHash\s*=\s*"([^"]*)"',
+            f'cargoHash = "{new_hash}"',
+            "cargoHash",
+        )
+
+    def update_vendor_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
+        self._replace(
+            recipe, pname,
+            r'vendorHash\s*=\s*"([^"]*)"',
+            f'vendorHash = "{new_hash}"',
+            "vendorHash",
+        )
+
+    def _find_package_block(
+        self, text: str, pname: str, abs_path: Path
+    ) -> tuple[int, int, str]:
+        for match in re.finditer(
+            rf'packages\.{re.escape(pname)}\s*=\s*\{{', text
+        ):
+            start = match.start()
+            depth = 1
+            pos = match.end()
+            while pos < len(text) and depth > 0:
+                if text[pos] == "{":
+                    depth += 1
+                elif text[pos] == "}":
+                    depth -= 1
+                pos += 1
+            return start, pos, text[start:pos]
+        raise RecipeParseError(abs_path, f"package '{pname}' not found for replacement")
+
+    def _replace(
+        self, recipe: Recipe, pname: str, pattern: str, replacement: str, field: str
+    ) -> None:
+        text = "".join(recipe.raw_lines)
+
+        block_start, block_end, block_text = self._find_package_block(
+            text, pname, recipe.abs_path
+        )
+
+        new_block, count = re.subn(pattern, replacement, block_text, count=1)
+        if count == 0:
+            raise RecipeParseError(
+                recipe.abs_path, f"cannot find {field} for {pname}"
+            )
+
+        new_text = text[:block_start] + new_block + text[block_end:]
+        recipe.raw_lines = new_text.splitlines(keepends=True)
+
+        old_match = re.search(pattern, block_text)
+        old_value = old_match.group(1) if old_match else "?"
+        label = f"{pname}.{field}"
+        self.pending_changes.append(
+            (
+                label,
+                old_value,
+                replacement.split('"')[1] if '"' in replacement else replacement,
+            )
+        )
+
+    def apply(self, recipe: Recipe) -> None:
+        if self.dry_run:
+            for field, old, new in self.pending_changes:
+                print(f"  {field}: {old!r} \u2192 {new!r}")
+            return
+        _ = recipe.abs_path.write_text("".join(recipe.raw_lines))

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -278,6 +278,24 @@ class RecipeWriter:
             "vendorHash",
         )
 
+    def update_npm_deps_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
+        self._replace(
+            recipe,
+            pname,
+            regexes.FIELD_NPM_DEPS_HASH,
+            f'npmDepsHash = "{new_hash}"',
+            "npmDepsHash",
+        )
+
+    def update_pnpm_deps_hash(self, recipe: Recipe, pname: str, new_hash: str) -> None:
+        self._replace(
+            recipe,
+            pname,
+            regexes.FIELD_PNPM_DEPS_HASH,
+            f'pnpmDepsHash = "{new_hash}"',
+            "pnpmDepsHash",
+        )
+
     def update_git_rev(self, recipe: Recipe, pname: str, new_rev: str) -> None:
         text = "".join(recipe.raw_lines)
         _, _, block_text = self._find_package_block(text, pname, recipe.abs_path)

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 
+from . import regexes
 from .errors import RecipeNotFoundError, RecipeParseError
 from .types import (
     BuilderHashes,
@@ -65,7 +66,7 @@ class RecipeParser:
         character-by-character counting depth instead.
         """
         blocks: list[tuple[str, str]] = []
-        for match in re.finditer(r"packages\.([\w-]+)\s*=\s*\{", text):
+        for match in re.finditer(regexes.PACKAGE_BLOCK, text):
             pname = match.group(1)
             start = match.start()
             depth = 1
@@ -80,7 +81,7 @@ class RecipeParser:
         return blocks
 
     def _extract_version(self, text: str, path: Path) -> str:
-        match = re.search(r'version\s*=\s*"([^"]*)"', text)
+        match = re.search(regexes.FIELD_VERSION, text)
         if not match:
             raise RecipeParseError(path, "version field not found")
         return match.group(1)
@@ -94,7 +95,7 @@ class RecipeParser:
         """
         source_hash = self._extract_source_hash(text)
 
-        git_match = re.search(r'\bgit\s*=\s*"([^"]*)"', text)
+        git_match = re.search(regexes.FIELD_GIT, text)
         if git_match:
             return Source(
                 type=SourceType.GIT,
@@ -102,7 +103,7 @@ class RecipeParser:
                 hash=source_hash,
             )
 
-        url_match = re.search(r'\burl\s*=\s*"([^"]*)"', text)
+        url_match = re.search(regexes.FIELD_URL, text)
         if url_match:
             return Source(
                 type=SourceType.URL,
@@ -110,7 +111,7 @@ class RecipeParser:
                 hash=source_hash,
             )
 
-        path_match = re.search(r'\bpath\s*=\s*(\./[\w./-]+)', text)
+        path_match = re.search(regexes.FIELD_PATH, text)
         if path_match:
             return Source(
                 type=SourceType.PATH,
@@ -120,7 +121,7 @@ class RecipeParser:
         raise RecipeParseError(path, "no source (git/url/path) found")
 
     def _extract_source_hash(self, text: str) -> str:
-        match = re.search(r'\bhash\s*=\s*"([^"]*)"', text)
+        match = re.search(regexes.FIELD_HASH, text)
         return match.group(1) if match else ""
 
     def _parse_git(self, spec: str, text: str, path: Path) -> GitSource:
@@ -146,17 +147,17 @@ class RecipeParser:
         else:
             raise RecipeParseError(path, f"cannot parse git spec: {spec}")
 
-        submodules = bool(re.search(r"submodules\s*=\s*true", text))
+        submodules = bool(re.search(regexes.SUBMODULES, text))
 
         return GitSource(
             host=host, owner=owner, repo=repo, rev=rev, submodules=submodules
         )
 
     def _parse_generic_git(self, rest: str, text: str) -> GitSource:
-        rev_match = re.search(r"rev=([^&]+)", rest)
+        rev_match = re.search(regexes.GIT_REV, rest)
         rev = rev_match.group(1) if rev_match else "HEAD"
 
-        submodules = bool(re.search(r"submodules\s*=\s*true", text))
+        submodules = bool(re.search(regexes.SUBMODULES, text))
 
         return GitSource(
             host=ForgeHost.GENERIC_GIT,
@@ -179,9 +180,7 @@ class RecipeParser:
 
         # re.DOTALL lets `.' span newlines. We need this because
         # the builder name and `enable = true' are on separate lines.
-        builder_match = re.search(
-            r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true", text, re.DOTALL
-        )
+        builder_match = re.search(regexes.ENABLED_BUILDER, text, re.DOTALL)
         if not builder_match:
             return BuilderType.STANDARD, BuilderHashes()
 
@@ -189,19 +188,19 @@ class RecipeParser:
         builder_type = builder_map.get(builder_key, BuilderType.STANDARD)
 
         hashes = BuilderHashes()
-        cargo = re.search(r'cargoHash\s*=\s*"([^"]*)"', text)
+        cargo = re.search(regexes.FIELD_CARGO_HASH, text)
         if cargo:
             hashes.cargo_hash = cargo.group(1)
 
-        vendor = re.search(r'vendorHash\s*=\s*"([^"]*)"', text)
+        vendor = re.search(regexes.FIELD_VENDOR_HASH, text)
         if vendor:
             hashes.vendor_hash = vendor.group(1)
 
-        npm = re.search(r'npmDepsHash\s*=\s*"([^"]*)"', text)
+        npm = re.search(regexes.FIELD_NPM_DEPS_HASH, text)
         if npm:
             hashes.npm_deps_hash = npm.group(1)
 
-        pnpm = re.search(r'pnpmDepsHash\s*=\s*"([^"]*)"', text)
+        pnpm = re.search(regexes.FIELD_PNPM_DEPS_HASH, text)
         if pnpm:
             hashes.pnpm_deps_hash = pnpm.group(1)
 
@@ -220,7 +219,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'version\s*=\s*"([^"]*)"',
+            regexes.FIELD_VERSION,
             f'version = "{new_version}"',
             "version",
         )
@@ -229,7 +228,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'git\s*=\s*"([^"]*)"',
+            regexes.FIELD_GIT,
             f'git = "{new_git}"',
             "source.git",
         )
@@ -238,7 +237,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'\bhash\s*=\s*"([^"]*)"',
+            regexes.FIELD_HASH,
             f'hash = "{new_hash}"',
             "source.hash",
         )
@@ -247,7 +246,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'cargoHash\s*=\s*"([^"]*)"',
+            regexes.FIELD_CARGO_HASH,
             f'cargoHash = "{new_hash}"',
             "cargoHash",
         )
@@ -256,7 +255,7 @@ class RecipeWriter:
         self._replace(
             recipe,
             pname,
-            r'vendorHash\s*=\s*"([^"]*)"',
+            regexes.FIELD_VENDOR_HASH,
             f'vendorHash = "{new_hash}"',
             "vendorHash",
         )

--- a/flake/develop/commands/dev/update/forge_update/recipe.py
+++ b/flake/develop/commands/dev/update/forge_update/recipe.py
@@ -336,18 +336,14 @@ class RecipeWriter:
 
         old_match = re.search(pattern, block_text)
         old_value = old_match.group(1) if old_match else "?"
-        label = f"{pname}.{field}"
         self.pending_changes.append(
             (
-                label,
+                field,
                 old_value,
                 replacement.split('"')[1] if '"' in replacement else replacement,
             )
         )
 
     def apply(self, recipe: Recipe) -> None:
-        if self.dry_run:
-            for field, old, new in self.pending_changes:
-                print(f"  {field}: {old!r} \u2192 {new!r}")
-            return
-        _ = recipe.abs_path.write_text("".join(recipe.raw_lines))
+        if not self.dry_run:
+            _ = recipe.abs_path.write_text("".join(recipe.raw_lines))

--- a/flake/develop/commands/dev/update/forge_update/regexes.py
+++ b/flake/develop/commands/dev/update/forge_update/regexes.py
@@ -17,3 +17,5 @@ SUBMODULES = r"submodules\s*=\s*true"
 GIT_REV = r"(?:rev|tag)=([^&]+)"
 
 NIX_BUILD_GOT_HASH = r"got:\s+(sha256-\S+)"
+
+NUMERIC_VERSION = r"(\d+(?:\.\d+)*)"

--- a/flake/develop/commands/dev/update/forge_update/regexes.py
+++ b/flake/develop/commands/dev/update/forge_update/regexes.py
@@ -14,6 +14,6 @@ PACKAGE_BLOCK = r"packages\.([\w-]+)\s*=\s*\{"
 ENABLED_BUILDER = r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true"
 
 SUBMODULES = r"submodules\s*=\s*true"
-GIT_REV = r"rev=([^&]+)"
+GIT_REV = r"(?:rev|tag)=([^&]+)"
 
 NIX_BUILD_GOT_HASH = r"got:\s+(sha256-\S+)"

--- a/flake/develop/commands/dev/update/forge_update/regexes.py
+++ b/flake/develop/commands/dev/update/forge_update/regexes.py
@@ -1,0 +1,17 @@
+"""Named regex patterns for recipe field extraction and replacement."""
+
+FIELD_VERSION = r'version\s*=\s*"([^"]*)"'
+FIELD_GIT = r'\bgit\s*=\s*"([^"]*)"'
+FIELD_URL = r'\burl\s*=\s*"([^"]*)"'
+FIELD_PATH = r"\bpath\s*=\s*(\./[\w./-]+)"
+FIELD_HASH = r'\bhash\s*=\s*"([^"]*)"'
+FIELD_CARGO_HASH = r'cargoHash\s*=\s*"([^"]*)"'
+FIELD_VENDOR_HASH = r'vendorHash\s*=\s*"([^"]*)"'
+FIELD_NPM_DEPS_HASH = r'npmDepsHash\s*=\s*"([^"]*)"'
+FIELD_PNPM_DEPS_HASH = r'pnpmDepsHash\s*=\s*"([^"]*)"'
+
+PACKAGE_BLOCK = r"packages\.([\w-]+)\s*=\s*\{"
+ENABLED_BUILDER = r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true"
+
+SUBMODULES = r"submodules\s*=\s*true"
+GIT_REV = r"rev=([^&]+)"

--- a/flake/develop/commands/dev/update/forge_update/regexes.py
+++ b/flake/develop/commands/dev/update/forge_update/regexes.py
@@ -15,3 +15,5 @@ ENABLED_BUILDER = r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true"
 
 SUBMODULES = r"submodules\s*=\s*true"
 GIT_REV = r"rev=([^&]+)"
+
+NIX_BUILD_GOT_HASH = r"got:\s+(sha256-\S+)"

--- a/flake/develop/commands/dev/update/forge_update/regexes.py
+++ b/flake/develop/commands/dev/update/forge_update/regexes.py
@@ -11,7 +11,7 @@ FIELD_NPM_DEPS_HASH = r'npmDepsHash\s*=\s*"([^"]*)"'
 FIELD_PNPM_DEPS_HASH = r'pnpmDepsHash\s*=\s*"([^"]*)"'
 
 PACKAGE_BLOCK = r"packages\.([\w-]+)\s*=\s*\{"
-ENABLED_BUILDER = r"(\w+)Builder\s*=\s*\{[^}]*\benable\b\s*=\s*true"
+BUILDER_DECL = r"(\w+)Builder\s*=\s*\{"
 
 SUBMODULES = r"submodules\s*=\s*true"
 GIT_REV = r"(?:rev|tag)=([^&]+)"

--- a/flake/develop/commands/dev/update/forge_update/types.py
+++ b/flake/develop/commands/dev/update/forge_update/types.py
@@ -65,12 +65,17 @@ class BuilderHashes:
 
 
 @dataclass
-class Recipe:
-    rel_path: Path
-    abs_path: Path
+class PackageEntry:
     pname: str
     version: str
     source: Source
     builder_type: BuilderType
     builder_hashes: BuilderHashes = field(default_factory=BuilderHashes)
+
+
+@dataclass
+class Recipe:
+    rel_path: Path
+    abs_path: Path
     raw_lines: list[str] = field(default_factory=list)
+    packages: list[PackageEntry] = field(default_factory=list)

--- a/flake/develop/commands/dev/update/forge_update/types.py
+++ b/flake/develop/commands/dev/update/forge_update/types.py
@@ -66,6 +66,8 @@ class BuilderHashes:
 
 @dataclass
 class PackageEntry:
+    """A single package declared within a recipe.nix file."""
+
     pname: str
     version: str
     source: Source
@@ -75,6 +77,8 @@ class PackageEntry:
 
 @dataclass
 class Recipe:
+    """A recipe.nix file, which may declare one or more packages."""
+
     rel_path: Path
     abs_path: Path
     raw_lines: list[str] = field(default_factory=list)

--- a/flake/develop/commands/dev/update/forge_update/types.py
+++ b/flake/develop/commands/dev/update/forge_update/types.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+
+
+class SourceType(Enum):
+    GIT = auto()
+    URL = auto()
+    PATH = auto()
+
+
+class BuilderType(Enum):
+    STANDARD = auto()
+    RUST = auto()
+    GO = auto()
+    NPM = auto()
+    PNPM = auto()
+    PYTHON_APP = auto()
+    PYTHON_PACKAGE = auto()
+
+
+class ForgeHost(Enum):
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    CODEBERG = "codeberg"
+    FORGEJO = "forgejo"
+    GITEA = "gitea"
+    GENERIC_GIT = "git"
+
+
+@dataclass
+class GitSource:
+    host: ForgeHost
+    owner: str
+    repo: str
+    rev: str
+    submodules: bool = False
+
+
+@dataclass
+class UrlSource:
+    url: str
+
+
+@dataclass
+class PathSource:
+    path: Path
+
+
+@dataclass
+class Source:
+    type: SourceType
+    git: GitSource | None = None
+    url: UrlSource | None = None
+    path: PathSource | None = None
+    hash: str = ""
+
+
+@dataclass
+class BuilderHashes:
+    cargo_hash: str | None = None
+    vendor_hash: str | None = None
+    npm_deps_hash: str | None = None
+    pnpm_deps_hash: str | None = None
+
+
+@dataclass
+class Recipe:
+    rel_path: Path
+    abs_path: Path
+    pname: str
+    version: str
+    source: Source
+    builder_type: BuilderType
+    builder_hashes: BuilderHashes = field(default_factory=BuilderHashes)
+    raw_lines: list[str] = field(default_factory=list)

--- a/flake/develop/commands/dev/update/forge_update/types.py
+++ b/flake/develop/commands/dev/update/forge_update/types.py
@@ -34,6 +34,7 @@ class GitSource:
     owner: str
     repo: str
     rev: str
+    remote_url: str = ""
     submodules: bool = False
 
 

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -3,8 +3,6 @@ import re
 import subprocess
 from dataclasses import dataclass
 
-from packaging.version import InvalidVersion, Version
-
 from .errors import VersionDetectionError
 from .types import GitSource, Recipe, Source, SourceType
 
@@ -55,7 +53,7 @@ class VersionDetector:
             )
 
         raw_tags = self._fetch_tags(remote, git_source)
-        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
+        version_tags = self._filter_version_tags(raw_tags)
 
         if not version_tags:
             raise VersionDetectionError(
@@ -83,13 +81,17 @@ class VersionDetector:
 
     def _get_latest_tag(self, remote: str, git_source: GitSource) -> str:
         raw_tags = self._fetch_tags(remote, git_source)
-        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
+        version_tags = self._filter_version_tags(raw_tags)
         if not version_tags:
             raise VersionDetectionError(
                 Source(type=SourceType.GIT, git=git_source),
                 f"no tags found at {remote} (needed for hash-based derivation)",
             )
         return self._sort_tags(version_tags)[0]
+
+    @staticmethod
+    def _filter_version_tags(tags: set[str]) -> list[str]:
+        return [t for t in tags if len(re.findall(r"\d+", t)) >= 2]
 
     def _fetch_tags(self, remote: str, git_source: GitSource) -> set[str]:
         try:
@@ -159,11 +161,8 @@ class VersionDetector:
 
     @staticmethod
     def _sort_tags(tags: list[str]) -> list[str]:
-        def key(tag: str) -> tuple[int, Version | str]:
-            stripped = tag.removeprefix("v")
-            try:
-                return (1, Version(stripped))
-            except InvalidVersion:
-                return (0, tag)
+        def key(tag: str) -> tuple[int, ...]:
+            nums = re.findall(r"\d+", tag.removeprefix("v"))
+            return tuple(int(n) for n in nums)
 
         return sorted(tags, key=key, reverse=True)

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -14,12 +14,7 @@ class VersionResult:
 
 
 class VersionDetector:
-    def detect(
-        self, recipe: Recipe, explicit_version: str | None = None
-    ) -> VersionResult:
-        if explicit_version is not None:
-            return VersionResult(version=explicit_version, rev="")
-
+    def detect(self, recipe: Recipe) -> VersionResult:
         source = recipe.packages[0].source
 
         match source.type:

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -1,5 +1,7 @@
+import datetime
 import re
 import subprocess
+from dataclasses import dataclass
 
 from packaging.version import InvalidVersion, Version
 
@@ -7,10 +9,18 @@ from .errors import VersionDetectionError
 from .types import GitSource, Recipe, Source, SourceType
 
 
+@dataclass
+class VersionResult:
+    version: str
+    rev: str
+
+
 class VersionDetector:
-    def detect(self, recipe: Recipe, explicit_version: str | None = None) -> str:
+    def detect(
+        self, recipe: Recipe, explicit_version: str | None = None
+    ) -> VersionResult:
         if explicit_version is not None:
-            return explicit_version
+            return VersionResult(version=explicit_version, rev="")
 
         source = recipe.packages[0].source
 
@@ -27,7 +37,16 @@ class VersionDetector:
 
         raise VersionDetectionError(source, "no git source found")
 
-    def _detect_from_git(self, git_source: GitSource) -> str:
+    def _detect_from_git(self, git_source: GitSource) -> VersionResult:
+        if self._is_commit_hash(git_source.rev):
+            return self._detect_hash_based(git_source)
+        return self._detect_tag_based(git_source)
+
+    @staticmethod
+    def _is_commit_hash(rev: str) -> bool:
+        return bool(re.fullmatch(r"[0-9a-f]{40}", rev))
+
+    def _detect_tag_based(self, git_source: GitSource) -> VersionResult:
         remote = git_source.remote_url
         if not remote:
             raise VersionDetectionError(
@@ -35,6 +54,44 @@ class VersionDetector:
                 f"no remote URL for {git_source.host.value} source",
             )
 
+        raw_tags = self._fetch_tags(remote, git_source)
+        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
+
+        if not version_tags:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"no version tags found at {remote}",
+            )
+
+        sorted_tags = self._sort_tags(version_tags)
+        latest = sorted_tags[0]
+        return VersionResult(version=latest.removeprefix("v"), rev=latest)
+
+    def _detect_hash_based(self, git_source: GitSource) -> VersionResult:
+        remote = git_source.remote_url
+        if not remote:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"no remote URL for {git_source.host.value} source",
+            )
+
+        latest_tag = self._get_latest_tag(remote, git_source)
+        latest_hash = self._get_head_commit(remote, git_source)
+        date = datetime.date.today().isoformat()
+        version = f"{latest_tag.removeprefix('v')}-unstable-{date}"
+        return VersionResult(version=version, rev=latest_hash)
+
+    def _get_latest_tag(self, remote: str, git_source: GitSource) -> str:
+        raw_tags = self._fetch_tags(remote, git_source)
+        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
+        if not version_tags:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"no tags found at {remote} (needed for hash-based derivation)",
+            )
+        return self._sort_tags(version_tags)[0]
+
+    def _fetch_tags(self, remote: str, git_source: GitSource) -> set[str]:
         try:
             result = subprocess.run(
                 ["git", "ls-remote", "--tags", remote],
@@ -53,19 +110,39 @@ class VersionDetector:
                 Source(type=SourceType.GIT, git=git_source),
                 f"git ls-remote timed out for {remote}",
             )
+        return self._parse_tags(result.stdout)
 
-        raw_tags = self._parse_tags(result.stdout)
-        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
-
-        if not version_tags:
+    def _get_head_commit(self, remote: str, git_source: GitSource) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", remote, "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            result.check_returncode()
+        except subprocess.CalledProcessError as e:
             raise VersionDetectionError(
                 Source(type=SourceType.GIT, git=git_source),
-                f"no version tags found at {remote}",
+                f"git ls-remote HEAD failed (exit {e.returncode}): {(e.stderr or '').strip()}",
+            )
+        except subprocess.TimeoutExpired:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"git ls-remote HEAD timed out for {remote}",
             )
 
-        sorted_tags = self._sort_tags(version_tags)
-        latest = sorted_tags[0]
-        return latest.removeprefix("v")
+        for line in result.stdout.splitlines():
+            if "\t" not in line:
+                continue
+            sha, ref = line.split("\t", 1)
+            if ref == "HEAD":
+                return sha
+
+        raise VersionDetectionError(
+            Source(type=SourceType.GIT, git=git_source),
+            f"no HEAD ref found at {remote}",
+        )
 
     @staticmethod
     def _parse_tags(raw: str) -> set[str]:

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -84,10 +84,7 @@ class VersionDetector:
         raw_tags = self._fetch_tags(remote, git_source)
         version_tags = self._filter_version_tags(raw_tags)
         if not version_tags:
-            raise VersionDetectionError(
-                Source(type=SourceType.GIT, git=git_source),
-                f"no tags found at {remote} (needed for hash-based derivation)",
-            )
+            return "0"
         return self._sort_tags(version_tags)[0]
 
     @staticmethod

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -22,18 +22,19 @@ class VersionDetector:
 
         source = recipe.packages[0].source
 
-        if source.type == SourceType.GIT and source.git is not None:
-            return self._detect_from_git(source.git)
-        elif source.type == SourceType.URL:
-            raise VersionDetectionError(
-                source, "URL sources not supported for auto-detection"
-            )
-        elif source.type == SourceType.PATH:
-            raise VersionDetectionError(
-                source, "PATH sources not supported for auto-detection"
-            )
-
-        raise VersionDetectionError(source, "no git source found")
+        match source.type:
+            case SourceType.GIT if source.git is not None:
+                return self._detect_from_git(source.git)
+            case SourceType.URL:
+                raise VersionDetectionError(
+                    source, "URL sources not supported for auto-detection"
+                )
+            case SourceType.PATH:
+                raise VersionDetectionError(
+                    source, "PATH sources not supported for auto-detection"
+                )
+            case _:
+                raise VersionDetectionError(source, "no git source found")
 
     def _detect_from_git(self, git_source: GitSource) -> VersionResult:
         if self._is_commit_hash(git_source.rev):

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 
+from . import regexes
 from .errors import VersionDetectionError
 from .types import GitSource, Recipe, Source, SourceType
 
@@ -37,6 +38,11 @@ class VersionDetector:
         return self._detect_tag_based(git_source)
 
     @staticmethod
+    def _extract_numeric_version(tag: str) -> str:
+        match = re.search(regexes.NUMERIC_VERSION, tag)
+        return match.group(1) if match else tag
+
+    @staticmethod
     def _is_commit_hash(rev: str) -> bool:
         return bool(re.fullmatch(r"[0-9a-f]{40}", rev))
 
@@ -59,7 +65,7 @@ class VersionDetector:
 
         sorted_tags = self._sort_tags(version_tags)
         latest = sorted_tags[0]
-        return VersionResult(version=latest.removeprefix("v"), rev=latest)
+        return VersionResult(version=self._extract_numeric_version(latest), rev=latest)
 
     def _detect_hash_based(self, git_source: GitSource) -> VersionResult:
         remote = git_source.remote_url

--- a/flake/develop/commands/dev/update/forge_update/version.py
+++ b/flake/develop/commands/dev/update/forge_update/version.py
@@ -1,0 +1,92 @@
+import re
+import subprocess
+
+from packaging.version import InvalidVersion, Version
+
+from .errors import VersionDetectionError
+from .types import GitSource, Recipe, Source, SourceType
+
+
+class VersionDetector:
+    def detect(self, recipe: Recipe, explicit_version: str | None = None) -> str:
+        if explicit_version is not None:
+            return explicit_version
+
+        source = recipe.packages[0].source
+
+        if source.type == SourceType.GIT and source.git is not None:
+            return self._detect_from_git(source.git)
+        elif source.type == SourceType.URL:
+            raise VersionDetectionError(
+                source, "URL sources not supported for auto-detection"
+            )
+        elif source.type == SourceType.PATH:
+            raise VersionDetectionError(
+                source, "PATH sources not supported for auto-detection"
+            )
+
+        raise VersionDetectionError(source, "no git source found")
+
+    def _detect_from_git(self, git_source: GitSource) -> str:
+        remote = git_source.remote_url
+        if not remote:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"no remote URL for {git_source.host.value} source",
+            )
+
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", "--tags", remote],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            result.check_returncode()
+        except subprocess.CalledProcessError as e:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"git ls-remote failed (exit {e.returncode}): {(e.stderr or '').strip()}",
+            )
+        except subprocess.TimeoutExpired:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"git ls-remote timed out for {remote}",
+            )
+
+        raw_tags = self._parse_tags(result.stdout)
+        version_tags = [t for t in raw_tags if re.search(r"\d", t)]
+
+        if not version_tags:
+            raise VersionDetectionError(
+                Source(type=SourceType.GIT, git=git_source),
+                f"no version tags found at {remote}",
+            )
+
+        sorted_tags = self._sort_tags(version_tags)
+        latest = sorted_tags[0]
+        return latest.removeprefix("v")
+
+    @staticmethod
+    def _parse_tags(raw: str) -> set[str]:
+        tags: set[str] = set()
+        for line in raw.splitlines():
+            if "\t" not in line:
+                continue
+            _, ref = line.split("\t", 1)
+            if ref.startswith("refs/tags/"):
+                tag = ref.removeprefix("refs/tags/")
+                tag = tag.removesuffix("^{}")
+                tags.add(tag)
+        return tags
+
+    @staticmethod
+    def _sort_tags(tags: list[str]) -> list[str]:
+        def key(tag: str) -> tuple[int, Version | str]:
+            stripped = tag.removeprefix("v")
+            try:
+                return (1, Version(stripped))
+            except InvalidVersion:
+                return (0, tag)
+
+        return sorted(tags, key=key, reverse=True)


### PR DESCRIPTION
The script is written in Python in hopes of sane typing and error handling. It can:

Update individual recipes:

```
nix develop --command forge-update tau-tower
```

<img width="752" height="291" alt="image" src="https://github.com/user-attachments/assets/8b8f97e6-6529-441b-8333-de5d82b0fc1f" />


Update multiple recipes:

```
nix develop --command forge-update tau-tower tau-radio
```

<img width="752" height="356" alt="image" src="https://github.com/user-attachments/assets/7e462d5a-1c1b-4b37-9054-276e26a0a98d" />


Update all recipes:

```
nix develop --command forge-update --all
```

Update recipes and commit changes:

```
nix develop --command forge-update tau-radio --commit
```

It also has a `--dry-run` mode, which won't prefetch hashes or modify recipe files:

```
nix develop --command forge-update --all --dry-run
```

For more details, run:

```
nix develop --command forge-update --help
```

Closes: https://github.com/ngi-nix/forge/issues/614
Related: https://github.com/ngi-nix/forge/issues/219