### PR TITLE
refactor: drop obsolete recipeDirs option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,10 +83,6 @@
                 forge = {
                   repositoryUrl = self.sourceInfo.url or "github:ngi-nix/forge";
                   maintainerLists = [ self.maintainerList ];
-                  recipeDirs = {
-                    pkgs = "recipes/pkgs";
-                    apps = "recipes/apps";
-                  };
                 };
               };
           });

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -41,7 +41,6 @@
       modules = [
         {
           options = {
-
             maintainerLists = lib.mkOption {
               type = lib.types.listOf lib.types.path;
               default = [ ];
@@ -58,35 +57,6 @@
               example = "github:ngi-nix/forge";
               description = "URL of the flake repository.";
             };
-
-            recipeDirs = {
-              pkgs = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = "recipes/pkgs";
-                description = ''
-                  Directory containing package recipe files.
-                  Each recipe should be a recipe.nix file in a subdirectory
-                  (e.g., recipes/pkgs/hello/recipe.nix).
-
-                  Set to null to disable automatic package recipe loading.
-                '';
-                example = "recipes/pkgs";
-              };
-
-              apps = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = "recipes/apps";
-                description = ''
-                  Directory containing app recipe files.
-                  Each recipe should be a recipe.nix file in a subdirectory
-                  (e.g., recipes/apps/my-app/recipe.nix).
-
-                  Set to null to disable automatic app recipe loading.
-                '';
-                example = "recipes/apps";
-              };
-            };
-
           };
         }
       ];

--- a/forge/modules/recipe-metadata.nix
+++ b/forge/modules/recipe-metadata.nix
@@ -22,7 +22,7 @@
       type = lib.types.str;
       default =
         let
-          locs = builtins.map (
+          locs = map (
             def: builtins.unsafeGetAttrPos name def.value
           ) specialArgs.forgeOptions.${config._recipeType}.definitionsWithLocations;
           validLocs = builtins.filter (loc: loc != null) locs;

--- a/ui/src/Main/Config.elm
+++ b/ui/src/Main/Config.elm
@@ -29,7 +29,6 @@ type alias UrlHttp =
 
 type alias Config =
     { config_repository : NixUrl
-    , config_recipe : ConfigRecipe
     , config_apps : Dict AppName App
     , config_pkgs : Dict PkgName Pkg
     }
@@ -38,7 +37,6 @@ type alias Config =
 initConfig : Config
 initConfig =
     { config_repository = "github:ngi-nix/forge"
-    , config_recipe = initRecipe
     , config_apps = Dict.empty
     , config_pkgs = Dict.empty
     }
@@ -46,46 +44,7 @@ initConfig =
 
 decodeConfig : Decoder Config
 decodeConfig =
-    Decode.map4 Config
+    Decode.map3 Config
         (Decode.field "repositoryUrl" Decode.string)
-        (Decode.field "recipeDirs" decodeConfigRecipe)
         (Decode.field "apps" (Decode.dict Config.decodeApp))
         (Decode.field "pkgs" (Decode.dict Config.decodePkg))
-
-
-type alias ConfigRecipe =
-    { configRecipe_apps : Directory
-    , configRecipe_pkgs : Directory
-    }
-
-
-initRecipe : ConfigRecipe
-initRecipe =
-    { configRecipe_apps = ""
-    , configRecipe_pkgs = ""
-    }
-
-
-decodeConfigRecipe : Decoder ConfigRecipe
-decodeConfigRecipe =
-    Decode.map2 ConfigRecipe
-        (Decode.field "apps" decodeDirectory)
-        (Decode.field "pkgs" decodeDirectory)
-
-
-type alias Path =
-    String
-
-
-decodePath : Decoder Path
-decodePath =
-    Decode.string
-
-
-type alias Directory =
-    Path
-
-
-decodeDirectory : Decoder Directory
-decodeDirectory =
-    decodePath


### PR DESCRIPTION
recipeDirs option is not used anymore. We use recipePath instead.
