### PR TITLE
feat: allow to add resources to service components

### DIFF
--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -62,7 +62,9 @@ Start the recipe with the following content:
 
 ### Links
 
-Add a [`links`](https://ngi.nixos.org/recipe/options?p=apps&p=packages&s=apps.%3Cname%3E.links) block that contains URLs to the project source, website, and documentation.
+Add a
+[`links`](https://ngi.nixos.org/recipe/options?p=apps&p=packages&s=apps.%3Cname%3E.links)
+block that contains URLs to the project source, website, and documentation.
 
 ```nix
 links = {
@@ -164,21 +166,21 @@ program-cli
 ## Services
 
 Add a `services` block if the application provides services. It can contain
-one or more services called _service components_.
+one or more _service components_.
 
 Start with runtime-independent service configuration. The only required option
-is `command`, which specifies the executable to start the service. Additional
-arguments are passed using the `argv` option. Services typically also need
-a configuration file, which can be supplied via the `configData` option.
-
-<!-- TODO: document `extraComponents` after [#425](https://github.com/ngi-nix/forge/issues/425) is merged. -->
+is `process.command`, which specifies the executable to start the service.
+Additional arguments are passed using the `process.argv` option. Services
+typically also need a configuration file, which can be supplied via the
+`process.configData` option. Configuration files are made available at runtime
+under `$XDG_CONFIG_HOME`, which can be referenced directly in `process.argv`.
 
 ```nix
 services = {
   components.my-service = {
-    command = pkgs.package;
-    argv = [ "--config" "service.toml" ];
-    configData."service.toml" = {
+    process.command = pkgs.package;
+    process.argv = [ "--config" "$XDG_CONFIG_HOME/service.toml" ];
+    process.configData."service.toml" = {
       source = ./service.toml;
       path = "service.toml";
     };
@@ -187,44 +189,44 @@ services = {
 ```
 
 Additionally, environment variables can be used to configure the service using
-the `environment` option.
+the `process.environment` option.
 
 ```nix
 services = {
   components.my-service = {
     ...
-    environment = {
+    process.environment = {
       LOG_LEVEL = "info";
-    }
+    };
     ...
   };
 };
 ```
 
 Service user and state directory (persistent data directory) are automatically
-created and managed by Forge but can be customized using `user` and `stateDir`
-options if required.
+created and managed by Forge but can be customized using `process.user` and
+`process.stateDir` options if required.
 
 ```nix
 services = {
   components.my-service = {
     ...
-    user = "root";
-    stateDir = "/var/lib/foo";
+    process.user = "root";
+    process.stateDir = "/var/lib/foo";
     ...
   };
 };
 ```
 
-All service ports exposed to the user must be configured using the `ports` option. This list is
-used to configure port mapping for the _container_ runtime and to configure port forwarding when
-a _nixos_ system is launched in a VM.
+All service ports exposed to the user must be set using the `process.ports` option.
+This list is used to configure port mapping for the _container_ runtime and to
+configure port forwarding when a _nixos_ system is launched in a VM.
 
 ```nix
 services = {
   components.my-service = {
     ...
-    ports = [
+    process.ports = [
       "8080:8080"
       "8081:8081"
       "8082:8082"
@@ -234,15 +236,15 @@ services = {
 };
 ```
 
-A pre-start script can be configured using the `preStart` option. The pre-start
-script runs before service startup, including restarts. This is useful for
-tasks like database migrations.
+A pre-start script can be configured using the `process.preStart` option. The
+pre-start script runs before service startup, including restarts. This is useful
+for tasks like database migrations.
 
 ```nix
 services = {
   components.my-service = {
     ...
-    preStart = ''
+    process.preStart = ''
       program makemigrations && program migrate
     '';
     ...
@@ -250,8 +252,8 @@ services = {
 };
 ```
 
-Multiple services (service components) can be ordered using the `after` option to control
-startup order.
+Multiple services (service components) can be ordered using the `after` option
+to control startup order.
 
 ```nix
 services = {
@@ -263,6 +265,31 @@ services = {
     ...
     after = [ "my-service-A" ];
     ...
+  };
+};
+```
+
+### Additional resources
+
+Additional resources required by a service - such as a database or reverse proxy
+can be configured using the `resources` option.
+
+Resources can be shared between multiple components.
+
+```nix
+services = {
+  components.my-service = {
+    ...
+    process.command = pkgs.my-service;
+    ...
+
+    resources.database.nixosConfig = {
+      services.postgresql.enable = true;
+    };
+
+    resources.reverse-proxy.nixosConfig = {
+      services.nginx.enable = true;
+    };
   };
 };
 ```
@@ -280,10 +307,16 @@ at startup — for example, to create directory structures or copy configuration
 #### "container" runtime
 
 The _container_ runtime runs each service component in a separate container
-using a Podman compose file automatically generated from the recipe
-configuration. Nimi script is configured as a container entrypoint.
+using a Podman Compose file automatically generated from the recipe
+configuration. Nimi is used as the container entrypoint.
 
-Enable the runtime and configure a setup script:
+Each _component_ runs in separate single-process container, while _resources_
+run in a full NixOS systemd container.
+
+Both _components_ and _resources_ can be extended with container
+runtime-specific configuration.
+
+Enable the runtime, configure a setup script and resource configuration:
 
 ```nix
 services = {
@@ -291,11 +324,16 @@ services = {
     ...
   };
 
-  runtimes.container.my-service = {
+  runtimes.container = {
     enable = true;
-    setup = ''
+
+    components.my-service.setup = ''
       mkdir /var/lib/my-service/data
     '';
+
+    resources.database.nixosConfig = {
+      services.postgresql.enableTCPIP = true;
+    };
   };
 };
 ```
@@ -389,7 +427,12 @@ podman-compose -f build-container/<service-name>/compose.yaml exec <service-name
 The _nixos_ runtime runs all services inside a NixOS machine. Each service
 component maps to a systemd unit which is launching a Nimi script.
 
-Enable the runtime and configure a setup script:
+All _components_ and _resources_ are running in a single NixOS system.
+
+Components, resources, and the NixOS system itself can be extended with
+runtime-specific configuration using the `nixosConfig` option.
+
+Enable the runtime, configure a setup script, and add resource configuration:
 
 ```nix
 services = {
@@ -397,34 +440,21 @@ services = {
     ...
   };
 
-  runtimes.nixos.my-service = {
+  runtimes.nixos = {
     enable = true;
+
     setup = ''
       mkdir /var/lib/my-service/data
     '';
+
+    nixosConfig = {
+      services.postgresql.authentication = ''
+        local all all trust
+      '';
+    };
   };
 };
 ```
-
-Add additional NixOS services when required:
-
-```nix
-services = {
-  components.my-service = {
-    ...
-  };
-
-  runtimes.nixos.my-service = {
-    enable = true;
-    ...
-    nixosConfig = ''
-      services.postgresql.enable = true;
-    '';
-  };
-};
-```
-
-<!-- TODO: document `extraComponents` after [#425](https://github.com/ngi-nix/forge/issues/425) is merged. -->
 
 Run the application in a NixOS VM:
 

--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -82,7 +82,7 @@ apps."{name}" = {{
 
   services = {{
     components.{name} = {{
-      command = pkgs.hello;
+      process.command = pkgs.hello;
     }};
     runtimes = {{
       container = {{

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -136,32 +136,7 @@
     };
 
     resources = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options.nixosConfig = lib.mkOption {
-            type = lib.types.deferredModule;
-            default = { };
-            description = ''
-              Runtime independent configuration of the resource.
-
-              See the list of available
-              [NixOS options](https://search.nixos.org/options) .
-            '';
-            example = lib.literalExpression "{ services.postgresql.enable = true; }";
-          };
-          options.ports = lib.mkOption {
-            type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
-            default = [ ];
-            description = ''
-              List of ports exposed by the resource.
-
-              Format:
-                _HOST_PORT:RESOURCE_PORT_
-            '';
-            example = lib.literalExpression ''[ "5432:5432" ]'';
-          };
-        }
-      );
+      type = lib.types.attrsOf (lib.types.submodule ./resource.nix);
       default = { };
       description = "Resource configuration";
       example = lib.literalExpression ''

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -7,12 +7,6 @@
   ...
 }:
 {
-  imports = [
-    (lib.modules.importApply (forge-inputs.nixpkgs + "/lib/services/config-data.nix") {
-      inherit pkgs;
-    })
-  ];
-
   options = {
     name = lib.mkOption {
       internal = true;
@@ -22,110 +16,159 @@
       description = "Name of service component.";
     };
 
-    command = lib.mkOption {
-      type = lib.types.either lib.types.package lib.types.str;
-      description = ''
-        Main command used to launch a service.
+    process = lib.mkOption {
+      type = lib.types.submoduleWith {
+        modules = [
+          (lib.modules.importApply (forge-inputs.nixpkgs + "/lib/services/config-data.nix") {
+            inherit pkgs;
+          })
+          {
+            options = {
+              command = lib.mkOption {
+                type = lib.types.either lib.types.package lib.types.str;
+                description = ''
+                  Main command used to launch the service.
 
-        Can be a package (e.g. `pkgs.hello`) or an explicit binary path.
-      '';
-      example = lib.literalExpression ''"''${pkgs.hello}/bin/hello"'';
+                  Can be a package (e.g. `pkgs.hello`) or an explicit binary path.
+                '';
+                example = lib.literalExpression ''"''${pkgs.hello}/bin/hello"'';
+              };
+
+              argv = lib.mkOption {
+                type = lib.types.listOf lib.types.singleLineStr;
+                default = [ ];
+                description = "List of arguments that will be passed to the main program.";
+                example = [
+                  "--config"
+                  "service.toml"
+                ];
+              };
+
+              environment = lib.mkOption {
+                type = lib.types.attrsOf lib.types.str;
+                default = { };
+                description = "Environment variables passed to the service.";
+                example = lib.literalExpression ''
+                  {
+                    DEBUG = "1";
+                    LOG_LEVEL = "info";
+                  }
+                '';
+              };
+
+              preStart = lib.mkOption {
+                description = ''
+                  Script to run before each start of this service.
+
+                  Runs before every start attempt, including restarts.
+                  If the script exits with a non-zero status, the service
+                  is considered failed and the restart policy applies.
+
+                  Set to `null` to disable.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                apply = self: if self != null then pkgs.writeShellScript "${name}-pre-start" self else null;
+                example = ''
+                  # bash
+                  echo "Running DB migration ..."
+                  program-manage makemigrations && program-manage migrate
+                '';
+              };
+
+              user = lib.mkOption {
+                type = lib.types.enum [
+                  "root"
+                  "prefer-dynamic"
+                  "non-privileged"
+                ];
+                default = "prefer-dynamic";
+                description = ''
+                  User account under which the service runs.
+
+                  - `root`: service runs as root. A non-privileged user and group named
+                    after the service are also created for services that start as root
+                    and then drop privileges.
+
+                  - `prefer-dynamic`: on NixOS runtime , uses `DynamicUser` - no physical
+                    user or group account is created. On container runtime, uses a
+                    non-privileged user named after the service.
+
+                  - `non-privileged`: service always runs as a non-privileged user named
+                    after the service.
+                '';
+              };
+
+              stateDir = lib.mkOption {
+                type = lib.types.str;
+                default = "/var/lib/${name}";
+                description = ''
+                  Path to the service state directory.
+                '';
+                example = "/var/lib/myservice";
+              };
+
+              packages = lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                default = [ ];
+                description = ''
+                  Additional packages available for the service.
+                '';
+                example = lib.literalExpression "[ pkgs.rsync pkgs.jq ]";
+              };
+
+              ports = lib.mkOption {
+                type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
+                default = [ ];
+                description = ''
+                  List of ports exposed by the service.
+
+                  Format:
+                    _HOST_PORT:SERVICE_PORT_
+                '';
+                example = lib.literalExpression ''[ "8000:8000" "5432:5432" ]'';
+              };
+            };
+          }
+        ];
+      };
+      description = "Process configuration.";
     };
 
-    argv = lib.mkOption {
-      type = lib.types.listOf lib.types.singleLineStr;
-      default = [ ];
-      description = "List of arguments that will be passed to the main program.";
-      example = [
-        "--config"
-        "service.toml"
-      ];
-    };
+    resources = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.nixosConfig = lib.mkOption {
+            type = lib.types.deferredModule;
+            default = { };
+            description = ''
+              Runtime independent configuration of the resource.
 
-    environment = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
+              See the list of available
+              [NixOS options](https://search.nixos.org/options) .
+            '';
+            example = lib.literalExpression "{ services.postgresql.enable = true; }";
+          };
+          options.ports = lib.mkOption {
+            type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
+            default = [ ];
+            description = ''
+              List of ports exposed by the resource.
+
+              Format:
+                _HOST_PORT:RESOURCE_PORT_
+            '';
+            example = lib.literalExpression ''[ "5432:5432" ]'';
+          };
+        }
+      );
       default = { };
-      description = "Environment variables passed to the service.";
+      description = "Resource configuration";
       example = lib.literalExpression ''
         {
-          DEBUG = "1";
-          LOG_LEVEL = "info";
+          database.nixosConfig = { services.postgresql.enable = true; };
+          cache.nixosConfig = { services.redis.servers.default.enable = true; };
         }
-      '';
-    };
-
-    preStart = lib.mkOption {
-      description = ''
-        Script to run before each start of this service.
-
-        Runs before every start attempt, including restarts.
-        If the script exits with a non-zero status, the service
-        is considered failed and the restart policy applies.
-
-        Set to `null` to disable.
-      '';
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      apply = self: if self != null then pkgs.writeShellScript "${name}-pre-start" self else null;
-      example = ''
-        # bash
-        echo "Running DB migration ..."
-        program-manage makemigrations && program-manage migrate
-      '';
-    };
-
-    user = lib.mkOption {
-      type = lib.types.enum [
-        "root"
-        "prefer-dynamic"
-        "non-privileged"
-      ];
-      default = "prefer-dynamic";
-      description = ''
-        User account under which the service runs.
-
-        - `root`: service runs as root. A non-privileged user and group named
-          after the service are also created for services that start as root
-          and then drop privileges.
-
-        - `prefer-dynamic`: on NixOS runtime , uses `DynamicUser` - no physical
-          user or group account is created. On container runtime, uses a
-          non-privileged user named after the service.
-
-        - `non-privileged`: service always runs as a non-privileged user named
-          after the service.
-      '';
-    };
-
-    stateDir = lib.mkOption {
-      type = lib.types.str;
-      default = "/var/lib/${name}";
-      description = ''
-        Path to the service state directory.
-      '';
-      example = "/var/lib/myservice";
-    };
-
-    packages = lib.mkOption {
-      type = lib.types.listOf lib.types.package;
-      default = [ ];
-      description = ''
-        Additional packages available for the service.
-      '';
-      example = lib.literalExpression "[ pkgs.rsync pkgs.jq ]";
-    };
-
-    ports = lib.mkOption {
-      type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
-      default = [ ];
-      description = ''
-        List of ports exposed by the service.
-
-        Format:
-          _HOST_PORT:SERVICE_PORT_
-      '';
-      example = lib.literalExpression ''
-        [ "8000:8000" "5432:5432" ]
       '';
     };
 

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -75,33 +75,7 @@
 
     resources = lib.mkOption {
       internal = true;
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options.nixosConfig = lib.mkOption {
-            type = lib.types.deferredModule;
-            default = { };
-            description = ''
-              Runtime independent configuration of the resource.
-
-              See the list of available
-              [NixOS options](https://search.nixos.org/options) .
-            '';
-            example = lib.literalExpression "{ services.postgresql.enable = true; }";
-          };
-          options.ports = lib.mkOption {
-            type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
-            default = [ ];
-            description = ''
-              List of ports exposed by the resource.
-
-              Format:
-                _HOST_PORT:RESOURCE_PORT_
-            '';
-            example = lib.literalExpression ''[ "5432:5432" ]'';
-            apply = self: lib.unique self;
-          };
-        }
-      );
+      type = lib.types.attrsOf (lib.types.submodule ./resource.nix);
       default = { };
       description = "Resource configuration";
       example = lib.literalExpression ''

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -72,5 +72,55 @@
       default = { };
       description = "Portable services runtimes.";
     };
+
+    resources = lib.mkOption {
+      internal = true;
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.nixosConfig = lib.mkOption {
+            type = lib.types.deferredModule;
+            default = { };
+            description = ''
+              Runtime independent configuration of the resource.
+
+              See the list of available
+              [NixOS options](https://search.nixos.org/options) .
+            '';
+            example = lib.literalExpression "{ services.postgresql.enable = true; }";
+          };
+          options.ports = lib.mkOption {
+            type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
+            default = [ ];
+            description = ''
+              List of ports exposed by the resource.
+
+              Format:
+                _HOST_PORT:RESOURCE_PORT_
+            '';
+            example = lib.literalExpression ''[ "5432:5432" ]'';
+            apply = self: lib.unique self;
+          };
+        }
+      );
+      default = { };
+      description = "Resource configuration";
+      example = lib.literalExpression ''
+        {
+          database.nixosConfig = { services.postgresql.enable = true; };
+          cache.nixosConfig = { services.redis.servers.default.enable = true; };
+        }
+      '';
+    };
   };
+
+  config.resources =
+    let
+      componentResources = lib.pipe config.components [
+        (lib.attrValues)
+        (lib.catAttrs "resources")
+      ];
+
+      runtimeResources = [ config.runtimes.container.resources ];
+    in
+    lib.mkMerge (runtimeResources ++ componentResources);
 }

--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -16,13 +16,16 @@
         }
       );
       default = { };
-      description = "Portable services components.";
-      # map user-config to a format which can be used by modular services
+      description = ''
+        Services components.
+
+        Each component must have `process.command` set and can optionally
+        declare one or more `resources` providing NixOS configuration.
+      '';
       apply =
         self:
         lib.mapAttrs (
           _: service:
-
           let
             knownComponents = lib.attrNames config.components;
             invalidAfterDeps = lib.filter (dep: !lib.elem dep knownComponents) service.after;
@@ -38,8 +41,6 @@
               '';
             };
 
-            serviceCommand =
-              if lib.isDerivation service.command then lib.getExe service.command else service.command;
           in
 
           assert (lib.any (c: lib.throwIf c.cond c.msg true) (lib.attrValues checks));
@@ -47,9 +48,17 @@
           service
           // {
             result = {
-              process.argv = [ serviceCommand ] ++ service.argv;
-              configData = service.configData;
-              preStart = service.preStart;
+              process.argv =
+                let
+                  serviceCommand =
+                    if lib.isDerivation service.process.command then
+                      lib.getExe service.process.command
+                    else
+                      service.process.command;
+                in
+                [ serviceCommand ] ++ service.process.argv;
+              configData = service.process.configData;
+              preStart = service.process.preStart;
             };
           }
         ) self;

--- a/forge/modules/apps/services/resource.nix
+++ b/forge/modules/apps/services/resource.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  ...
+}:
+{
+  options.nixosConfig = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+    description = ''
+      Runtime independent configuration of the resource.
+
+      See the list of available
+      [NixOS options](https://search.nixos.org/options) .
+    '';
+    example = lib.literalExpression "{ services.postgresql.enable = true; }";
+  };
+  options.ports = lib.mkOption {
+    type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
+    default = [ ];
+    description = ''
+      List of ports exposed by the resource.
+
+      Format:
+        _HOST_PORT:RESOURCE_PORT_
+    '';
+    example = lib.literalExpression ''[ "5432:5432" ]'';
+    apply = self: lib.unique self;
+  };
+}

--- a/forge/modules/apps/services/resource.nix
+++ b/forge/modules/apps/services/resource.nix
@@ -14,6 +14,27 @@
     '';
     example = lib.literalExpression "{ services.postgresql.enable = true; }";
   };
+  options.role = lib.mkOption {
+    type = lib.types.enum [
+      "backend"
+      "frontend"
+    ];
+    default = "backend";
+    description = ''
+      Role of this resource relative to the component that declares it.
+
+      - `backend` (default): the component depends on this resource, so the
+        resource starts before the component. Use this for services the
+        component needs at startup, such as a database or a message queue.
+
+      - `frontend`: this resource depends on the component, so the component
+        starts before the resource. Use this for services that sit in front
+        of the component, such as a reverse proxy, which needs the component
+        to be running and resolvable in the container network DNS before it
+        can start.
+    '';
+    example = lib.literalExpression ''"frontend"'';
+  };
   options.ports = lib.mkOption {
     type = lib.types.listOf (lib.types.strMatching "^[0-9]+:[0-9]+$");
     default = [ ];

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -269,7 +269,7 @@
           cap_add = [ "SYS_ADMIN" ];
           stop_signal = "SIGRTMIN+3";
           stop_grace_period = "30s";
-        }) config.resources;
+        }) app.services.resources;
 
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (
           lib.generators.toYAML { } {

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -63,30 +63,7 @@
     };
 
     resources = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options.nixosConfig = lib.mkOption {
-            type = lib.types.deferredModule;
-            default = { };
-            description = ''
-              Container runtime specific configuration.
-
-              See the list of available
-              [NixOS options](https://search.nixos.org/options) .
-            '';
-            example = lib.literalExpression ''
-              {
-                services.postgresql.enableTCPIP = true;
-                services.postgresql.authentication = '''
-                  local all all trust
-                  host all all 0.0.0.0/0 trust
-                  host all all ::0/0 trust
-                ''';
-              }
-            '';
-          };
-        }
-      );
+      type = lib.types.attrsOf (lib.types.submodule ../../resource.nix);
       default = { };
       description = "Per-resource container runtime NixOS configuration.";
       apply =

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -14,16 +14,18 @@ let
     acc: cname: comp:
     acc
     // lib.mapAttrs (
-      rname: r:
+      compResourceName: compResource:
       let
-        runtimeOverride = config.resources.${rname}.nixosConfig or { };
+        runtimeResource = config.resources.${compResourceName} or { };
+        runtimeOverride = runtimeResource.nixosConfig or { };
       in
       {
-        nixosModules = (acc.${rname}.nixosModules or [ ]) ++ [
-          r.nixosConfig
+        # combine both runtime and service-component resources
+        nixosModules = (acc.${compResourceName}.nixosModules or [ ]) ++ [
+          compResource.nixosConfig
           runtimeOverride
         ];
-        ports = r.ports;
+        ports = compResource.ports;
       }
     ) comp.resources
   ) { } app.services.components;

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -371,7 +371,7 @@ in
             ) config.result.nixosImages}
           )
           for image in "''${IMAGES[@]}"; do
-            podman load < "$image"
+            podman load --quiet < "$image"
           done
 
           ${lib.getExe pkgs.podman-compose} \

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -13,16 +13,6 @@
   options = {
     enable = lib.mkEnableOption "Container runtime";
 
-    composeFile = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
-      default = null;
-      description = ''
-        Path to the custom container compose file.
-        Set to null to automatically generate this file.
-      '';
-      example = lib.literalExpression "./compose.yaml";
-    };
-
     components = lib.mkOption {
       type = lib.types.attrsOf (
         lib.types.submoduleWith {
@@ -55,21 +45,6 @@
                   example = lib.literalExpression "[ pkgs.curl ]";
                 };
 
-                imageConfig = lib.mkOption {
-                  type = with lib.types; lazyAttrsOf anything;
-                  default = { };
-                  description = ''
-                    OCI image configuration.
-
-                    See the list of available
-                    [OCI image configuration options](https://specs.opencontainers.org/image-spec/config/#properties) .
-                  '';
-                  example = lib.literalExpression ''
-                    {
-                      WorkingDir = "/var/lib/myservice";
-                    }
-                  '';
-                };
               };
             }
           ];
@@ -187,22 +162,18 @@
 
     result.build =
       let
-        effectiveComposeFile =
-          if config.composeFile != null then
-            config.composeFile
-          else
-            pkgs.writeText "${app.name}-compose.yaml" (
-              lib.generators.toYAML { } {
-                services = lib.mapAttrs (name: service: {
-                  image = "localhost/${name}:latest";
-                  ports = service.ports;
-                  depends_on = lib.genAttrs service.after (_name: { });
-                  tmpfs = [ "/tmp:rw,size=64m" ];
-                  volumes = [ "${name}-data:${service.stateDir}" ];
-                }) app.services.components;
-                volumes = lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components;
-              }
-            );
+        composeFile = pkgs.writeText "${app.name}-compose.yaml" (
+          lib.generators.toYAML { } {
+            services = lib.mapAttrs (name: service: {
+              image = "localhost/${name}:latest";
+              ports = service.ports;
+              depends_on = lib.genAttrs service.after (_name: { });
+              tmpfs = [ "/tmp:rw,size=64m" ];
+              volumes = [ "${name}-data:${service.stateDir}" ];
+            }) app.services.components;
+            volumes = lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components;
+          }
+        );
 
         build-oci-images = pkgs.writeShellScriptBin "build-oci-images" (
           lib.concatMapAttrsStringSep "\n" (name: value: ''
@@ -212,7 +183,7 @@
         );
 
         compose-file = pkgs.runCommand "compose-file" { } ''
-          install -D ${effectiveComposeFile} $out/${app.name}/compose.yaml
+          install -D ${composeFile} $out/${app.name}/compose.yaml
         '';
 
         cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${builtins.hashString "md5" specialArgs.forgeConfig.forge.repositoryUrl}/tmp";

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -9,27 +9,6 @@
   specialArgs,
   ...
 }@args:
-let
-  resources = lib.foldlAttrs (
-    acc: cname: comp:
-    acc
-    // lib.mapAttrs (
-      compResourceName: compResource:
-      let
-        runtimeResource = config.resources.${compResourceName} or { };
-        runtimeOverride = runtimeResource.nixosConfig or { };
-      in
-      {
-        # combine both runtime and service-component resources
-        nixosModules = (acc.${compResourceName}.nixosModules or [ ]) ++ [
-          compResource.nixosConfig
-          runtimeOverride
-        ];
-        ports = compResource.ports;
-      }
-    ) comp.resources
-  ) { } app.services.components;
-in
 {
   options = {
     enable = lib.mkEnableOption "Container runtime";
@@ -233,6 +212,7 @@ in
         nixosEval = forge-inputs.nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            (resource.nixosConfig)
             (pkgs.path + "/nixos/modules/profiles/minimal.nix")
             {
               boot.isContainer = true;
@@ -261,8 +241,7 @@ in
               nix.enable = false;
               system.stateVersion = "26.05";
             }
-          ]
-          ++ resource.nixosModules;
+          ];
         };
         toplevel = nixosEval.config.system.build.toplevel;
         initScript = pkgs.runCommand "${name}-init" { } ''
@@ -283,11 +262,11 @@ in
           StopSignal = "SIGRTMIN+3";
         };
       }
-    ) resources;
+    ) app.services.resources;
 
     result.build =
       let
-        resourceNames = lib.attrNames resources;
+        resourceNames = lib.attrNames app.services.resources;
 
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (
           lib.generators.toYAML { } {
@@ -315,10 +294,10 @@ in
                 cap_add = [ "SYS_ADMIN" ];
                 stop_signal = "SIGRTMIN+3";
                 stop_grace_period = "30s";
-              }) resources;
+              }) app.services.resources;
             volumes =
               lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components
-              // lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) resources;
+              // lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.resources;
           }
         );
 

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -9,6 +9,25 @@
   specialArgs,
   ...
 }@args:
+let
+  resources = lib.foldlAttrs (
+    acc: cname: comp:
+    acc
+    // lib.mapAttrs (
+      rname: r:
+      let
+        runtimeOverride = config.resources.${rname}.nixosConfig or { };
+      in
+      {
+        nixosModules = (acc.${rname}.nixosModules or [ ]) ++ [
+          r.nixosConfig
+          runtimeOverride
+        ];
+        ports = r.ports;
+      }
+    ) comp.resources
+  ) { } app.services.components;
+in
 {
   options = {
     enable = lib.mkEnableOption "Container runtime";
@@ -44,7 +63,6 @@
                   '';
                   example = lib.literalExpression "[ pkgs.curl ]";
                 };
-
               };
             }
           ];
@@ -63,6 +81,46 @@
           self;
     };
 
+    resources = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.nixosConfig = lib.mkOption {
+            type = lib.types.deferredModule;
+            default = { };
+            description = ''
+              Container runtime specific configuration.
+
+              See the list of available
+              [NixOS options](https://search.nixos.org/options) .
+            '';
+            example = lib.literalExpression ''
+              {
+                services.postgresql.enableTCPIP = true;
+                services.postgresql.authentication = '''
+                  local all all trust
+                  host all all 0.0.0.0/0 trust
+                  host all all ::0/0 trust
+                ''';
+              }
+            '';
+          };
+        }
+      );
+      default = { };
+      description = "Per-resource container runtime NixOS configuration.";
+      apply =
+        self:
+        let
+          knownResources = lib.concatMap (c: lib.attrNames c.resources) (
+            lib.attrValues app.services.components
+          );
+          unknownResources = lib.subtractLists knownResources (lib.attrNames self);
+        in
+        lib.throwIf (unknownResources != [ ])
+          "services.runtimes.container.resources: unknown resource(s): ${lib.concatStringsSep ", " unknownResources}. Must be one of: ${lib.concatStringsSep ", " (lib.unique knownResources)}"
+          self;
+    };
+
     result = {
       modules = lib.mkOption {
         internal = true;
@@ -75,6 +133,13 @@
         readOnly = true;
         type = with lib.types; lazyAttrsOf (either attrs anything);
         description = "Nimi module evaluation.";
+      };
+
+      nixosImages = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = with lib.types; lazyAttrsOf package;
+        description = "OCI images built from NixOS configurations for resource components.";
       };
 
       recipes = lib.mkOption {
@@ -125,14 +190,14 @@
     }) app.services.components;
 
     result.evals = lib.mapAttrs (
-      name: value:
+      name: _:
       forge-inputs.nimi.packages.${system}.nimi.passthru.evalNimiModule {
         config = config.result.modules.${name};
       }
     ) app.services.components;
 
     result.recipes = lib.mapAttrs (
-      name: value:
+      name: _:
       forge-inputs.nimi.packages.${system}.nimi.mkContainerImage {
         config = config.result.modules.${name};
       }
@@ -141,12 +206,12 @@
     result.shellRunner = lib.mapAttrs (
       serviceName: service:
       let
-        componentPackages = service.packages;
+        componentPackages = service.process.packages;
         runtimeComponentPackages = config.components.${serviceName}.packages or [ ];
         binPaths = lib.makeBinPath ([ pkgs.coreutils ] ++ componentPackages ++ runtimeComponentPackages);
       in
       forge-inputs.nimi.packages.${system}.nimi.mkBwrap {
-        settings.bubblewrap.environment = service.environment // {
+        settings.bubblewrap.environment = service.process.environment // {
           PATH = binPaths;
         };
         settings.bubblewrap.prependFlags = [ "--clearenv" ];
@@ -160,18 +225,98 @@
       }
     ) app.services.components;
 
+    result.nixosImages = lib.mapAttrs (
+      name: resource:
+      let
+        nixosEval = forge-inputs.nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            (pkgs.path + "/nixos/modules/profiles/minimal.nix")
+            {
+              boot.isContainer = true;
+              boot.specialFileSystems = lib.mkForce { };
+              boot.nixStoreMountOpts = lib.mkForce [ ];
+              networking.hostName = "";
+              networking.useDHCP = false;
+              networking.resolvconf.enable = false;
+              environment.etc.hosts.enable = false;
+              systemd.services.systemd-logind.enable = false;
+              systemd.services.console-getty.enable = false;
+              systemd.sockets.nix-daemon.enable = lib.mkDefault false;
+              systemd.services.nix-daemon.enable = lib.mkDefault false;
+              systemd.oomd.enable = false;
+              system.nssModules = lib.mkForce [ ];
+              system.disableInstallerTools = true;
+              system.switch.enable = false;
+              services.nscd.enable = false;
+              services.journald.extraConfig = ''
+                Storage=volatile
+              '';
+              system.activationScripts.logs-hint.text = ''
+                echo "Run 'podman exec \$(podman ps -qf name=${app.name}_${name}) journalctl -f' to see more logs ..."
+              '';
+
+              nix.enable = false;
+              system.stateVersion = "26.05";
+            }
+          ]
+          ++ resource.nixosModules;
+        };
+        toplevel = nixosEval.config.system.build.toplevel;
+        initScript = pkgs.runCommand "${name}-init" { } ''
+          mkdir -p $out/usr/sbin
+          ln -s ${toplevel}/init $out/usr/sbin/init
+        '';
+      in
+      pkgs.dockerTools.streamLayeredImage {
+        inherit name;
+        tag = "latest";
+        contents = [ initScript ];
+        config = {
+          Cmd = [ "/usr/sbin/init" ];
+          Env = [
+            "container=docker"
+            "PATH=/usr/bin:/run/current-system/sw/bin/"
+          ];
+          StopSignal = "SIGRTMIN+3";
+        };
+      }
+    ) resources;
+
     result.build =
       let
+        resourceNames = lib.attrNames resources;
+
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (
           lib.generators.toYAML { } {
-            services = lib.mapAttrs (name: service: {
-              image = "localhost/${name}:latest";
-              ports = service.ports;
-              depends_on = lib.genAttrs service.after (_name: { });
-              tmpfs = [ "/tmp:rw,size=64m" ];
-              volumes = [ "${name}-data:${service.stateDir}" ];
-            }) app.services.components;
-            volumes = lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components;
+            services =
+              lib.mapAttrs (name: service: {
+                image = "localhost/${name}:latest";
+                ports = service.process.ports;
+                depends_on = lib.genAttrs (service.after ++ resourceNames) (_name: {
+                  condition = "service_started";
+                });
+                tmpfs = [
+                  "/tmp:rw,size=64m"
+                  "/run:rw,size=64m"
+                ];
+                volumes = [ "${name}-data:${service.process.stateDir}" ];
+              }) app.services.components
+              // lib.mapAttrs (name: resource: {
+                image = "localhost/${name}:latest";
+                ports = resource.ports;
+                tmpfs = [
+                  "/run"
+                  "/run/wrappers"
+                ];
+                volumes = [ "${name}-data:/var/lib" ];
+                cap_add = [ "SYS_ADMIN" ];
+                stop_signal = "SIGRTMIN+3";
+                stop_grace_period = "30s";
+              }) resources;
+            volumes =
+              lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components
+              // lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) resources;
           }
         );
 
@@ -180,6 +325,10 @@
             ${value.copyTo}/bin/copy-to oci-archive:${name}.tar:${name}:latest
             echo "Created container image in $(pwd)/${name}.tar"
           '') config.result.recipes
+          + lib.concatMapAttrsStringSep "\n" (name: imageStream: ''
+            ${imageStream} 2>/dev/null > "${name}.tar"
+            echo "Created container image in $(pwd)/${name}.tar"
+          '') config.result.nixosImages
         );
 
         compose-file = pkgs.runCommand "compose-file" { } ''

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -272,6 +272,7 @@
             "/run:rw,size=64m"
           ];
           volumes = [ "${name}-data:${service.process.stateDir}" ];
+          labels = [ "ngi-forge.type=component" ];
         }) app.services.components;
 
         resourcesComponents = lib.mapAttrs (name: resource: {
@@ -290,6 +291,7 @@
           cap_add = [ "SYS_ADMIN" ];
           stop_signal = "SIGRTMIN+3";
           stop_grace_period = "30s";
+          labels = [ "ngi-forge.type=resource" ];
         }) app.services.resources;
 
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -243,12 +243,28 @@
 
     result.build =
       let
-        resourceNames = lib.attrNames app.services.resources;
+        # Collect frontend resources and the components that declare them as such.
+        # Result: { <resource-name> = [ <component-name> ... ]; }
+        # Frontend resources start after these components so that upstream
+        # hostnames are registered in the container network DNS before the
+        # resource process (e.g. nginx) performs its startup checks.
+        frontendResourceDeps = lib.foldlAttrs (
+          acc: cname: comp:
+          lib.foldlAttrs (
+            acc2: rname: r:
+            if r.role == "frontend" then acc2 // { ${rname} = (acc2.${rname} or [ ]) ++ [ cname ]; } else acc2
+          ) acc comp.resources
+        ) { } app.services.components;
+
+        # Backend resources start before components — components depend on them.
+        backendResourceNames = lib.filter (rname: !(lib.hasAttr rname frontendResourceDeps)) (
+          lib.attrNames app.services.resources
+        );
 
         serviceComponents = lib.mapAttrs (name: service: {
           image = "localhost/${name}:latest";
           ports = service.process.ports;
-          depends_on = lib.genAttrs (service.after ++ resourceNames) (_name: {
+          depends_on = lib.genAttrs (service.after ++ backendResourceNames) (_name: {
             condition = "service_started";
           });
           tmpfs = [
@@ -261,6 +277,11 @@
         resourcesComponents = lib.mapAttrs (name: resource: {
           image = "localhost/${name}:latest";
           ports = resource.ports;
+          depends_on = lib.optionalAttrs (lib.hasAttr name frontendResourceDeps) (
+            lib.genAttrs frontendResourceDeps.${name} (_: {
+              condition = "service_started";
+            })
+          );
           tmpfs = [
             "/run"
             "/run/wrappers"

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -320,14 +320,36 @@ in
           }
         );
 
+        cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${lib.hashString "md5" specialArgs.forgeConfig.forge.repositoryUrl}";
+
+        imageHash = drv: lib.unsafeDiscardStringContext (lib.substring 0 32 (baseNameOf drv.outPath));
+
+        imageTar = name: drv: "$CACHE_DIR/${name}-${imageHash drv}.tar";
+
         build-oci-images = pkgs.writeShellScriptBin "build-oci-images" (
-          lib.concatMapAttrsStringSep "\n" (name: value: ''
-            ${value.copyTo}/bin/copy-to oci-archive:${name}.tar:${name}:latest
-            echo "Created container image in $(pwd)/${name}.tar"
+          ''
+            CACHE_DIR="${cacheDir}"
+            mkdir -p "$CACHE_DIR"
+          ''
+          + lib.concatMapAttrsStringSep "\n" (name: recipe: ''
+            IMAGE_TAR="${imageTar name recipe}"
+            if [ ! -f "$IMAGE_TAR" ]; then
+              printf "Creating container image %s ... " "$IMAGE_TAR"
+              ${recipe.copyTo}/bin/copy-to oci-archive:$IMAGE_TAR:${name}:latest >/dev/null
+              echo "done."
+            else
+              echo "Image already exists in cache: $IMAGE_TAR"
+            fi
           '') config.result.recipes
           + lib.concatMapAttrsStringSep "\n" (name: imageStream: ''
-            ${imageStream} 2>/dev/null > "${name}.tar"
-            echo "Created container image in $(pwd)/${name}.tar"
+            IMAGE_TAR="${imageTar name imageStream}"
+            if [ ! -f "$IMAGE_TAR" ]; then
+              printf "Creating container image %s ... " "$IMAGE_TAR"
+              ${imageStream} 2>/dev/null > "$IMAGE_TAR"
+              echo "done."
+            else
+              echo "Image already exists in cache: $IMAGE_TAR"
+            fi
           '') config.result.nixosImages
         );
 
@@ -335,23 +357,22 @@ in
           install -D ${composeFile} $out/${app.name}/compose.yaml
         '';
 
-        cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${builtins.hashString "md5" specialArgs.forgeConfig.forge.repositoryUrl}/tmp";
-
         run-podman = pkgs.writeShellScriptBin "run-podman" ''
           CACHE_DIR="${cacheDir}"
-          mkdir -p "$CACHE_DIR"
-          TMPDIR=$(mktemp -d -p "$CACHE_DIR")
 
-          trap 'rm -rf "$TMPDIR"' EXIT
+          ${lib.getExe build-oci-images}
 
-          pushd $TMPDIR
-            ${lib.getExe build-oci-images}
-
-            for image in *.tar; do
-              podman load < "$image"
-              rm "$image"
-            done
-          popd
+          IMAGES=(
+            ${lib.concatMapAttrsStringSep "\n    " (
+              name: recipe: "\"${imageTar name recipe}\""
+            ) config.result.recipes}
+            ${lib.concatMapAttrsStringSep "\n    " (
+              name: imageStream: "\"${imageTar name imageStream}\""
+            ) config.result.nixosImages}
+          )
+          for image in "''${IMAGES[@]}"; do
+            podman load < "$image"
+          done
 
           ${lib.getExe pkgs.podman-compose} \
             -f ${compose-file}/${app.name}/compose.yaml \

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -360,7 +360,7 @@
 
           ${lib.getExe pkgs.podman-compose} \
             -f ${compose-file}/${app.name}/compose.yaml \
-            up --force-recreate "$@"
+            up --force-recreate --remove-orphans "$@"
         '';
 
         run-container = pkgs.writeShellScriptBin "run-container" ''

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -268,33 +268,38 @@
       let
         resourceNames = lib.attrNames app.services.resources;
 
+        serviceComponents = lib.mapAttrs (name: service: {
+          image = "localhost/${name}:latest";
+          ports = service.process.ports;
+          depends_on = lib.genAttrs (service.after ++ resourceNames) (_name: {
+            condition = "service_started";
+          });
+          tmpfs = [
+            "/tmp:rw,size=64m"
+            "/run:rw,size=64m"
+          ];
+          volumes = [ "${name}-data:${service.process.stateDir}" ];
+        }) app.services.components;
+
+        resourcesComponents = lib.mapAttrs (name: resource: {
+          image = "localhost/${name}:latest";
+          ports = resource.ports;
+          tmpfs = [
+            "/run"
+            "/run/wrappers"
+          ];
+          volumes = [ "${name}-data:/var/lib" ];
+          cap_add = [ "SYS_ADMIN" ];
+          stop_signal = "SIGRTMIN+3";
+          stop_grace_period = "30s";
+        }) config.resources;
+
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (
           lib.generators.toYAML { } {
-            services =
-              lib.mapAttrs (name: service: {
-                image = "localhost/${name}:latest";
-                ports = service.process.ports;
-                depends_on = lib.genAttrs (service.after ++ resourceNames) (_name: {
-                  condition = "service_started";
-                });
-                tmpfs = [
-                  "/tmp:rw,size=64m"
-                  "/run:rw,size=64m"
-                ];
-                volumes = [ "${name}-data:${service.process.stateDir}" ];
-              }) app.services.components
-              // lib.mapAttrs (name: resource: {
-                image = "localhost/${name}:latest";
-                ports = resource.ports;
-                tmpfs = [
-                  "/run"
-                  "/run/wrappers"
-                ];
-                volumes = [ "${name}-data:/var/lib" ];
-                cap_add = [ "SYS_ADMIN" ];
-                stop_signal = "SIGRTMIN+3";
-                stop_grace_period = "30s";
-              }) app.services.resources;
+            services = lib.foldl lib.recursiveUpdate { } [
+              resourcesComponents
+              serviceComponents
+            ];
             volumes =
               lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.components
               // lib.mapAttrs' (name: _: lib.nameValuePair "${name}-data" { }) app.services.resources;

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -22,7 +22,7 @@
         etcFiles = pkgs.runCommand "etc-${serviceName}" { } ''
           mkdir -p $out/etc
           echo 'root:x:0:0:root:/root:/bin/sh' > $out/etc/passwd
-          echo '${serviceName}:x:${uid}:${gid}:${serviceName}:${service.stateDir}:/sbin/nologin' >> $out/etc/passwd
+          echo '${serviceName}:x:${uid}:${gid}:${serviceName}:${service.process.stateDir}:/sbin/nologin' >> $out/etc/passwd
           echo 'root:x:0:' > $out/etc/group
           echo '${serviceName}:x:${gid}:' >> $out/etc/group
           echo 'root:!:0::::::' > $out/etc/shadow
@@ -32,7 +32,7 @@
       in
       pkgs.buildEnv {
         name = "runtime-bins";
-        paths = service.packages ++ runtimeConfig.packages ++ [ etcFiles ];
+        paths = service.process.packages ++ runtimeConfig.packages ++ [ etcFiles ];
         pathsToLink = [
           "/bin"
           "/etc"
@@ -40,16 +40,16 @@
       };
 
     imageConfig = {
-      WorkingDir = service.stateDir;
-      User = if service.user == "root" then "root" else serviceName;
+      WorkingDir = service.process.stateDir;
+      User = if service.process.user == "root" then "root" else serviceName;
       Volumes = {
-        "${service.stateDir}" = { };
+        "${service.process.stateDir}" = { };
       };
       Env =
         let
           envAttrsToList = attrs: lib.mapAttrsToList (n: v: "${n}=${v}") attrs;
         in
-        envAttrsToList service.environment;
+        envAttrsToList service.process.environment;
     };
   };
 

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -6,7 +6,6 @@
   runtimeConfig ? {
     setup = "";
     packages = [ ];
-    imageConfig = { };
   },
   pkgs,
   lib,
@@ -43,35 +42,14 @@
     imageConfig = {
       WorkingDir = service.stateDir;
       User = if service.user == "root" then "root" else serviceName;
-    }
-    // runtimeConfig.imageConfig
-    // {
-      Volumes = (runtimeConfig.imageConfig.Volumes or { }) // {
+      Volumes = {
         "${service.stateDir}" = { };
       };
       Env =
         let
-          # { K = "V"; } -> [ "K=V" ]
           envAttrsToList = attrs: lib.mapAttrsToList (n: v: "${n}=${v}") attrs;
-
-          # imageConfig.Env follows OCI spec: list of "K=V" strings
-          containerEnv = lib.listToAttrs (
-            map (
-              envPair:
-              let
-                parts = lib.splitString "=" envPair;
-              in
-              {
-                name = lib.head parts;
-                value = lib.concatStringsSep "=" (lib.tail parts);
-              }
-            ) (runtimeConfig.imageConfig.Env or [ ])
-          );
-
-          # NOTE: we merge Attrs to remove duplicate keys
-          envList = service.environment // containerEnv;
         in
-        envAttrsToList envList;
+        envAttrsToList service.environment;
     };
   };
 

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -3,6 +3,7 @@
   forge-inputs,
   config,
   system,
+  app,
   ...
 }@args:
 {
@@ -41,14 +42,16 @@
       type = with lib.types; deferredModule;
       default = { };
       description = ''
-        NixOS system configuration.
+        NixOS runtime specific configuration.
 
         See the list of available
         [NixOS options](https://search.nixos.org/options) .
       '';
       example = lib.literalExpression ''
         {
-          services.postgresql.enable = true;
+          services.postgresql.authentication = '''
+            local all all trust
+          ''';
         }
       '';
     };
@@ -126,6 +129,22 @@
       packages = {
         environment.systemPackages = config.packages;
       };
+      nixosComponents = {
+        imports = lib.concatMap (c: map (r: r.nixosConfig) (lib.attrValues c.resources)) (
+          lib.attrValues app.services.components
+        );
+
+        networking.extraHosts =
+          let
+            componentNames = lib.attrNames app.services.components;
+            resourceNames = lib.concatMap (c: lib.attrNames c.resources) (
+              lib.attrValues app.services.components
+            );
+          in
+          lib.concatMapStringsSep "\n" (name: "127.0.0.1 ${name}") (
+            lib.unique (componentNames ++ resourceNames)
+          );
+      };
     };
 
     result.nixosModule = {
@@ -134,6 +153,7 @@
         config.result.modules.nimi
         config.result.modules.packages
         config.result.modules.nixosConfig
+        config.result.modules.nixosComponents
       ];
     };
 

--- a/forge/modules/apps/services/runtimes/nixos/default.nix
+++ b/forge/modules/apps/services/runtimes/nixos/default.nix
@@ -130,9 +130,7 @@
         environment.systemPackages = config.packages;
       };
       nixosComponents = {
-        imports = lib.concatMap (c: map (r: r.nixosConfig) (lib.attrValues c.resources)) (
-          lib.attrValues app.services.components
-        );
+        imports = lib.mapAttrsToList (name: value: value.nixosConfig) app.services.resources;
 
         networking.extraHosts =
           let

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -18,7 +18,7 @@
 
   users.groups = lib.mkMerge (
     lib.mapAttrsToList (serviceName: _: { ${serviceName} = { }; }) (
-      lib.filterAttrs (_: service: service.user != "prefer-dynamic") app.services.components
+      lib.filterAttrs (_: service: service.process.user != "prefer-dynamic") app.services.components
     )
   );
 
@@ -28,29 +28,31 @@
         isSystemUser = true;
         group = serviceName;
       };
-    }) (lib.filterAttrs (_: service: service.user != "prefer-dynamic") app.services.components)
+    }) (lib.filterAttrs (_: service: service.process.user != "prefer-dynamic") app.services.components)
   );
 
   systemd.services = lib.mapAttrs (
     serviceName: service:
     let
-      serviceAfterUnits = map (a: a + ".service") service.after;
+      serviceAfterUnits = map (a: a + ".service") (
+        lib.filter (a: app.services.components ? ${a}) service.after
+      );
     in
     {
-      environment = service.environment;
-      path = service.packages;
+      environment = service.process.environment;
+      path = service.process.packages;
       serviceConfig = lib.mkMerge [
         {
-          PassEnvironment = lib.attrNames service.environment;
+          PassEnvironment = lib.attrNames service.process.environment;
           User = lib.mkDefault serviceName;
           Group = lib.mkDefault serviceName;
           StateDirectory = serviceName;
-          WorkingDirectory = service.stateDir;
+          WorkingDirectory = service.process.stateDir;
         }
-        (lib.optionalAttrs (service.user == "prefer-dynamic") {
+        (lib.optionalAttrs (service.process.user == "prefer-dynamic") {
           DynamicUser = true;
         })
-        (lib.optionalAttrs (service.user == "root") {
+        (lib.optionalAttrs (service.process.user == "root") {
           User = "root";
         })
       ];

--- a/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
@@ -30,9 +30,10 @@
         servicePorts = lib.concatMap (service: service.process.ports) (
           lib.attrValues app.services.components
         );
-        resourcePorts = lib.concatMap (
-          service: lib.concatMap (r: r.ports) (lib.attrValues service.resources)
-        ) (lib.attrValues app.services.components);
+        resourcePorts = lib.pipe app.services.resources [
+          (lib.mapAttrsToList (name: value: value.ports))
+          (lib.flatten)
+        ];
       in
       map (
         portRange:
@@ -44,6 +45,6 @@
           host.port = lib.toInt (lib.elemAt portSplit 0);
           guest.port = lib.toInt (lib.elemAt portSplit 1);
         }
-      ) (lib.unique (servicePorts ++ resourcePorts));
+      ) (servicePorts ++ resourcePorts);
   };
 }

--- a/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/virt.nix
@@ -27,7 +27,12 @@
 
     forwardPorts =
       let
-        servicePorts = lib.concatMap (service: service.ports) (lib.attrValues app.services.components);
+        servicePorts = lib.concatMap (service: service.process.ports) (
+          lib.attrValues app.services.components
+        );
+        resourcePorts = lib.concatMap (
+          service: lib.concatMap (r: r.ports) (lib.attrValues service.resources)
+        ) (lib.attrValues app.services.components);
       in
       map (
         portRange:
@@ -39,6 +44,6 @@
           host.port = lib.toInt (lib.elemAt portSplit 0);
           guest.port = lib.toInt (lib.elemAt portSplit 1);
         }
-      ) servicePorts;
+      ) (lib.unique (servicePorts ++ resourcePorts));
   };
 }

--- a/recipes/apps/dutctl/recipe.nix
+++ b/recipes/apps/dutctl/recipe.nix
@@ -67,21 +67,21 @@
 
     services = {
       components.dutagent = {
-        command = "${pkgs.dutctl}/bin/dutagent";
-        argv = [
+        process.command = "${pkgs.dutctl}/bin/dutagent";
+        process.argv = [
           "-a" # address
           "0.0.0.0:1024"
           "-c" # path to config
           "/var/lib/dutagent/config.yaml"
         ];
-        ports = [
+        process.ports = [
           "1024:1024"
         ];
-        configData."dutagent/config.yaml" = {
+        process.configData."dutagent/config.yaml" = {
           source = ./dutagent-cfg-example.yaml;
           path = "dutagent/config.yaml";
         };
-        preStart = ''
+        process.preStart = ''
           echo "Installing configuration files ..."
           cp -v ''$XDG_CONFIG_HOME/dutagent/config.yaml /var/lib/dutagent/config.yaml
         '';

--- a/recipes/apps/example/recipe.nix
+++ b/recipes/apps/example/recipe.nix
@@ -49,9 +49,9 @@
 
     services = {
       components.hello-web = {
-        command = pkgs.hello-web;
-        argv = [ "serve" ];
-        ports = [ "5000:5000" ];
+        process.command = pkgs.hello-web;
+        process.argv = [ "serve" ];
+        process.ports = [ "5000:5000" ];
       };
 
       runtimes = {

--- a/recipes/apps/garage/recipe.nix
+++ b/recipes/apps/garage/recipe.nix
@@ -83,16 +83,16 @@
 
     services = {
       components.garage = {
-        preStart = ''
+        process.preStart = ''
           mkdir -p /var/lib/garage/meta /var/lib/garage/data
         '';
-        command = pkgs.garage_2;
-        argv = [
+        process.command = pkgs.garage_2;
+        process.argv = [
           "-c"
           "${./garage.toml}"
           "server"
         ];
-        ports = [
+        process.ports = [
           "3900:3900"
           "3901:3901"
           "3902:3902"

--- a/recipes/apps/goupile/recipe.nix
+++ b/recipes/apps/goupile/recipe.nix
@@ -28,12 +28,12 @@
     services = {
       components = {
         goupile = {
-          command = pkgs.goupile;
-          argv = [
+          process.command = pkgs.goupile;
+          process.argv = [
             "-C"
             "${./goupile.ini}"
           ];
-          ports = [ "8181:8181" ];
+          process.ports = [ "8181:8181" ];
         };
       };
 

--- a/recipes/apps/ironcalc/recipe.nix
+++ b/recipes/apps/ironcalc/recipe.nix
@@ -38,12 +38,12 @@
 
     services = {
       components.ironcalc = {
-        command = lib.getExe pkgs.ironcalc;
-        environment = {
+        process.command = lib.getExe pkgs.ironcalc;
+        process.environment = {
           ROCKET_ADDRESS = "0.0.0.0";
           IRONCALC_DB_PATH = "/var/lib/ironcalc/ironcalc.sqlite";
         };
-        ports = [ "8000:8000" ];
+        process.ports = [ "8000:8000" ];
       };
 
       runtimes.container = {

--- a/recipes/apps/mox/recipe.nix
+++ b/recipes/apps/mox/recipe.nix
@@ -61,27 +61,27 @@
 
     services = {
       components.mox = {
-        configData."mox.conf" = {
+        process.configData."mox.conf" = {
           source = ./mox.conf;
           path = "mox.conf";
         };
-        configData."domains.conf" = {
+        process.configData."domains.conf" = {
           source = ./domains.conf;
           path = "domains.conf";
         };
-        preStart = ''
+        process.preStart = ''
           echo "Installing configuration files ..."
           cp -v ''$XDG_CONFIG_HOME/mox.conf /var/lib/mox/config/mox.conf
           cp -v ''$XDG_CONFIG_HOME/domains.conf /var/lib/mox/config/domains.conf
         '';
-        user = "root";
-        command = pkgs.mox;
-        argv = [
+        process.user = "root";
+        process.command = pkgs.mox;
+        process.argv = [
           "-config"
           "/var/lib/mox/config/mox.conf"
           "serve"
         ];
-        ports = [
+        process.ports = [
           "8080:8080"
           "8081:8081"
           "8082:8082"

--- a/recipes/apps/offen/recipe.nix
+++ b/recipes/apps/offen/recipe.nix
@@ -43,14 +43,14 @@
 
     services = {
       components.offen = {
-        command = pkgs.offen;
-        argv = [ "serve" ];
-        environment = {
+        process.command = pkgs.offen;
+        process.argv = [ "serve" ];
+        process.environment = {
           OFFEN_SERVER_PORT = "3000";
           OFFEN_DATABASE_DIALECT = "sqlite3";
           OFFEN_DATABASE_CONNECTIONSTRING = "/var/lib/offen/offen.db";
         };
-        ports = [ "3000:3000" ];
+        process.ports = [ "3000:3000" ];
       };
 
       runtimes = {

--- a/recipes/apps/protomaps/recipe.nix
+++ b/recipes/apps/protomaps/recipe.nix
@@ -57,26 +57,26 @@
 
     services = {
       components.pmtiles-viewer = {
-        environment = {
+        process.environment = {
           PMTILES_APP_ROOT = "${pkgs.pmtiles-viewer}/share/pmtiles-app";
         };
-        configData."Caddyfile" = {
+        process.configData."Caddyfile" = {
           source = ./Caddyfile;
           path = "Caddyfile";
         };
-        preStart = ''
+        process.preStart = ''
           echo "Installing configuration files ..."
           cp -v ''$XDG_CONFIG_HOME/Caddyfile /var/lib/pmtiles-viewer/Caddyfile
         '';
-        command = pkgs.caddy;
-        argv = [
+        process.command = pkgs.caddy;
+        process.argv = [
           "run"
           "--adapter"
           "caddyfile"
           "--config"
           "Caddyfile"
         ];
-        ports = [ "8080:8080" ];
+        process.ports = [ "8080:8080" ];
       };
 
       runtimes = {

--- a/recipes/apps/python-web/recipe.nix
+++ b/recipes/apps/python-web/recipe.nix
@@ -1,0 +1,194 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  apps.python-web = {
+    displayName = "Python Web Example";
+    description = "Example web API with database backend.";
+    usage = ''
+      This is a simple example application that provides a web API for
+      managing a list of users.
+
+      * Initialize database
+
+      ```bash
+      curl -X POST localhost:8000/init
+      ```
+
+      * Add a new user
+
+      ```bash
+      curl -X POST \
+        --header "Content-Type: application/json" \
+        --data '{"name":"username"}' \
+      localhost:8000/users
+      ```
+
+      * Get list of all users
+
+      ```bash
+      curl localhost:8000/users
+      ```
+
+      * API
+
+      ```bash
+      curl localhost:8000/api
+      ```
+    '';
+
+    links = {
+      website = pkgs.python-web.meta.homepage;
+      docs = pkgs.python-web.meta.homepage;
+      source = pkgs.python-web.meta.homepage;
+    };
+
+    ngi.grants = {
+      Commons = [
+        "Example 1"
+        "Example 2"
+      ];
+      Core = [
+        "Example 1"
+        "Example 2"
+      ];
+    };
+
+    services = {
+      # Main app component
+      components.python-web = {
+        process.command = pkgs.python-web;
+        process.preStart = ''
+          until ${pkgs.postgresql}/bin/pg_isready -h database -U postgres; do
+            sleep 1
+          done
+        '';
+        process.packages = with pkgs; [ coreutils ];
+        process.environment = {
+          DB_HOST = "database";
+          DB_NAME = "postgres";
+          DB_USER = "postgres";
+        };
+
+        # DB resource (shared with api component)
+        resources.database.nixosConfig = {
+          services.postgresql.enable = true;
+        };
+
+        # Reverse proxy resource (shared with api component)
+        resources.reverse-proxy = {
+          nixosConfig = {
+            services.nginx = {
+              enable = true;
+              virtualHosts."_" = {
+                listen = [
+                  {
+                    addr = "0.0.0.0";
+                    port = 8000;
+                  }
+                ];
+                locations."/" = {
+                  proxyPass = "http://python-web:5000";
+                };
+              };
+            };
+          };
+          ports = [ "8000:8000" ];
+          role = "frontend";
+        };
+      };
+
+      # API component
+      components.api = {
+        process.command = pkgs.postgrest;
+        process.configData."postgrest.conf" = {
+          text = ''
+            db-uri = "postgresql://postgres@database/postgres"
+            db-schemas = "public"
+            db-anon-role = "postgres"
+            server-host = "0.0.0.0"
+            server-port = 5001
+          '';
+          path = "postgrest.conf";
+        };
+        process.preStart = ''
+          install -m 644 ''$XDG_CONFIG_HOME/postgrest.conf /var/lib/api/postgrest.conf
+          cat /var/lib/api/postgrest.conf
+          until ${pkgs.postgresql}/bin/pg_isready -h database -U postgres; do
+            sleep 1
+          done
+        '';
+        process.argv = [ "/var/lib/api/postgrest.conf" ];
+        process.packages = with pkgs; [ coreutils ];
+
+        # DB resource (shared with main app component)
+        resources.database.nixosConfig = {
+          services.postgresql.enable = true;
+        };
+
+        # Reverse proxy resource (shared with main app component)
+        resources.reverse-proxy = {
+          nixosConfig = {
+            services.nginx = {
+              enable = true;
+              virtualHosts."_".locations."/api/" = {
+                proxyPass = "http://api:5001/";
+              };
+            };
+          };
+          ports = [ "8000:8000" ];
+          role = "frontend";
+        };
+        after = [ "python-web" ];
+      };
+
+      runtimes = {
+        # Container runtime
+        container = {
+          enable = true;
+
+          # Container specific resources configuration
+          resources.database.nixosConfig = {
+            services.postgresql.enableTCPIP = true;
+            services.postgresql.authentication = ''
+              host all all 0.0.0.0/0 trust
+              host all all ::0/0 trust
+            '';
+          };
+        };
+
+        # NixOS runtime
+        nixos = {
+          enable = true;
+
+          nixosConfig = {
+            # NixOS specific configuration for all components, resources and
+            # whole system
+            services.postgresql.authentication = ''
+              local all all trust
+              host all all 127.0.0.1/32 trust
+              host all all ::1/128 trust
+            '';
+          };
+        };
+      };
+    };
+
+    test.services = {
+      script = ''
+        curl="curl --retry 10 --retry-max-time 120 --retry-all-errors"
+
+        $curl -X POST localhost:8000/init
+
+        $curl -X POST \
+          --header "Content-Type: application/json" \
+          --data '{"name":"username"}' \
+          localhost:8000/users
+
+        $curl localhost:8000/users
+      '';
+    };
+  };
+}

--- a/recipes/apps/qlever/recipe.nix
+++ b/recipes/apps/qlever/recipe.nix
@@ -35,22 +35,22 @@
 
     services = {
       components.qlever-ui = {
-        command = pkgs.qlever-ui;
-        argv = [
+        process.command = pkgs.qlever-ui;
+        process.argv = [
           "--bind=0.0.0.0:8080"
         ];
-        environment = {
+        process.environment = {
           DJANGO_SETTINGS_MODULE = "qlever.settings";
           QLEVERUI_DATABASE_URL = "sqlite:////var/lib/qlever-ui/db/qleverui.sqlite3";
         };
-        preStart = ''
+        process.preStart = ''
           qlever-ui-manage makemigrations --merge && qlever-ui-manage migrate
         '';
-        packages = with pkgs; [
+        process.packages = with pkgs; [
           qlever-ui
           subversion
         ];
-        ports = [
+        process.ports = [
           "8080:8080"
         ];
         after = [
@@ -59,11 +59,11 @@
       };
 
       components.qlever-server = {
-        configData."service-data" = {
+        process.configData."service-data" = {
           source = "${pkgs.qlever-olympics-rdf-data}/olympics.nt";
           path = "olympics.nt";
         };
-        preStart = ''
+        process.preStart = ''
           WORKDIR=/var/lib/qlever-server
 
           echo "Installing configuration files ..."
@@ -73,20 +73,20 @@
           install -D ''$XDG_CONFIG_HOME/olympics.nt "$WORKDIR"/olympics.nt
           qlever index --overwrite-existing
         '';
-        command = pkgs.qlever-control;
-        argv = [
+        process.command = pkgs.qlever-control;
+        process.argv = [
           "--qleverfile"
           "/var/lib/qlever-server/Qleverfile"
           "start"
           "--run-in-foreground"
         ];
-        packages = with pkgs; [
+        process.packages = with pkgs; [
           curl
           qlever
           qlever-control
           unzip
         ];
-        ports = [
+        process.ports = [
           "7019:7019"
         ];
       };

--- a/recipes/apps/rotonda/recipe.nix
+++ b/recipes/apps/rotonda/recipe.nix
@@ -55,12 +55,12 @@
 
     services = {
       components.rotonda = {
-        command = pkgs.rotonda;
-        argv = [
+        process.command = pkgs.rotonda;
+        process.argv = [
           "-c"
           "${./rotonda.conf}"
         ];
-        ports = [
+        process.ports = [
           "8080:8080"
           "11019:11019"
         ];

--- a/recipes/apps/tau/recipe.nix
+++ b/recipes/apps/tau/recipe.nix
@@ -51,12 +51,12 @@
 
     services = {
       components.tau-tower = {
-        command = pkgs.tau-tower;
-        configData."tau/tower.toml" = {
+        process.command = pkgs.tau-tower;
+        process.configData."tau/tower.toml" = {
           source = ./config.toml;
           path = "tau/tower.toml";
         };
-        ports = [
+        process.ports = [
           "3001:3001"
           "3002:3002"
         ];

--- a/recipes/packages/python-web/recipe.nix
+++ b/recipes/packages/python-web/recipe.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  packages.python-web = {
+    version = "0.0.1";
+    description = "Python web application example built from GitHub source.";
+    homePage = "https://github.com/imincik/python-web-example";
+    mainProgram = "python-web";
+    license = lib.licenses.mit;
+
+    source = {
+      git = "github:imincik/python-web-example/bd57b302e930f3b8b80448d2c08a3aac7d48e4ec";
+      hash = "sha256-nSW5746+criXHPrxmJ+0zhJCMwl78eer03qQAvDIo5U=";
+    };
+
+    build.pythonAppBuilder = {
+      enable = true;
+      packages.build-system = [
+        pkgs.python3Packages.setuptools
+      ];
+      packages.dependencies = [
+        pkgs.python3Packages.flask
+        pkgs.python3Packages.psycopg2
+      ];
+    };
+  };
+}

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -59,14 +59,18 @@ type alias AppProgramsRuntimes =
 type alias AppPrograms =
     { appPrograms_runtimes : AppProgramsRuntimes
     , appPrograms_runProgram : String
+    , appPrograms_packages : List String
+    , appPrograms_mainPackage : Maybe String
     }
 
 
 decodeAppPrograms : Decoder AppPrograms
 decodeAppPrograms =
-    Decode.map2 AppPrograms
+    Decode.map4 AppPrograms
         (Decode.field "runtimes" decodeAppProgramsRuntimes)
         (Decode.field "runProgram" Decode.string)
+        (Decode.field "packages" (Decode.list Decode.string))
+        (Decode.field "mainPackage" (Decode.nullable Decode.string))
 
 
 decodeAppProgramsRuntimes : Decoder AppProgramsRuntimes
@@ -291,6 +295,44 @@ decodeAppLinks =
         (Decode.maybe (Decode.field "docs" Decode.string))
         (Decode.maybe (Decode.field "source" Decode.string))
         (Decode.maybe (Decode.field "website" Decode.string))
+
+
+storePathToName : String -> String
+storePathToName path =
+    let
+        basename =
+            path |> String.split "/" |> List.reverse |> List.head |> Maybe.withDefault path
+
+        -- Nix store basenames are "<32-char-hash>-<name>", drop hash and separator
+        hashLength =
+            33
+    in
+    String.dropLeft hashLength basename
+
+
+getAppProgramPackageNames : AppPrograms -> List String
+getAppProgramPackageNames programs =
+    let
+        main =
+            programs.appPrograms_mainPackage |> Maybe.map List.singleton |> Maybe.withDefault []
+    in
+    (main ++ programs.appPrograms_packages)
+        |> List.map storePathToName
+        |> List.sort
+        |> deduplicate
+
+
+deduplicate : List String -> List String
+deduplicate =
+    List.foldr
+        (\x acc ->
+            if List.member x acc then
+                acc
+
+            else
+                x :: acc
+        )
+        []
 
 
 getAppServicesPorts : AppServices -> List String

--- a/ui/src/Main/Config/App.elm
+++ b/ui/src/Main/Config/App.elm
@@ -88,15 +88,28 @@ decodeAppProgramsRuntimesShell =
         (Decode.field "enable" Decode.bool)
 
 
+type alias AppResource =
+    { appResource_ports : List String
+    }
+
+
+decodeAppResource : Decoder AppResource
+decodeAppResource =
+    Decode.map AppResource
+        (Decode.field "ports" (Decode.list Decode.string))
+
+
 type alias AppComponent =
     { appComponent_ports : List String
+    , appComponent_resources : Dict String AppResource
     }
 
 
 decodeAppComponent : Decoder AppComponent
 decodeAppComponent =
-    Decode.map AppComponent
-        (Decode.field "ports" (Decode.list Decode.string))
+    Decode.map2 AppComponent
+        (Decode.field "process" (Decode.field "ports" (Decode.list Decode.string)))
+        (Decode.field "resources" (Decode.dict decodeAppResource))
 
 
 type alias AppServices =
@@ -284,7 +297,14 @@ getAppServicesPorts : AppServices -> List String
 getAppServicesPorts services =
     services.appServices_components
         |> Dict.toList
-        |> List.concatMap (Tuple.second >> .appComponent_ports)
+        |> List.concatMap
+            (\( _, component ) ->
+                component.appComponent_ports
+                    ++ (component.appComponent_resources
+                            |> Dict.toList
+                            |> List.concatMap (Tuple.second >> .appResource_ports)
+                       )
+            )
 
 
 type alias Maintainer =

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -137,6 +137,48 @@ viewPageAppUsage _ pageApp =
         text ""
 
 
+viewPortList : List String -> Html Update
+viewPortList ports =
+    if List.isEmpty ports then
+        text ""
+
+    else
+        ul
+            [ class "ms-3 mb-1"
+            , style "list-style-type" "none"
+            , style "padding" "0px"
+            ]
+            (List.map
+                (\p -> li [] [ small [ class "text-body-secondary" ] [ text (String.replace ":" " → " p) ] ])
+                ports
+            )
+
+
+viewResource : ( String, AppResource ) -> Html Update
+viewResource ( rname, resource ) =
+    div []
+        [ small [ class "text-body-secondary" ] [ text rname ]
+        , viewPortList resource.appResource_ports
+        ]
+
+
+viewComponent : ( String, AppComponent ) -> Html Update
+viewComponent ( cname, component ) =
+    li []
+        [ small [] [ text cname ]
+        , viewPortList component.appComponent_ports
+        , if Dict.isEmpty component.appComponent_resources then
+            text ""
+
+          else
+            div [ class "ms-2" ]
+                (component.appComponent_resources
+                    |> Dict.toList
+                    |> List.map viewResource
+                )
+        ]
+
+
 viewPageAppConfiguration : Model -> PageApp -> Html Update
 viewPageAppConfiguration _ pageApp =
     let
@@ -162,20 +204,19 @@ viewPageAppConfiguration _ pageApp =
                 ]
                 []
             ]
-        , if List.isEmpty (getAppServicesPorts pageApp.pageApp_app.app_services) then
+        , if Dict.isEmpty pageApp.pageApp_app.app_services.appServices_components then
             text ""
 
           else
             div []
-                [ div [ class "ms-2 mb-1" ]
-                    [ small [ class "text-body-secondary" ] [ text "Forwarded Ports" ] ]
-                , ul
-                    [ class "mb-3 ms-4"
-                    , style "list-style-type" "none"
-                    , style "padding" "0px"
+                [ ul
+                    [ class "ms-2 mb-3"
+                    , style "list-style-type" "disc"
+                    , style "padding-left" "1.2em"
                     ]
-                    (getAppServicesPorts pageApp.pageApp_app.app_services
-                        |> List.map (\p -> li [] [ text (String.replace ":" " → " p) ])
+                    (pageApp.pageApp_app.app_services.appServices_components
+                        |> Dict.toList
+                        |> List.map viewComponent
                     )
                 ]
         , div [ class "ms-2 mb-1" ]

--- a/ui/src/Main/View/Page/App.elm
+++ b/ui/src/Main/View/Page/App.elm
@@ -137,6 +137,16 @@ viewPageAppUsage _ pageApp =
         text ""
 
 
+viewBulletList : List (Html Update) -> Html Update
+viewBulletList items =
+    ul
+        [ class "ms-2 mb-3"
+        , style "list-style-type" "disc"
+        , style "padding-left" "1.2em"
+        ]
+        items
+
+
 viewPortList : List String -> Html Update
 viewPortList ports =
     if List.isEmpty ports then
@@ -184,6 +194,12 @@ viewPageAppConfiguration _ pageApp =
     let
         routeApp =
             pageApp.pageApp_route
+
+        packageNames =
+            getAppProgramPackageNames pageApp.pageApp_app.app_programs
+
+        components =
+            pageApp.pageApp_app.app_services.appServices_components
     in
     div
         [ class "box-container target-highlight mb-3"
@@ -204,20 +220,25 @@ viewPageAppConfiguration _ pageApp =
                 ]
                 []
             ]
-        , if Dict.isEmpty pageApp.pageApp_app.app_services.appServices_components then
+        , if List.isEmpty packageNames then
             text ""
 
           else
             div []
-                [ ul
-                    [ class "ms-2 mb-3"
-                    , style "list-style-type" "disc"
-                    , style "padding-left" "1.2em"
-                    ]
-                    (pageApp.pageApp_app.app_services.appServices_components
-                        |> Dict.toList
-                        |> List.map viewComponent
-                    )
+                [ div [ class "ms-2 mb-1" ]
+                    [ small [ class "text-body-secondary" ] [ text "Programs" ] ]
+                , viewBulletList
+                    (List.map (\n -> li [] [ small [] [ text n ] ]) packageNames)
+                ]
+        , if Dict.isEmpty components then
+            text ""
+
+          else
+            div []
+                [ div [ class "ms-2 mb-1" ]
+                    [ small [ class "text-body-secondary" ] [ text "Services" ] ]
+                , viewBulletList
+                    (components |> Dict.toList |> List.map viewComponent)
                 ]
         , div [ class "ms-2 mb-1" ]
             [ small [ class "text-body-secondary" ] [ text "Runtimes" ] ]


### PR DESCRIPTION
Based on on #543 implemented by @phanirithvij .

## Description

Allow configuration of additional resources required by application service component using `apps.<name>.services.components.<name>.resources.<name>.nixosConfig` option. 

Resources always run in NixOS system:
* in container runtime: as separate systemd container per resource
* in nixos runtime: inside of NixOS system beside all components

Resources can be shared between components. This makes a sense for databases or reverse proxy.

Additional changes in this PR:
- All component process configuration is now separated to `apps.<name>.services.components.<name>.process`
- Cache all container images permanently
- Remove container runtime `imageConfig` and `composeFile` - should be only generated from recipe configuration
- Show components in application details page
- Show programs in application details page

Resources configuration can be extended with runtime specific configuration in `apps.<name>.services.runtimes.container.resources.<name>.nixosConfig` or in `apps.<name>.services.runtimes.nixos.nixosConfig`

## Example configuration

Example recipe containing `python-web` app and `api` components with shared `database` and `reverse-proxy` resource:

```nix
     services = {
      # Main app component
      components.python-web = {
        process.command = pkgs.python-web;
        process.environment = {
          DB_HOST = "database";
          DB_NAME = "postgres";
          DB_USER = "postgres";
        };

        # DB resource (shared with api component)
        resources.database.nixosConfig = {
          services.postgresql.enable = true;
        };

        # Reverse proxy resource (shared with api component)
        resources.reverse-proxy = {
          nixosConfig = {
            services.nginx = {
              enable = true;
              virtualHosts."_" = {
                listen = [
                  {
                    addr = "0.0.0.0";
                    port = 8000;
                  }
                ];
                locations."/" = {
                  proxyPass = "http://python-web:5000";
                };
              };
            };
          };
          ports = [ "8000:8000" ];
        };
      };

      # API component
      components.api = {
        process.command = pkgs.postgrest;
        process.configData."postgrest.conf" = {
          text = ''
            db-uri = "postgresql://postgres@database/postgres"
            db-schemas = "public"
            db-anon-role = "postgres"
            server-host = "0.0.0.0"
            server-port = 5001
          '';
          path = "postgrest.conf";
        };
        process.preStart = ''
          cp -v ''$XDG_CONFIG_HOME/postgrest.conf /var/lib/api/postgrest.conf
          cat /var/lib/api/postgrest.conf
          until ${pkgs.postgresql}/bin/pg_isready -h database -U postgres; do
            sleep 1
          done
        '';
        process.argv = [ "/var/lib/api/postgrest.conf" ];

        # DB resource (shared with main app component)
        resources.database.nixosConfig = {
          services.postgresql.enable = true;
        };

        # Reverse proxy resource (shared with main app component)
        resources.reverse-proxy = {
          nixosConfig = {
            services.nginx = {
              enable = true;
              virtualHosts."_".locations."/api/" = {
                proxyPass = "http://api:5001/";
              };
            };
          };
          ports = [ "8000:8000" ];
        };
        after = [ "python-web" ];
      };

      runtimes = {
        # Container runtime
        container = {
          enable = true;

          # Container specific components configuration
          components.api.packages = with pkgs; [
            coreutils # cp
          ];

          # Container specific resources configuration
          resources.database.nixosConfig = {
            services.postgresql.enableTCPIP = true;
            services.postgresql.authentication = ''
              host all all 0.0.0.0/0 trust
              host all all ::0/0 trust
            '';
          };
        };

        # NixOS runtime
        nixos = {
          enable = true;

          nixosConfig = {
            # NixOS specific configuration for all components, resources and
            # whole system
            services.postgresql.authentication = ''
              local all all trust
              host all all 127.0.0.1/32 trust
              host all all ::1/128 trust
            '';
          };
        };
      };
    };

```


Run in container:

```
nix run .#apps.python-web.container
```

```
Image already exists in cache: /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/api-ebbb49c10fd98824ae8dc8553247e1ad.tar
Image already exists in cache: /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/python-web-9a58bb1f2fb205aed0a0a43f8295d422.tar
Image already exists in cache: /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/database-8c268fd8939c12c70219064ca6ac93f0.tar
Image already exists in cache: /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/reverse-proxy-d923b95ff4751647d2b27cb26bf5293b.tar
Getting image source signatures
Copying blob 358c2b4dcbcd skipped: already exists
Copying config 1d3346df72 done   |
Writing manifest to image destination
Loaded image: localhost/api:latest
Getting image source signatures
Copying blob b88b9fff997b skipped: already exists
Copying config 6171abc7c3 done   |
Writing manifest to image destination
Loaded image: localhost/python-web:latest
Getting image source signatures
Copying blob a5a01c41ce78 skipped: already exists
Copying blob a5a01c41ce78 skipped: already exists
Copying blob a5a01c41ce78 skipped: already exists
Copying blob 8154d24a560a skipped: already exists
Copying blob 6032ed358799 skipped: already exists
Copying blob 48b17080114e skipped: already exists
Copying blob 5c2174def459 skipped: already exists
Copying blob 26c0bf498c3f skipped: already exists
Copying blob fe0d375409ba skipped: already exists
Copying blob 1a2bd2fc98a0 skipped: already exists
Copying blob cd4f2f5dbfcc skipped: already exists
Copying blob 197ef0157d94 skipped: already exists
Copying blob 73f9a9963679 skipped: already exists
Copying blob 69ccbe420f3e skipped: already exists
Copying blob b171ff4ba408 skipped: already exists
Copying blob b68ec149ea8b skipped: already exists
Copying blob f69823d90517 skipped: already exists
Copying blob 15bc99bcacbb skipped: already exists
Copying blob d840dfa87d7f skipped: already exists
Copying blob d03e08a36ab4 skipped: already exists
Copying blob 414886cb135d skipped: already exists
Copying blob aa50ae926faa skipped: already exists
Copying blob 9419bf2eceea skipped: already exists
Copying blob c845868cbeeb skipped: already exists
Copying blob 29f4b7f9c937 skipped: already exists
Copying blob b073db9402f2 skipped: already exists
Copying blob ef81e07d08f8 skipped: already exists
Copying blob 18e03867da7c skipped: already exists
Copying blob dfde6066aebe skipped: already exists
Copying blob 3d4eae6a0657 skipped: already exists
Copying blob 2abd01c99d53 skipped: already exists
Copying blob ff25386a8107 skipped: already exists
Copying blob 4f69db519027 skipped: already exists
Copying blob e8edb7667276 skipped: already exists
Copying blob 5613c5c4be03 skipped: already exists
Copying blob 9ca2e9c15b1e skipped: already exists
Copying blob 7f98299cd785 skipped: already exists
Copying blob cb3ca21523ef skipped: already exists
Copying blob b34da7ed78f1 skipped: already exists
Copying blob 098cb77b5022 skipped: already exists
Copying blob e730e9653339 skipped: already exists
Copying blob ecd26ad059d8 skipped: already exists
Copying blob 65e2d62140bf skipped: already exists
Copying blob b98e4dc8d943 skipped: already exists
Copying blob 573b1c0ab798 skipped: already exists
Copying blob b73afdb9ac56 skipped: already exists
Copying blob fa2d6876eef0 skipped: already exists
Copying blob 9fa34f19e84f skipped: already exists
Copying config adff7501a1 done   |
Writing manifest to image destination
Loaded image: localhost/database:latest
Getting image source signatures
Copying blob a5a01c41ce78 skipped: already exists
Copying blob a5a01c41ce78 skipped: already exists
Copying blob a5a01c41ce78 skipped: already exists
Copying blob 5c2174def459 skipped: already exists
Copying blob 8154d24a560a skipped: already exists
Copying blob c3088acc4fc3 skipped: already exists
Copying blob 6032ed358799 skipped: already exists
Copying blob 48b17080114e skipped: already exists
Copying blob 197ef0157d94 skipped: already exists
Copying blob 73f9a9963679 skipped: already exists
Copying blob fe0d375409ba skipped: already exists
Copying blob b15e3edc68eb skipped: already exists
Copying blob cd4f2f5dbfcc skipped: already exists
Copying blob 26c0bf498c3f skipped: already exists
Copying blob 69ccbe420f3e skipped: already exists
Copying blob b68ec149ea8b skipped: already exists
Copying blob b171ff4ba408 skipped: already exists
Copying blob f69823d90517 skipped: already exists
Copying blob d840dfa87d7f skipped: already exists
Copying blob d03e08a36ab4 skipped: already exists
Copying blob 414886cb135d skipped: already exists
Copying blob c845868cbeeb skipped: already exists
Copying blob 15bc99bcacbb skipped: already exists
Copying blob 3235f504217a skipped: already exists
Copying blob b073db9402f2 skipped: already exists
Copying blob 9419bf2eceea skipped: already exists
Copying blob aa50ae926faa skipped: already exists
Copying blob 29f4b7f9c937 skipped: already exists
Copying blob dfde6066aebe skipped: already exists
Copying blob ff25386a8107 skipped: already exists
Copying blob ef81e07d08f8 skipped: already exists
Copying blob 3d4eae6a0657 skipped: already exists
Copying blob 2abd01c99d53 skipped: already exists
Copying blob 18e03867da7c skipped: already exists
Copying blob 4f69db519027 skipped: already exists
Copying blob e8edb7667276 skipped: already exists
Copying blob 5613c5c4be03 skipped: already exists
Copying blob 098cb77b5022 skipped: already exists
Copying blob 9ca2e9c15b1e skipped: already exists
Copying blob 7f98299cd785 skipped: already exists
Copying blob cb3ca21523ef skipped: already exists
Copying blob 22dfb838b571 skipped: already exists
Copying blob faf80ce63003 skipped: already exists
Copying blob ecd26ad059d8 skipped: already exists
Copying blob 65e2d62140bf skipped: already exists
Copying blob f09febddbef6 skipped: already exists
Copying blob 87a771d52556 skipped: already exists
Copying blob 1243b9888874 skipped: already exists
Copying config f52182f678 done   |
Writing manifest to image destination
Loaded image: localhost/reverse-proxy:latest
python-web_api_1
python-web_reverse-proxy_1
python-web_python-web_1
python-web_database_1
python-web_api_1
python-web_python-web_1
python-web_reverse-proxy_1
python-web_database_1
83557210dc9745c2327e39699643f622f63ce31d5e9167ff535c7f91bc50c3aa
python-web_default
73605cd3c12e199bb80717e56808cfc9a76915fad06dd9b89c4d4d8d4d3e1673
a1fce7ecaa32ee3e1eec9081ca8cfaf8534d7b115f322708e745ebcbb1366c94
e4a1626015dd07be9dd18439ef1e883a7ae1c9375e712fd388ca393e0870917b
561b169dca3e4493731b3eecee810b9e99759b55466c687c6c1c0c9998e0d096
2d5d79a4f0bff01d100587c51ae245bcdd145edbd8112a1e720e5391dd2d4714
[database]      |
[database]      | <<< NixOS Stage 2 >>>
[database]      |
[database]      | booting system configuration /nix/store/7vrjzqmx026g3vj9afqdx3k3hs0ihz0r-nixos-system-unnamed-26.11.20260616.567a49d
[database]      | running activation script...
[reverse-proxy] |
[reverse-proxy] | <<< NixOS Stage 2 >>>
[reverse-proxy] |
[reverse-proxy] | booting system configuration /nix/store/nb0zqv00giyc2if4asa1q3spfwzssyyp-nixos-system-unnamed-26.11.20260616.567a49d
[database]      | reviving group 'systemd-coredump' with GID 999
[reverse-proxy] | running activation script...
[database]      | setting up /etc...
[database]      | Run 'podman exec $(podman ps -qf name=python-web_database) journalctl -f' to see more logs ...
[database]      | starting systemd...
[reverse-proxy] | reviving group 'systemd-coredump' with GID 999
[reverse-proxy] | setting up /etc...
[reverse-proxy] | Run 'podman exec $(podman ps -qf name=python-web_reverse-proxy) journalctl -f' to see more logs ...
[reverse-proxy] | starting systemd...
[python-web]    | [2026-06-27T10:10:41Z INFO  nimi::cli] Launching process manager...
[python-web]    | [2026-06-27T10:10:41Z INFO  nimi::process_manager] Starting process manager...
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: DB_HOST=database
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: DB_NAME=postgres
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: DB_USER=postgres
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: HOME=/var/lib/python-web
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: HOSTNAME=561b169dca3e
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: PATH=/nix/store/yssab91xhfzc5q7g3xq08afrmirljpw4-nimi-0.1.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: PWD=/var/lib/python-web
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: SHLVL=0
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Environment: container=podman
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] XDG_CONFIG_HOME=/tmp/nimi-config-44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
[python-web]    | [2026-06-27T10:10:41Z INFO  python-web] Running: /nix/store/qyvb9v5x46vrkmccfcmm5ckxrw7cqs8l-python-web-0.0.1/bin/python-web
[api]           | [2026-06-27T10:10:41Z INFO  nimi::cli] Launching process manager...
[api]           | [2026-06-27T10:10:41Z INFO  nimi::process_manager] Starting process manager...
[api]           | [2026-06-27T10:10:41Z INFO  api] Running pre-start script (/nix/store/ch8383zb2677n3fhf3g2frirnykap45x-api-pre-start)
[api]           | [2026-06-27T10:10:41Z ERROR api] cp: cannot create regular file '/var/lib/api/postgrest.conf': Permission denied
[api]           | [2026-06-27T10:10:41Z DEBUG api] '/tmp/nimi-config-1d7cf52d3704f3e7c0f7ebf09bfed19e05d7a1245c3821de3925f54b966134ed/postgrest.conf' -> '/var/lib/api/postgrest.conf'
[api]           | [2026-06-27T10:10:41Z DEBUG api] db-uri = "postgresql://postgres@database/postgres"
[api]           | [2026-06-27T10:10:41Z DEBUG api] db-schemas = "public"
[api]           | [2026-06-27T10:10:41Z DEBUG api] db-anon-role = "postgres"
[api]           | [2026-06-27T10:10:41Z DEBUG api] server-host = "0.0.0.0"
[api]           | [2026-06-27T10:10:41Z DEBUG api] server-port = 5001
[api]           | [2026-06-27T10:10:41Z DEBUG api] database:5432 - no response
[python-web]    | [2026-06-27T10:10:41Z DEBUG python-web]  * Serving Flask app 'python_web.app'
[python-web]    | [2026-06-27T10:10:41Z DEBUG python-web]  * Debug mode: off
[python-web]    | [2026-06-27T10:10:41Z ERROR python-web] WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
[python-web]    | [2026-06-27T10:10:41Z ERROR python-web]  * Running on all addresses (0.0.0.0)
[python-web]    | [2026-06-27T10:10:41Z ERROR python-web]  * Running on http://127.0.0.1:5000
[python-web]    | [2026-06-27T10:10:41Z ERROR python-web]  * Running on http://10.89.0.4:5000
[python-web]    | [2026-06-27T10:10:41Z ERROR python-web] Press CTRL+C to quit
[api]           | [2026-06-27T10:10:42Z DEBUG api] database:5432 - accepting connections
[api]           | [2026-06-27T10:10:42Z INFO  api] Config: postgrest.conf -> /nix/store/r27m4s2a6mj7r9mlvfcfaliahxw5wfr4-service-configdata-postgrest.conf
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: HOME=/var/lib/api
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: HOSTNAME=2d5d79a4f0bf
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: PATH=/nix/store/yssab91xhfzc5q7g3xq08afrmirljpw4-nimi-0.1.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: PWD=/var/lib/api
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: SHLVL=0
[api]           | [2026-06-27T10:10:42Z INFO  api] Environment: container=podman
[api]           | [2026-06-27T10:10:42Z INFO  api] XDG_CONFIG_HOME=/tmp/nimi-config-1d7cf52d3704f3e7c0f7ebf09bfed19e05d7a1245c3821de3925f54b966134ed
[api]           | [2026-06-27T10:10:42Z INFO  api] Running: /nix/store/7jl2nn1z6h7amqr8f0fk5m3dm8gprqfh-postgrest-14.13-bin/bin/postgrest /var/lib/api/postgrest.conf
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Starting PostgREST 14.13...
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: API server listening on 0.0.0.0:5001
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Successfully connected to PostgreSQL 17.10 on x86_64-pc-linux-gnu, compiled by clang version 21.1.8, 64-bit
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Connection Pool initialized with a maximum size of 10 connections
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Listener connected to PostgreSQL 17.10 on x86_64-pc-linux-gnu, compiled by clang version 21.1.8, 64-bit on "database:5432" and listening for database notifications on the "pgrst" channel
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Config reloaded
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Schema cache queried in 283.3 milliseconds
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Schema cache loaded 0 Relations, 0 Relationships, 0 RPCs, 0 Domain Representations, 4 Media Type Handlers, 1196 Timezones
[api]           | [2026-06-27T10:10:42Z ERROR api] 27/Jun/2026:10:10:42 +0000: Schema cache loaded in 3.6 milliseconds
```

### TODOs

- [ ] Update application recipe docs
- [ ] Remove python-web app recipe used for testing.