### PR TITLE
Read service configuration files directly from XDG_CONFIG_HOME

### DIFF
--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -170,10 +170,13 @@ one or more _service components_.
 
 Start with runtime-independent service configuration. The only required option
 is `process.command`, which specifies the executable to start the service.
-Additional arguments are passed using the `process.argv` option. Services
-typically also need a configuration file, which can be supplied via the
-`process.configData` option. Configuration files are made available at runtime
-under `$XDG_CONFIG_HOME`, which can be referenced directly in `process.argv`.
+
+Additional arguments are passed using the `process.argv` option.
+
+Services typically also need a configuration file, which can be supplied
+via the `process.configData` option. Configuration files are installed
+to `$XDG_CONFIG_HOME` directory, which can be referenced directly in
+`process.argv`.
 
 ```nix
 services = {

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780647125,
-        "narHash": "sha256-g0A9MEdOhePoVkGsTrh6ZG+floNyfSlCnC37gXSvqRE=",
+        "lastModified": 1782892141,
+        "narHash": "sha256-hjLR3sKILmg4ragMOiVBAK4XVOTGy9TvkU0Hryob+68=",
         "owner": "ngi-nix",
         "repo": "nimi",
-        "rev": "4738013b0e89ce19238cfd293e34ccbac9d405dd",
+        "rev": "52e275234fe472cebc81fa266aad3018e4369094",
         "type": "github"
       },
       "original": {

--- a/recipes/apps/dutctl/recipe.nix
+++ b/recipes/apps/dutctl/recipe.nix
@@ -72,7 +72,7 @@
           "-a" # address
           "0.0.0.0:1024"
           "-c" # path to config
-          "/var/lib/dutagent/config.yaml"
+          "$XDG_CONFIG_HOME/dutagent/config.yaml"
         ];
         process.ports = [
           "1024:1024"
@@ -81,10 +81,6 @@
           source = ./dutagent-cfg-example.yaml;
           path = "dutagent/config.yaml";
         };
-        process.preStart = ''
-          echo "Installing configuration files ..."
-          cp -v ''$XDG_CONFIG_HOME/dutagent/config.yaml /var/lib/dutagent/config.yaml
-        '';
       };
 
       runtimes = {
@@ -92,7 +88,6 @@
           enable = true;
           components.dutagent.packages = with pkgs; [
             bash # for entering the container
-            coreutils # mkdir, echo, ...
             dutctl
           ];
         };

--- a/recipes/apps/mox/domains.conf
+++ b/recipes/apps/mox/domains.conf
@@ -7,11 +7,11 @@ Domains:
 			Selectors:
 				2026a:
 					Expiration: 72h
-					PrivateKeyFile: dkim/dkima.rsa2048.privatekey.pkcs8.pem
+					PrivateKeyFile: /var/lib/mox/config/dkim/dkima.rsa2048.privatekey.pkcs8.pem
 
 				2026b:
 					Expiration: 72h
-					PrivateKeyFile: dkim/dkimb.rsa2048.privatekey.pkcs8.pem
+					PrivateKeyFile: /var/lib/mox/config/dkim/dkimb.rsa2048.privatekey.pkcs8.pem
 
 			Sign:
 				- 2026a

--- a/recipes/apps/mox/mox.conf
+++ b/recipes/apps/mox/mox.conf
@@ -1,4 +1,4 @@
-DataDir: ../data
+DataDir: /var/lib/mox/data
 LogLevel: debug
 User: mox
 Hostname: mail.example.com

--- a/recipes/apps/mox/recipe.nix
+++ b/recipes/apps/mox/recipe.nix
@@ -69,16 +69,11 @@
           source = ./domains.conf;
           path = "domains.conf";
         };
-        process.preStart = ''
-          echo "Installing configuration files ..."
-          cp -v ''$XDG_CONFIG_HOME/mox.conf /var/lib/mox/config/mox.conf
-          cp -v ''$XDG_CONFIG_HOME/domains.conf /var/lib/mox/config/domains.conf
-        '';
         process.user = "root";
         process.command = pkgs.mox;
         process.argv = [
           "-config"
-          "/var/lib/mox/config/mox.conf"
+          "$XDG_CONFIG_HOME/mox.conf"
           "serve"
         ];
         process.ports = [
@@ -109,7 +104,7 @@
             '';
             packages = [
               pkgs.bash # required for entering the container
-              pkgs.coreutils # required for mkdir, echo
+              pkgs.coreutils # required by setup script
               pkgs.mox # required for admin tasks
             ];
           };

--- a/recipes/apps/protomaps/recipe.nix
+++ b/recipes/apps/protomaps/recipe.nix
@@ -64,17 +64,13 @@
           source = ./Caddyfile;
           path = "Caddyfile";
         };
-        process.preStart = ''
-          echo "Installing configuration files ..."
-          cp -v ''$XDG_CONFIG_HOME/Caddyfile /var/lib/pmtiles-viewer/Caddyfile
-        '';
         process.command = pkgs.caddy;
         process.argv = [
           "run"
           "--adapter"
           "caddyfile"
           "--config"
-          "Caddyfile"
+          "$XDG_CONFIG_HOME/Caddyfile"
         ];
         process.ports = [ "8080:8080" ];
       };
@@ -82,9 +78,6 @@
       runtimes = {
         container = {
           enable = true;
-          components.pmtiles-viewer.packages = with pkgs; [
-            coreutils # mkdir, echo
-          ];
         };
 
         nixos.enable = true;

--- a/recipes/apps/python-web/recipe.nix
+++ b/recipes/apps/python-web/recipe.nix
@@ -114,13 +114,11 @@
           path = "postgrest.conf";
         };
         process.preStart = ''
-          install -m 644 ''$XDG_CONFIG_HOME/postgrest.conf /var/lib/api/postgrest.conf
-          cat /var/lib/api/postgrest.conf
           until ${pkgs.postgresql}/bin/pg_isready -h database -U postgres; do
             sleep 1
           done
         '';
-        process.argv = [ "/var/lib/api/postgrest.conf" ];
+        process.argv = [ "$XDG_CONFIG_HOME/postgrest.conf" ];
         process.packages = with pkgs; [ coreutils ];
 
         # DB resource (shared with main app component)

--- a/recipes/apps/qlever/recipe.nix
+++ b/recipes/apps/qlever/recipe.nix
@@ -59,6 +59,10 @@
       };
 
       components.qlever-server = {
+        process.configData."qleverfile" = {
+          source = ./Qleverfile;
+          path = "Qleverfile";
+        };
         process.configData."service-data" = {
           source = "${pkgs.qlever-olympics-rdf-data}/olympics.nt";
           path = "olympics.nt";
@@ -66,17 +70,14 @@
         process.preStart = ''
           WORKDIR=/var/lib/qlever-server
 
-          echo "Installing configuration files ..."
-          install -D ${./Qleverfile} "$WORKDIR"/Qleverfile
-
           echo "Fetching and indexing data ..."
           install -D ''$XDG_CONFIG_HOME/olympics.nt "$WORKDIR"/olympics.nt
-          qlever index --overwrite-existing
+          qlever --qleverfile ''$XDG_CONFIG_HOME/Qleverfile index --overwrite-existing
         '';
         process.command = pkgs.qlever-control;
         process.argv = [
           "--qleverfile"
-          "/var/lib/qlever-server/Qleverfile"
+          "$XDG_CONFIG_HOME/Qleverfile"
           "start"
           "--run-in-foreground"
         ];


### PR DESCRIPTION
This PR removes `preStart` hack we used to install service configuration files to the known location in filesystem.

PR depends on https://github.com/ngi-nix/nimi/pull/8  which implements environment variables expansion in `argv`. Nimi PR needs to be merged first and `nimi` input updated in `flake.nix`.

- **flake: update nimi input**
- **recipes: read service configuration files directly from XDG_CONFIG_HOME**
