### PR TITLE
refactor: shared builder module and split src

### DIFF
--- a/forge/modules/builders/pnpm-package-builder/default.nix
+++ b/forge/modules/builders/pnpm-package-builder/default.nix
@@ -13,7 +13,7 @@
       attrs =
         builder: finalAttrs: previousAttrs:
         {
-          pnpmDeps = pkgs.fetchPnpmDeps ({
+          pnpmDeps = pkgs.fetchPnpmDeps {
             inherit (finalAttrs)
               pname
               src
@@ -22,7 +22,7 @@
               ;
             inherit (builder) pnpm fetcherVersion;
             hash = builder.pnpmDepsHash;
-          });
+          };
           nativeBuildInputs = previousAttrs.nativeBuildInputs or [ ] ++ [
             builder.pnpm
             pkgs.pnpmConfigHook

--- a/forge/modules/builders/python-app-builder/default.nix
+++ b/forge/modules/builders/python-app-builder/default.nix
@@ -1,5 +1,4 @@
 {
-  config,
   pkgs,
   packageBuilderModule,
   ...
@@ -7,29 +6,24 @@
 {
   imports = [
     ./options.nix
-    (packageBuilderModule (rec {
+    (packageBuilderModule {
       builderName = "pythonAppBuilder";
       mkDerivation = pkgs.python3Packages.buildPythonApplication;
-      attrs =
-        builder: finalAttrs: previousAttrs:
-        let
-          builder = config.build.${builderName};
-        in
-        {
-          format = "pyproject";
-          inherit (builder.packages)
-            build-system
-            dependencies
-            optional-dependencies
-            ;
-          inherit (builder)
-            disabledTests
-            ;
-          # Warning(consistency): such renames are not done elsewhere,
-          # eg. in `packages.${package}.build.npmPackageBuilder.npmDepsHash`
-          pythonImportsCheck = builder.importsCheck;
-          pythonRelaxDeps = builder.relaxDeps;
-        };
-    }))
+      attrs = builder: finalAttrs: previousAttrs: {
+        format = "pyproject";
+        inherit (builder.packages)
+          build-system
+          dependencies
+          optional-dependencies
+          ;
+        inherit (builder)
+          disabledTests
+          ;
+        # Warning(consistency): such renames are not done elsewhere,
+        # eg. in `packages.${package}.build.npmPackageBuilder.npmDepsHash`
+        pythonImportsCheck = builder.importsCheck;
+        pythonRelaxDeps = builder.relaxDeps;
+      };
+    })
   ];
 }

--- a/forge/modules/builders/rust-package-builder/default.nix
+++ b/forge/modules/builders/rust-package-builder/default.nix
@@ -1,5 +1,4 @@
 {
-  config,
   pkgs,
   packageBuilderModule,
   ...
@@ -7,16 +6,16 @@
 {
   imports = [
     ./options.nix
-    (packageBuilderModule (rec {
+    (packageBuilderModule {
       builderName = "rustPackageBuilder";
       mkDerivation = pkgs.rustPlatform.buildRustPackage;
       attrs = builder: finalAttrs: previousAttrs: {
-        inherit (config.build.${builderName})
+        inherit (builder)
           cargoHash
           cargoBuildFlags
           ;
       };
-    }))
+    })
   ];
 
 }

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -1,7 +1,5 @@
 {
   forge-inputs,
-  lib,
-  pkgs,
   ...
 }:
 {
@@ -13,7 +11,17 @@
         builderName,
         attrs,
       }:
-      { config, ... }:
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }@args:
+
+      let
+        builder = config.build.${builderName};
+      in
+
       {
         options.build.${builderName} = {
           packages = {
@@ -51,186 +59,93 @@
             };
           };
         };
-        config =
-          let
-            builder = config.build.${builderName};
-          in
-          lib.mkIf builder.enable {
-            result.derivation =
-              let
-                initAttrs =
-                  finalAttrs:
-                  {
-                    inherit (config) pname version;
-                    src =
-                      let
-                        fetchers = {
-                          path = pkg: pkg.source.path;
 
-                          git =
-                            let
-                              forges = {
-                                # forge = fetchFunction
-                                codeberg = pkgs.fetchFromCodeberg;
-                                forgejo = pkgs.fetchFromForgejo;
-                                gitea = pkgs.fetchFromGitea;
-                                github = pkgs.fetchFromGitHub;
-                                gitlab = pkgs.fetchFromGitLab;
-                              };
+        config = lib.mkIf builder.enable {
+          result.derivation =
+            let
+              initAttrs =
+                finalAttrs:
+                {
+                  inherit (config)
+                    pname
+                    version
+                    ;
 
-                              gitSchemas = lib.fix (self: {
-                                "3" = [
-                                  "owner"
-                                  "repo"
-                                  "rev"
-                                ];
+                  src = import ./shared/src.nix args;
 
-                                "4" = [ "domain" ] ++ self."3";
-                              });
-                            in
-                            pkg:
-                            let
-                              # Expected formats:
-                              # - "forge:owner/repo/rev"
-                              # - "forge:domain/owner/repo/rev"
-                              parts = lib.splitString ":" pkg.source.git;
-                              forge = lib.elemAt parts 0;
-                              rest = lib.concatStringsSep ":" (lib.tail parts);
-                            in
-                            if forge == "git" then
-                              let
-                                # Split "https://host/path?key=value" into url and query
-                                urlParts = lib.splitString "?" rest;
-                                url = lib.elemAt urlParts 0;
-                                queryAttrs =
-                                  let
-                                    # Parse key-value pairs into an attrset:
-                                    #   "key1=value1&key2=value2" -> { key1 = value; key2 = value2; }
-                                    parseQuery =
-                                      query:
-                                      lib.listToAttrs (
-                                        map (
-                                          param:
-                                          let
-                                            kv = lib.splitString "=" param;
-                                          in
-                                          lib.nameValuePair (lib.elemAt kv 0) (lib.elemAt kv 1)
-                                        ) (lib.splitString "&" query)
-                                      );
-                                  in
-                                  if lib.length urlParts > 1 then parseQuery (lib.elemAt urlParts 1) else { };
-                              in
-                              pkgs.fetchgit (
-                                lib.recursiveUpdate queryAttrs {
-                                  inherit url;
-                                  hash = pkg.source.hash;
-                                  fetchSubmodules = pkg.source.submodules;
-                                }
-                              )
-                            else
-                              let
-                                pathParts = lib.splitString "/" rest;
-                                schema = gitSchemas.${toString (lib.length pathParts)};
+                  inherit (config.source)
+                    patches
+                    ;
 
-                                # assign each source attribute to its appropriate path part
-                                sourceAttrs = lib.listToAttrs (lib.zipListsWith lib.nameValuePair schema pathParts);
-                              in
-                              forges.${forge} (
-                                lib.recursiveUpdate sourceAttrs {
-                                  hash = pkg.source.hash;
-                                  fetchSubmodules = pkg.source.submodules;
-                                }
-                              );
+                  nativeBuildInputs = builder.packages.build;
+                  buildInputs = builder.packages.run;
+                  nativeCheckInputs = builder.packages.check;
 
-                          url =
-                            pkg:
-                            pkgs.fetchurl {
-                              url = pkg.source.url;
-                              hash = pkg.source.hash;
-                            };
-                        };
-
-                        # Determine which source type is used
-                        sourceType =
-                          pkg:
-                          if pkg.source.path != null then
-                            "path"
-                          else if pkg.source.git != null then
-                            "git"
-                          else
-                            "url";
-                      in
-                      fetchers.${sourceType config} config;
-
-                    inherit (config.source) patches;
-                    nativeBuildInputs = builder.packages.build;
-                    buildInputs = builder.packages.run;
-                    nativeCheckInputs = builder.packages.check;
-
-                    passthru = {
-                      test = pkgs.testers.runCommand {
-                        name = "${finalAttrs.pname}-test";
-                        buildInputs = [ finalAttrs.finalPackage ] ++ config.test.packages;
-                        script = config.test.script + "\ntouch $out";
-                      };
-
-                      env = pkgs.mkShell {
-                        dontBuild = true;
-                        phases = [ "installPhase" ];
-                        installPhase = "touch $out";
-                        env.ENV_PACKAGE_NAME = finalAttrs.pname;
-                        env.ENV_PACKAGE_SOURCE = "${finalAttrs.src}";
-                        inputsFrom = [
-                          finalAttrs.finalPackage
-                        ];
-                        packages = config.develop.packages;
-                        shellHook = config.develop.shellHook;
-                      };
+                  passthru = {
+                    test = pkgs.testers.runCommand {
+                      name = "${finalAttrs.pname}-test";
+                      buildInputs = [ finalAttrs.finalPackage ] ++ config.test.packages;
+                      script = config.test.script + "\ntouch $out";
                     };
 
-                    meta = {
-                      inherit (config)
-                        description
-                        mainProgram
-                        license
-                        ;
-                      homepage = config.homePage;
+                    env = pkgs.mkShell {
+                      dontBuild = true;
+                      phases = [ "installPhase" ];
+                      installPhase = "touch $out";
+                      env.ENV_PACKAGE_NAME = finalAttrs.pname;
+                      env.ENV_PACKAGE_SOURCE = "${finalAttrs.src}";
+                      inputsFrom = [
+                        finalAttrs.finalPackage
+                      ];
+                      packages = config.develop.packages;
+                      shellHook = config.develop.shellHook;
                     };
-                  }
-                  // lib.optionalAttrs config.build.debug {
-                    shellHook = "source ${forge-inputs.inputs.nix-utils}/nix-develop-interactive.bash";
-                  }
-                  //
-                    # Warning(co-existence): `extraAttrs` is overridden by the builder's options.
-                    # Eg. in `goPackageBuilder`, if `modRoot` is set in `extraAttrs.modRoot`
-                    # instead of `build.goPackageBuilder.modRoot`,
-                    # then `build.goPackageBuilder.modRoot`'s default
-                    # will override `extraAttrs.modRoot`.
-                    #
-                    # This deprioritizing offen leads to a build failure
-                    # which helps to spot lingering `build.extraAttrs`
-                    # that must be converted once a proper option
-                    # has been introduced (eg. to typecheck/merge them).
-                    config.build.extraAttrs;
-                mkAttrs =
-                  finalAttrs:
-                  let
-                    init = initAttrs finalAttrs;
-                  in
-                  init // attrs builder finalAttrs init;
-              in
-              if mkDerivationProvidesFinalAttrs then
-                mkDerivation (mkAttrs)
-              else
-                let
-                  # Approximation for builder not yet providing `finalAttrs`
-                  # (eg. with `lib.extendMkDerivation`)
-                  finalAttrs = initAttrs finalAttrs // {
-                    finalPackage = config.result.derivation;
                   };
+
+                  meta = {
+                    inherit (config)
+                      description
+                      mainProgram
+                      license
+                      ;
+                    homepage = config.homePage;
+                  };
+                }
+                // lib.optionalAttrs config.build.debug {
+                  shellHook = "source ${forge-inputs.inputs.nix-utils}/nix-develop-interactive.bash";
+                }
+                //
+                  # Warning(co-existence): `extraAttrs` is overridden by the builder's options.
+                  # Eg. in `goPackageBuilder`, if `modRoot` is set in `extraAttrs.modRoot`
+                  # instead of `build.goPackageBuilder.modRoot`,
+                  # then `build.goPackageBuilder.modRoot`'s default
+                  # will override `extraAttrs.modRoot`.
+                  #
+                  # This deprioritizing offen leads to a build failure
+                  # which helps to spot lingering `build.extraAttrs`
+                  # that must be converted once a proper option
+                  # has been introduced (eg. to typecheck/merge them).
+                  config.build.extraAttrs;
+
+              mkAttrs =
+                finalAttrs:
+                let
+                  init = initAttrs finalAttrs;
                 in
-                mkDerivation (mkAttrs finalAttrs);
-          };
+                init // attrs builder finalAttrs init;
+            in
+            if mkDerivationProvidesFinalAttrs then
+              mkDerivation (mkAttrs)
+            else
+              let
+                # Approximation for builder not yet providing `finalAttrs`
+                # (eg. with `lib.extendMkDerivation`)
+                finalAttrs = initAttrs finalAttrs // {
+                  finalPackage = config.result.derivation;
+                };
+              in
+              mkDerivation (mkAttrs finalAttrs);
+        };
       };
   };
 }

--- a/forge/modules/builders/shared.nix
+++ b/forge/modules/builders/shared.nix
@@ -63,7 +63,7 @@
         config = lib.mkIf builder.enable {
           result.derivation =
             let
-              initAttrs =
+              mkSharedAttrs =
                 finalAttrs:
                 {
                   inherit (config)
@@ -127,24 +127,25 @@
                   # has been introduced (eg. to typecheck/merge them).
                   config.build.extraAttrs;
 
-              mkAttrs =
+              mkDrvAttrs =
                 finalAttrs:
                 let
-                  init = initAttrs finalAttrs;
+                  sharedAttrs = mkSharedAttrs finalAttrs;
+                  builderAttrs = attrs builder finalAttrs sharedAttrs;
                 in
-                init // attrs builder finalAttrs init;
+                sharedAttrs // builderAttrs;
             in
             if mkDerivationProvidesFinalAttrs then
-              mkDerivation (mkAttrs)
+              mkDerivation mkDrvAttrs
             else
               let
                 # Approximation for builder not yet providing `finalAttrs`
                 # (eg. with `lib.extendMkDerivation`)
-                finalAttrs = initAttrs finalAttrs // {
+                finalAttrs = mkSharedAttrs finalAttrs // {
                   finalPackage = config.result.derivation;
                 };
               in
-              mkDerivation (mkAttrs finalAttrs);
+              mkDerivation (mkDrvAttrs finalAttrs);
         };
       };
   };

--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -71,7 +71,7 @@
                     version
                     ;
 
-                  src = import ./shared/src.nix args;
+                  src = import ./src.nix args;
 
                   inherit (config.source)
                     patches

--- a/forge/modules/builders/shared/src.nix
+++ b/forge/modules/builders/shared/src.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  fetchers = {
+    path = pkg: pkg.source.path;
+
+    git =
+      let
+        forges = {
+          # forge = fetchFunction
+          codeberg = pkgs.fetchFromCodeberg;
+          forgejo = pkgs.fetchFromForgejo;
+          gitea = pkgs.fetchFromGitea;
+          github = pkgs.fetchFromGitHub;
+          gitlab = pkgs.fetchFromGitLab;
+        };
+
+        gitSchemas = lib.fix (self: {
+          "3" = [
+            "owner"
+            "repo"
+            "rev"
+          ];
+
+          "4" = [ "domain" ] ++ self."3";
+        });
+      in
+      pkg:
+      let
+        # Expected formats:
+        # - "forge:owner/repo/rev"
+        # - "forge:domain/owner/repo/rev"
+        parts = lib.splitString ":" pkg.source.git;
+        forge = lib.elemAt parts 0;
+        rest = lib.concatStringsSep ":" (lib.tail parts);
+      in
+      if forge == "git" then
+        let
+          # Split "https://host/path?key=value" into url and query
+          urlParts = lib.splitString "?" rest;
+          url = lib.elemAt urlParts 0;
+          queryAttrs =
+            let
+              # Parse key-value pairs into an attrset:
+              #   "key1=value1&key2=value2" -> { key1 = value; key2 = value2; }
+              parseQuery =
+                query:
+                lib.listToAttrs (
+                  map (
+                    param:
+                    let
+                      kv = lib.splitString "=" param;
+                    in
+                    lib.nameValuePair (lib.elemAt kv 0) (lib.elemAt kv 1)
+                  ) (lib.splitString "&" query)
+                );
+            in
+            if lib.length urlParts > 1 then parseQuery (lib.elemAt urlParts 1) else { };
+        in
+        pkgs.fetchgit (
+          lib.recursiveUpdate queryAttrs {
+            inherit url;
+            hash = pkg.source.hash;
+            fetchSubmodules = pkg.source.submodules;
+          }
+        )
+      else
+        let
+          pathParts = lib.splitString "/" rest;
+          schema = gitSchemas.${toString (lib.length pathParts)};
+
+          # assign each source attribute to its appropriate path part
+          sourceAttrs = lib.listToAttrs (lib.zipListsWith lib.nameValuePair schema pathParts);
+        in
+        forges.${forge} (
+          lib.recursiveUpdate sourceAttrs {
+            hash = pkg.source.hash;
+            fetchSubmodules = pkg.source.submodules;
+          }
+        );
+
+    url =
+      pkg:
+      pkgs.fetchurl {
+        url = pkg.source.url;
+        hash = pkg.source.hash;
+      };
+  };
+
+  # Determine which source type is used
+  sourceType =
+    pkg:
+    if pkg.source.path != null then
+      "path"
+    else if pkg.source.git != null then
+      "git"
+    else
+      "url";
+in
+fetchers.${sourceType config} config

--- a/forge/modules/packages.nix
+++ b/forge/modules/packages.nix
@@ -9,7 +9,7 @@
 {
   imports = [
     ./assertions-warnings.nix
-    builders/shared.nix
+    ./builders/shared
   ];
 
   options.forge = lib.mkOption {


### PR DESCRIPTION
## Changes

- split `src` into a separate file
- rename shared builder functions for more clarity
- clean up builders (which are needlessly using `rec`)
- move shared module location to a folder (for more future cleanups)

Followup to https://github.com/ngi-nix/forge/pull/586

Best reviewed commit by commit.