### PR TITLE
feat: add calendula 0.1.0 package recipe

### DIFF
--- a/recipes/packages/calendula/recipe.nix
+++ b/recipes/packages/calendula/recipe.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  ...
+}:
+
+{
+  packages.calendula = {
+    version = "0.1.0";
+    description = "CLI to manage calendars supporting CalDAV and ICS.";
+    homePage = "https://pimalaya.org";
+    mainProgram = "calendula";
+    license = lib.licenses.agpl3Plus;
+
+    source = {
+      git = "github:pimalaya/calendula/v0.1.0";
+      hash = "sha256-xMd4T+vQHcnqSVPXSZ3suQuMKmWpaI4T2gmljrVPk0w=";
+    };
+
+    build.rustPackageBuilder = {
+      enable = true;
+      cargoHash = "sha256-FIcGgPsOi2e+0dU5FRCVvlEkcZoxQ4H+Uro60wYpBQc=";
+    };
+
+    # Same pimalaya codebase pattern as cardamum — doc comments contain shell
+    # and iCalendar examples not marked `ignore`, causing doctest failures.
+    build.extraAttrs = {
+      cargoTestFlags = [ "--lib" "--bins" ];
+    };
+
+    test.script = ''
+      calendula --version
+      calendula --help
+    '';
+  };
+}

--- a/recipes/packages/calendula/recipe.nix
+++ b/recipes/packages/calendula/recipe.nix
@@ -24,7 +24,10 @@
     # Same pimalaya codebase pattern as cardamum — doc comments contain shell
     # and iCalendar examples not marked `ignore`, causing doctest failures.
     build.extraAttrs = {
-      cargoTestFlags = [ "--lib" "--bins" ];
+      cargoTestFlags = [
+        "--lib"
+        "--bins"
+      ];
     };
 
     test.script = ''


### PR DESCRIPTION
Adds a Forge package recipe for [calendula](https://pimalaya.org), a CLI to manage calendars supporting CalDAV and ICS (pimalaya / NGI-funded).

Supersedes #534 — re-submitting as a PR per @phanirithvij's request.

### Details
- Builder: `rustPackageBuilder`
- Source: `github:pimalaya/calendula/v0.1.0`
- Verified building and running on `x86_64-linux` (`calendula --version` / `--help` pass via the test script).

### Notes
- `cargoHash` is the `x86_64-linux`-authoritative value; it differs on `aarch64-darwin`.
- Same pimalaya codebase pattern as cardamum: doc comments contain shell/iCalendar examples not fenced with `ignore`, breaking doctests. `build.extraAttrs.cargoTestFlags = [ "--lib" "--bins" ]` skips doctests while keeping unit/bin tests.