### PR TITLE
fix: remove redundant container resources options

### DIFF
--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -63,7 +63,30 @@
     };
 
     resources = lib.mkOption {
-      type = lib.types.attrsOf (lib.types.submodule ../../resource.nix);
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.nixosConfig = lib.mkOption {
+            type = lib.types.deferredModule;
+            default = { };
+            description = ''
+              Container runtime specific configuration.
+
+              See the list of available
+              [NixOS options](https://search.nixos.org/options) .
+            '';
+            example = lib.literalExpression ''
+              {
+                services.postgresql.enableTCPIP = true;
+                services.postgresql.authentication = '''
+                  local all all trust
+                  host all all 0.0.0.0/0 trust
+                  host all all ::0/0 trust
+                ''';
+              }
+            '';
+          };
+        }
+      );
       default = { };
       description = "Per-resource container runtime NixOS configuration.";
       apply =


### PR DESCRIPTION
Remove redundant ports and role option which appeared after final refactoring of #660 in 54e6e5b7c8c886e7b222fea05d545fe2897bb0d0 .
