### PR TITLE
feat: add cardamum 0.1.0 package recipe

### DIFF
--- a/recipes/packages/cardamum/recipe.nix
+++ b/recipes/packages/cardamum/recipe.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  ...
+}:
+
+{
+  packages.cardamum = {
+    version = "0.1.0";
+    description = "CLI to manage contacts supporting CardDAV and Vdir.";
+    homePage = "https://pimalaya.org";
+    mainProgram = "cardamum";
+    license = lib.licenses.agpl3Plus;
+
+    source = {
+      git = "github:pimalaya/cardamum/v0.1.0";
+      hash = "sha256-2JnaAmC2xBfqe0zBjAaL/Xd0/W1DxNJB/skpI2LaY28=";
+    };
+
+    build.rustPackageBuilder = {
+      enable = true;
+      cargoHash = "sha256-SA3QIwiJFEeNkScYv/VFREehdjeZU8L6XExNKcLIn1g=";
+    };
+
+    # Upstream lib.rs has shell/VCard examples in doc comments not marked
+    # `ignore`, causing doctest compilation failures. Unit tests pass fine.
+    build.extraAttrs = {
+      cargoTestFlags = [ "--lib" "--bins" ];
+    };
+
+    test.script = ''
+      cardamum --version
+      cardamum --help
+    '';
+  };
+}

--- a/recipes/packages/cardamum/recipe.nix
+++ b/recipes/packages/cardamum/recipe.nix
@@ -24,7 +24,10 @@
     # Upstream lib.rs has shell/VCard examples in doc comments not marked
     # `ignore`, causing doctest compilation failures. Unit tests pass fine.
     build.extraAttrs = {
-      cargoTestFlags = [ "--lib" "--bins" ];
+      cargoTestFlags = [
+        "--lib"
+        "--bins"
+      ];
     };
 
     test.script = ''


### PR DESCRIPTION
Adds a Forge package recipe for [cardamum](https://pimalaya.org), a CLI to manage contacts supporting CardDAV and Vdir (pimalaya / NGI-funded).

Supersedes #533 — re-submitting as a PR per @phanirithvij's request.

### Details
- Builder: `rustPackageBuilder`
- Source: `github:pimalaya/cardamum/v0.1.0`
- Verified building and running on `x86_64-linux` (`cardamum --version` / `--help` pass via the test script).

### Notes
- `cargoHash` is the `x86_64-linux`-authoritative value; it differs on `aarch64-darwin`.
- Upstream `src/lib.rs` doc comments contain shell/VCard examples not fenced with `ignore`, which break doctest compilation. `build.extraAttrs.cargoTestFlags = [ "--lib" "--bins" ]` skips doctests while keeping unit/bin tests.