### PR TITLE
fix(ui-tests): replace tree with blob

### DIFF
--- a/ui/tests/e2e/specs/app/details.spec.ts
+++ b/ui/tests/e2e/specs/app/details.spec.ts
@@ -22,7 +22,7 @@ test.describe("App Details Page", () => {
 
     const recipeLink = resources.locator("a", { hasText: /Forge Recipe/i });
     await expect(recipeLink).toBeVisible();
-    await expect(recipeLink).toHaveAttribute("href", new RegExp(`tree/.*/recipes/apps/${TEST_APP_NAME}/recipe.nix`));
+    await expect(recipeLink).toHaveAttribute("href", new RegExp(`blob/.*/recipes/apps/${TEST_APP_NAME}/recipe.nix`));
   });
 
   test("shows NGI grants section if available", async ({ page }) => {


### PR DESCRIPTION
- closes #627

I was initially using `tree` urls by accident when I copied a folder link from github, but later changed it to `blob` when I realised `blob` is the correct url path for files, even though `tree` worked.

And I missed the reference in the ui test.

Confirmed `test-ui` is working.