### PR TITLE
fix(ci): add scheduled update defaults

### DIFF
--- a/.github/workflows/weekly-package-update.yml
+++ b/.github/workflows/weekly-package-update.yml
@@ -38,22 +38,16 @@ jobs:
       - name: Update packages
         id: update
         run: |
-          if [[ "$PACKAGES" = "" ]]; then
-            UPDATE_ARGS="--all"
-          else
-            UPDATE_ARGS="$PACKAGES"
-          fi
-
           git checkout "$TARGET_BRANCH"
-          nix develop --command forge-update "$UPDATE_ARGS" --commit 2>&1 | tee /tmp/update-all.log
+          nix develop --command forge-update "$PACKAGES" --commit 2>&1 | tee /tmp/update-all.log
 
           # Save commit-list of updated packages
           git log --reverse origin/"$TARGET_BRANCH"..HEAD --format="%H %s" \
             | grep "recipes(" \
             > /tmp/commits.txt || true
         env:
-          PACKAGES: ${{ inputs.packages }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PACKAGES: ${{ inputs.packages || '--all' }}
+          TARGET_BRANCH: ${{ inputs.target_branch || 'master' }}
 
       - name: Create list of valid packages
         run: |
@@ -135,4 +129,4 @@ jobs:
           #   * Read access to metadata
           #   * Read and Write access to code and pull requests
           GH_TOKEN: ${{ secrets.FLAKE_UPDATE }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
+          TARGET_BRANCH: ${{ inputs.target_branch || 'master' }}


### PR DESCRIPTION
because the `workflow_dispatch` inputs don't exist if the workflow hasn't been triggered manually.

(see https://github.com/ngi-nix/forge/actions/runs/29184314098/job/86627564808)