### PR TITLE
recipes(rpki-client): use stable release in source

### DIFF
--- a/recipes/pkgs/rpki-client/recipe.nix
+++ b/recipes/pkgs/rpki-client/recipe.nix
@@ -12,7 +12,7 @@
     license = "isc";
 
     source = {
-      git = "github:rpki-client/rpki-client-portable/15554f28842d7d9e6cc31eab5f95e36053b42f35";
+      git = "github:rpki-client/rpki-client-portable/9.8";
       hash = "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=";
     };
 


### PR DESCRIPTION
else the update script will attempt to bump the version to unstable (see https://github.com/ngi-nix/forge/pull/723).

closes: https://github.com/ngi-nix/forge/pull/723