### PR TITLE
ci: keep building, even if a package fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
-        run: nix flake check --accept-flake-config --max-jobs 1 --option sandbox relaxed
+        run: nix flake check --keep-going --accept-flake-config --max-jobs 1 --option sandbox relaxed
 
   lint:
     name: Run format checks


### PR DESCRIPTION
This way, we'll possibly know all build failures in a single workflow run. Example:

- https://github.com/ngi-nix/forge/pull/733
  - https://github.com/ngi-nix/forge/actions/runs/29309809610/job/87010989736?pr=733