### PR TITLE
fix(ui): don't show internal 'resources' option in the options browser

### DIFF
--- a/forge/modules/apps/services/default.nix
+++ b/forge/modules/apps/services/default.nix
@@ -75,6 +75,7 @@
 
     resources = lib.mkOption {
       internal = true;
+      visible = false;
       type = lib.types.attrsOf (lib.types.submodule ./resource.nix);
       default = { };
       description = "Resource configuration";


### PR DESCRIPTION
Prevent showing internale 'resources' option in
`apps.<name>.services.resources` .
