### PR TITLE
feat: add healthcheck for service components and resources

### DIFF
--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -272,6 +272,34 @@ services = {
 };
 ```
 
+### Health checks
+
+A health check can be configured for a service component using the `healthcheck`
+option. When enabled, dependent services wait for the component to become healthy
+before starting.
+
+The `test` command is executed directly (no shell) so binary paths must be
+fully specified. Use string interpolation to reference Nix store paths.
+
+```nix
+services = {
+  components.my-service-A = {
+    process = {
+      ...
+    };
+
+    healthcheck = {
+      enable = true;
+      test = [ "${lib.getExe pkgs.curl}" "-fs" "http://localhost:8080/health" ];
+      interval = "3s";
+      timeout = "3s";
+      startPeriod = "10s";
+      retries = 10;
+    };
+  };
+};
+```
+
 ### Additional resources
 
 Additional resources required by a service - such as a database or reverse proxy
@@ -413,6 +441,13 @@ Inspect container image:
 
 podman load < <service-name>.tar
 podman inspect localhost/<service-name>
+```
+
+Inspect a running container:
+
+```bash
+nix run .#apps.<app-name>.container
+podman inspect <app-name>_<TAB>
 ```
 
 Inspect service in a running container:

--- a/forge/modules/apps/services/component.nix
+++ b/forge/modules/apps/services/component.nix
@@ -147,6 +147,12 @@
       '';
     };
 
+    healthcheck = lib.mkOption {
+      type = lib.types.submodule ./healthcheck.nix;
+      default = { };
+      description = "Health check configuration.";
+    };
+
     dependsOn = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];

--- a/forge/modules/apps/services/healthcheck.nix
+++ b/forge/modules/apps/services/healthcheck.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+{
+  options = {
+    enable = lib.mkEnableOption "health check";
+
+    test = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Command to run to check health, as a list of strings (direct exec, no shell).
+      '';
+      example = lib.literalExpression ''[ "''${lib.getExe pkgs.curl}" "-fs" "http://localhost:5000/" ]'';
+    };
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        List of packages available to the health check command.
+      '';
+      example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
+    };
+    interval = lib.mkOption {
+      type = lib.types.str;
+      default = "30s";
+      description = "Time between health checks.";
+      example = "1m";
+    };
+    timeout = lib.mkOption {
+      type = lib.types.str;
+      default = "30s";
+      description = "Time to wait for a health check to succeed before considering it failed.";
+      example = "10s";
+    };
+    startPeriod = lib.mkOption {
+      type = lib.types.str;
+      default = "0s";
+      description = "Initialization period during which health check failures are not counted.";
+      example = "30s";
+    };
+    retries = lib.mkOption {
+      type = lib.types.int;
+      default = 3;
+      description = "Number of consecutive failures needed to consider the service unhealthy.";
+      example = 5;
+    };
+  };
+}

--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -306,26 +306,69 @@
           lib.attrNames app.services.resources
         );
 
-        serviceComponents = lib.mapAttrs (name: service: {
-          image = "localhost/${app.name}-${name}:${config.result.images.${name}.tag}";
-          ports = service.process.ports;
-          depends_on = lib.genAttrs (service.dependsOn ++ backendResourceNames) (_name: {
-            condition = "service_started";
-          });
-          tmpfs = [
-            "/tmp:rw,size=64m"
-            "/run:rw,size=64m"
+        dependsOnCondition =
+          depName:
+          if lib.hasAttr depName app.services.resources then
+            "service_healthy"
+          else if app.services.components.${depName}.healthcheck.enable then
+            "service_healthy"
+          else
+            "service_started";
+
+        serviceComponents = lib.mapAttrs (
+          name: service:
+          {
+            image = "localhost/${app.name}-${name}:${config.result.images.${name}.tag}";
+            ports = service.process.ports;
+            depends_on = lib.genAttrs (service.dependsOn ++ backendResourceNames) (depName: {
+              condition = dependsOnCondition depName;
+            });
+            tmpfs = [
+              "/tmp:rw,size=64m"
+              "/run:rw,size=64m"
+            ];
+            volumes = [ "${name}-data:${service.process.stateDir}" ];
+            labels = [ "ngi-forge.type=component" ];
+          }
+          // lib.optionalAttrs service.healthcheck.enable {
+            healthcheck = {
+              test = [ "CMD" ] ++ service.healthcheck.test;
+              interval = service.healthcheck.interval;
+              timeout = service.healthcheck.timeout;
+              start_period = service.healthcheck.startPeriod;
+              retries = service.healthcheck.retries;
+            };
+          }
+        ) app.services.components;
+
+        resourceDefaultHealthcheck = {
+          test = [
+            # Check for system reaching multi-user target and make sure that no
+            # unit is failing
+            "CMD-SHELL"
+            ''
+              if systemctl is-active --quiet multi-user.target \
+                && [ "$(systemctl list-units --state failed --output json)" = "[]" ]; then
+                logger "Healthcheck: OK"
+                exit 0
+              else
+                logger "Healthcheck: FAILED"
+                exit 1
+              fi
+            ''
           ];
-          volumes = [ "${name}-data:${service.process.stateDir}" ];
-          labels = [ "ngi-forge.type=component" ];
-        }) app.services.components;
+          interval = "5s";
+          timeout = "5s";
+          start_period = "30s";
+          retries = 10;
+        };
 
         resourcesComponents = lib.mapAttrs (name: resource: {
           image = "localhost/${app.name}-${name}:${config.result.images.${name}.tag}";
           ports = resource.ports;
           depends_on = lib.optionalAttrs (lib.hasAttr name frontendResourceDeps) (
-            lib.genAttrs frontendResourceDeps.${name} (_: {
-              condition = "service_started";
+            lib.genAttrs frontendResourceDeps.${name} (depName: {
+              condition = dependsOnCondition depName;
             })
           );
           tmpfs = [
@@ -337,6 +380,7 @@
           stop_signal = "SIGRTMIN+3";
           stop_grace_period = "30s";
           labels = [ "ngi-forge.type=resource" ];
+          healthcheck = resourceDefaultHealthcheck;
         }) app.services.resources;
 
         composeFile = pkgs.writeText "${app.name}-compose.yaml" (

--- a/forge/modules/apps/services/runtimes/container/modules/settings.nix
+++ b/forge/modules/apps/services/runtimes/container/modules/settings.nix
@@ -32,7 +32,12 @@
       in
       pkgs.buildEnv {
         name = "runtime-bins";
-        paths = service.process.packages ++ runtimeConfig.packages ++ [ etcFiles ];
+        paths = [
+          etcFiles
+        ]
+        ++ service.process.packages
+        ++ runtimeConfig.packages
+        ++ service.healthcheck.packages;
         pathsToLink = [
           "/bin"
           "/etc"

--- a/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
+++ b/forge/modules/apps/services/runtimes/nixos/modules/nimi.nix
@@ -2,6 +2,7 @@
   forge-inputs,
   app,
 
+  pkgs,
   lib,
   ...
 }:
@@ -37,6 +38,7 @@
       requiredServiceUnits = map (a: a + ".service") (
         lib.filter (a: app.services.components ? ${a}) service.dependsOn
       );
+
     in
     {
       environment = service.process.environment;
@@ -54,6 +56,30 @@
         })
         (lib.optionalAttrs (service.process.user == "root") {
           User = "root";
+        })
+        (lib.optionalAttrs service.healthcheck.enable {
+          ExecStartPost =
+            let
+              hc = service.healthcheck;
+              name = "${serviceName}-healthcheck";
+            in
+            lib.getExe (
+              pkgs.writeShellApplication {
+                name = name;
+                runtimeInputs = [ pkgs.coreutils ] ++ hc.packages;
+                text = ''
+                  sleep ${hc.startPeriod}
+                  for _ in $(seq 1 ${toString hc.retries}); do
+                    if timeout ${hc.timeout} ${lib.escapeShellArgs hc.test}; then
+                      exit 0
+                    fi
+                    sleep ${hc.interval}
+                  done
+                  exit 1
+                '';
+              }
+            );
+          TimeoutStartSec = "infinity";
         })
       ];
       after = requiredServiceUnits;

--- a/templates/provider/recipes/apps/multi-component/recipe.nix
+++ b/templates/provider/recipes/apps/multi-component/recipe.nix
@@ -140,6 +140,19 @@ in
             DB_USER = "postgres";
           };
         };
+        healthcheck = {
+          enable = true;
+          test = [
+            "curl"
+            "-fs"
+            "http://localhost:5000/health"
+          ];
+          packages = [ pkgs.curl ];
+          interval = "3s";
+          timeout = "3s";
+          startPeriod = "1s";
+          retries = 10;
+        };
 
         # DB resource (shared with api component)
         resources.database.nixosConfig = {
@@ -172,7 +185,6 @@ in
       # PostgREST API component
       components.api = {
         process = {
-          command = pkgs.postgrest;
           configData."postgrest.conf" = {
             text = ''
               db-uri = "postgresql://postgres@database/postgres"
@@ -183,16 +195,25 @@ in
             '';
             path = "postgrest.conf";
           };
-          preStart = ''
-            until pg_isready -h database -U postgres; do
-              sleep 1
-            done
-          '';
+          command = pkgs.postgrest;
           argv = [ "$XDG_CONFIG_HOME/postgrest.conf" ];
           packages = with pkgs; [
             coreutils
             postgresql
           ];
+        };
+        healthcheck = {
+          enable = true;
+          test = [
+            "curl"
+            "-fs"
+            "http://localhost:5001/"
+          ];
+          packages = [ pkgs.curl ];
+          interval = "3s";
+          timeout = "3s";
+          startPeriod = "1s";
+          retries = 10;
         };
 
         # DB resource (shared with web component)
@@ -211,6 +232,9 @@ in
           ports = recipe.services.components.web.resources.reverse-proxy.ports;
           role = recipe.services.components.web.resources.reverse-proxy.role;
         };
+
+        # Wait for `web` which runs `initdb` to create the `greetings` table.
+        dependsOn = [ "web" ];
       };
 
       # Runtimes

--- a/templates/provider/recipes/pkgs/hello-web/src/main.go
+++ b/templates/provider/recipes/pkgs/hello-web/src/main.go
@@ -92,6 +92,7 @@ func initdb() {
 func serve() {
 	if !dbEnabled() {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("request: %s %s", r.Method, r.URL.Path)
 			fmt.Fprint(w, defaultGreeting)
 		})
 
@@ -113,6 +114,7 @@ func serve() {
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("request: %s %s", r.Method, r.URL.Path)
 		var msg string
 		if err := db.QueryRow(`SELECT message FROM greetings ORDER BY RANDOM() LIMIT 1`).Scan(&msg); err != nil {
 			http.Error(w, "failed to fetch greeting from database", http.StatusInternalServerError)


### PR DESCRIPTION
Implement healthcheck for service components and resources.

1. Add configurable healthcheck for service components. Implemented in:
 * compose file for container runtime
 * via `systemd ExecStartPost` in nixos runtime

2. Add default (non-configurable) healthcheck for service resources

## Todos

- [x] Use `systemctl list-units --state failed ` as periodic check of services health 
- [x] Remove `multi-component` app used for testing and review


## Testing

```
nix run .#apps.multi-component.container
```