### PR TITLE
+packager@maintainability(forge): init packages.${package}.build{,.${builder}}.{env,structuredAttrs}

### DIFF
--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -27,6 +27,8 @@
         options.build = lib.mkOption {
           type = lib.types.submoduleWith {
             modules = [
+              ./env.nix
+              ./structuredAttrs.nix
               ({ specialArgs, config, ... }: {
                 options.${name} = lib.mkOption {
                   default = { };
@@ -34,6 +36,8 @@
                     inherit specialArgs;
                     modules = [
                       imports
+                      ./env.nix
+                      ./structuredAttrs.nix
                       {
                         options.packages = {
                           build = lib.mkOption {
@@ -73,6 +77,9 @@
                     ];
                   };
                 };
+                config = lib.mkIf config.${name}.enable {
+                  inherit (config.${name}) env structuredAttrs;
+                };
               })
             ];
           };
@@ -83,7 +90,8 @@
             let
               mkSharedAttrs =
                 finalAttrs:
-                {
+                config.build.structuredAttrs
+                // {
                   inherit (config)
                     pname
                     version
@@ -94,6 +102,9 @@
                   inherit (config.source)
                     patches
                     ;
+
+                  __structuredAttrs = true;
+                  inherit (config.build) env;
 
                   nativeBuildInputs = builder.packages.build;
                   buildInputs = builder.packages.run;

--- a/forge/modules/builders/shared/env.nix
+++ b/forge/modules/builders/shared/env.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+{
+  options.env = lib.mkOption {
+    description = ''
+      Exported environment variables.
+
+      Mapped to `env`.
+    '';
+    default = { };
+    apply = lib.filterAttrs (k: v: v != null);
+    type = lib.types.submodule {
+      freeformType =
+        with lib.types;
+        attrsOf (
+          nullOr (oneOf [
+            bool
+            float
+            int
+            package
+            path
+            str
+          ])
+        );
+    };
+  };
+}

--- a/forge/modules/builders/shared/structuredAttrs.nix
+++ b/forge/modules/builders/shared/structuredAttrs.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+{
+  options.structuredAttrs = lib.mkOption {
+    description = ''
+      Attributes local to the build script.
+
+      Mapped to themselves as attributes given to the builder.
+
+      See <https://nix.dev/manual/nix/latest/store/derivation/#structured-attrs>.
+    '';
+    default = { };
+    apply = lib.filterAttrs (k: v: v != null);
+    type = lib.types.submodule {
+      freeformType =
+        with lib.types;
+        attrsOf (
+          lib.types.serializableValueWith {
+            typeName = "structuredAttrs";
+            nullable = true;
+          }
+        );
+    };
+  };
+}

--- a/forge/modules/pkgs/pkg.nix
+++ b/forge/modules/pkgs/pkg.nix
@@ -173,6 +173,7 @@
       type = lib.types.submoduleWith {
         inherit specialArgs;
         modules = [
+          pkg/env.nix
           {
             options = {
               # Builder-specific options are defined in separate modular

--- a/forge/modules/pkgs/pkg/env.nix
+++ b/forge/modules/pkgs/pkg/env.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+{
+  options.env = lib.mkOption {
+    type = lib.types.submodule {
+      options = {
+        NIX_CFLAGS_COMPILE = lib.mkOption {
+          type = with lib.types; nullOr (listOf str);
+          default = null;
+          visible = false;
+          description = ''
+            Flags to pass to the C compiler, bypassing help builders.
+
+            Prefer to use help builders whenever possible.
+            See <https://github.com/NixOS/nixpkgs/issues/79303>
+          '';
+          apply = xs: if xs == null then null else lib.concatStringsSep " " xs;
+        };
+      };
+    };
+  };
+}

--- a/recipes/pkgs/pagedjs-cli/recipe.nix
+++ b/recipes/pkgs/pagedjs-cli/recipe.nix
@@ -32,10 +32,12 @@
       npmInstallFlags = [ "--ignore-scripts" ];
     };
 
-    build.extraAttrs = {
+    build.env = {
       # Skip Puppeteer's Chrome download during dependency installation
-      env.PUPPETEER_SKIP_DOWNLOAD = true;
+      PUPPETEER_SKIP_DOWNLOAD = true;
+    };
 
+    build.extraAttrs = {
       # Wrap the binary to set Chromium path
       # Launch browser with no sandboxing
       postInstall = ''

--- a/recipes/pkgs/tau-radio/recipe.nix
+++ b/recipes/pkgs/tau-radio/recipe.nix
@@ -42,7 +42,12 @@
 
     build.extraAttrs = {
       # fatal error: 'opus.h' file not found
-      env.NIX_CFLAGS_COMPILE = "-I${pkgs.libopus.dev}/include/opus";
+      # Because `pkg-config`'s configuration
+      # from `pkgs.libopus.dev` in `nativeBuildInputs` is not considered
+      # by the `bingen` wrapper.
+      preConfigure = ''
+        BINDGEN_EXTRA_CLANG_ARGS+=" $(pkg-config opus --cflags)"
+      '';
     };
 
     test.script = ''


### PR DESCRIPTION
Based upon https://github.com/ngi-nix/forge/pull/586
Closes https://github.com/ngi-nix/forge/issues/647

This PR introduces `env`/`structuredAttrs` twice once for global settings and once for builder-specific settings.
This enables to typecheck/find/document builder-specific settings in the relevant builder hierarchy of options.

- `-dev@compatibility(forge)`: to be able to import the same options `env`/`structuredAttrs` twice, `lib.types.submoduleWith` is used, but utilities like `lib.mkAliasOptionModule` do not work across submodules,
hence a following PR (https://github.com/ngi-nix/forge/pull/694) introduces a `forge-lib.mkAliasOptionModule`
supporting submodules.