### PR TITLE
docs: glob ToC pages

### DIFF
--- a/docs/announcements/index.md
+++ b/docs/announcements/index.md
@@ -2,6 +2,7 @@
 
 ```{toctree}
 :hidden: true
+:glob:
 
-version-0_1.md
+*
 ```

--- a/docs/manuals/contributor/index.md
+++ b/docs/manuals/contributor/index.md
@@ -2,8 +2,9 @@
 
 ```{toctree}
 :hidden: true
+:glob:
 
-how_to/package_recipe.md
-how_to/app_recipe.md
-how_to/dev_environment.md
+how_to/package*
+how_to/app*
+how_to/*
 ```

--- a/docs/manuals/developer/index.md
+++ b/docs/manuals/developer/index.md
@@ -2,6 +2,7 @@
 
 ```{toctree}
 :hidden: true
+:glob:
 
 how_to/develop.md
 how_to/test.md

--- a/docs/manuals/user/index.md
+++ b/docs/manuals/user/index.md
@@ -2,7 +2,7 @@
 
 ```{toctree}
 :hidden: true
+:glob:
 
-quick_start
-prerequisites
+*
 ```


### PR DESCRIPTION
instead of manually listing everything.

More information about `:glob:`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-option-toctree-glob