### PR TITLE
recipes(rpki-client): 9.8 -> 9.8-unstable-2026-06-30

### DIFF
--- a/recipes/pkgs/rpki-client/recipe.nix
+++ b/recipes/pkgs/rpki-client/recipe.nix
@@ -5,15 +5,15 @@
 
 {
   pkgs.rpki-client = {
-    version = "9.8";
+    version = "9.8-unstable-2026-06-30";
     description = "Port of OpenBSD's rpki-client RPKI relying party validator to other operating systems.";
     homePage = "https://www.rpki-client.org";
     mainProgram = "rpki-client";
     license = "isc";
 
     source = {
-      git = "github:rpki-client/rpki-client-portable/15554f28842d7d9e6cc31eab5f95e36053b42f35";
-      hash = "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=";
+      git = "github:rpki-client/rpki-client-portable/3b63adbdf6646a97a9785e60b96c1fc3365023b8";
+      hash = "sha256-QZPnGrNiC/gaPh0JNsoa+E6AOB3rdfJRf2TrZePSv1w=";
     };
 
     build = {


### PR DESCRIPTION

  ## Package update

  Update `pkgs.rpki-client` to the latest version.

  *PR auto-generated by the [weekly package-update workflow](../actions/workflows/weekly-package-update.yml).*
  