### PR TITLE
feat: add app prefix to container image

### DIFF
--- a/forge/modules/apps/services/runtimes/container/default.nix
+++ b/forge/modules/apps/services/runtimes/container/default.nix
@@ -194,7 +194,8 @@
       in
       {
         inherit tag;
-        copyToArchive = tar: "${image.copyTo}/bin/copy-to oci-archive:${tar}:${name}:${tag} >/dev/null";
+        copyToArchive =
+          tar: "${image.copyTo}/bin/copy-to oci-archive:${tar}:${app.name}-${name}:${tag} >/dev/null";
       }
     ) app.services.components;
 
@@ -264,7 +265,8 @@
         '';
         tag = forge-lib.nixStoreHash initScript;
         stream = pkgs.dockerTools.streamLayeredImage {
-          inherit name tag;
+          name = "${app.name}-${name}";
+          inherit tag;
           contents = [ initScript ];
           config = {
             Cmd = [ "/usr/sbin/init" ];
@@ -305,7 +307,7 @@
         );
 
         serviceComponents = lib.mapAttrs (name: service: {
-          image = "localhost/${name}:${config.result.images.${name}.tag}";
+          image = "localhost/${app.name}-${name}:${config.result.images.${name}.tag}";
           ports = service.process.ports;
           depends_on = lib.genAttrs (service.dependsOn ++ backendResourceNames) (_name: {
             condition = "service_started";
@@ -319,7 +321,7 @@
         }) app.services.components;
 
         resourcesComponents = lib.mapAttrs (name: resource: {
-          image = "localhost/${name}:${config.result.images.${name}.tag}";
+          image = "localhost/${app.name}-${name}:${config.result.images.${name}.tag}";
           ports = resource.ports;
           depends_on = lib.optionalAttrs (lib.hasAttr name frontendResourceDeps) (
             lib.genAttrs frontendResourceDeps.${name} (_: {
@@ -351,7 +353,7 @@
 
         cacheDir = "\${XDG_CACHE_HOME:-$HOME/.cache}/ngi-forge/${lib.hashString "md5" specialArgs.forgeConfig.forge.repositoryUrl}";
 
-        imageTar = name: tag: "$CACHE_DIR/${name}-${tag}.tar";
+        imageTar = name: tag: "$CACHE_DIR/${app.name}-${name}-${tag}.tar";
 
         build-oci-images = pkgs.writeShellScriptBin "build-oci-images" (
           ''
@@ -380,7 +382,7 @@
 
           ${lib.concatMapAttrsStringSep "\n" (name: image: ''
             podman load --quiet < "${imageTar name image.tag}"
-            podman tag ${name}:${image.tag} ${name}:latest
+            podman tag ${app.name}-${name}:${image.tag} ${app.name}-${name}:latest
           '') config.result.images}
 
           ${lib.getExe pkgs.podman-compose} \


### PR DESCRIPTION
Closes #706

With this PR,

files in the image cache:

```
ls -l ~/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/multi-component-*.tar

-rw-r--r-- 1 imincik users  71103488 Jul 15 16:01 /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/multi-component-api-q2276gshk5yc864771vx6hb9hqqgi9cj.tar
-rw-r--r-- 1 imincik users 538050560 Jul 15 16:01 /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/multi-component-database-k1i8b8l3f5mjsahcl08mn682qf9iq5xw.tar
-rw-r--r-- 1 imincik users 482723840 Jul 15 16:01 /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/multi-component-reverse-proxy-6cyv3xfc92g46s5dc4gh5v49lhrbp0sn.tar
-rw-r--r-- 1 imincik users  66190848 Jul 15 16:01 /home/imincik/.cache/ngi-forge/e70cdb819e14cb7e87c9ad6e517737ca/multi-component-web-gz8jvjs6dg04sczj5axqq23bc9cjarsk.tar
```

Images loaded to podman:

```
podman images | grep multi-component

localhost/multi-component-web            latest                            765d44664f50  30 hours ago    172 MB
localhost/multi-component-web            gz8jvjs6dg04sczj5axqq23bc9cjarsk  765d44664f50  30 hours ago    172 MB
localhost/multi-component-api            q2276gshk5yc864771vx6hb9hqqgi9cj  6d87fcaca722  30 hours ago    191 MB
localhost/multi-component-api            latest                            6d87fcaca722  30 hours ago    191 MB
localhost/multi-component-database       latest                            fc40c26db217  56 years ago    538 MB
localhost/multi-component-database       k1i8b8l3f5mjsahcl08mn682qf9iq5xw  fc40c26db217  56 years ago    538 MB
localhost/multi-component-reverse-proxy  latest                            d1225943331f  56 years ago    483 MB
localhost/multi-component-reverse-proxy  6cyv3xfc92g46s5dc4gh5v49lhrbp0sn  d1225943331f  56 years ago    483 MB
```