### PR TITLE
ci: check nixpkgs hydra for ngi packages build status

### DIFF
--- a/.github/workflows/hydra-build-status.yml
+++ b/.github/workflows/hydra-build-status.yml
@@ -1,0 +1,40 @@
+name: Hydra build status
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+env:
+  NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+
+jobs:
+  check-hydra-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86_64-linux
+          - aarch64-linux
+
+    name: Check build status
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@19effe9fe722874e6d46dd7182e4b8b7a43c4a99 # v31.10.0
+
+      - name: Generate packages file
+        run: >
+          nix eval --json --file maintainers/list-nixpkgs.nix packages --arg showBroken false
+          > packages.json
+
+      - name: Check build status
+        run: >
+          nix run github:imincik/nix-utils#hydra-build-status -- --failed-only --platforms ${{ matrix.platform }} --file packages.json
+          > "$GITHUB_STEP_SUMMARY"

--- a/maintainers/list-nixpkgs.nix
+++ b/maintainers/list-nixpkgs.nix
@@ -1,0 +1,79 @@
+# List nixpkgs packages maintained by a team.
+#
+# USAGE:
+# nix eval --json -f maintainers/list-nixpkgs.nix packages
+
+{
+  pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/master.tar.gz") {
+    config.allowBroken = true;
+    config.allowUnfree = true;
+  },
+
+  team ? "ngi",
+
+  showBroken ? true, # show broken packages
+}:
+
+let
+  inherit (pkgs.lib)
+    attrNames
+    concatMap
+    isAttrs
+    isDerivation
+    ;
+
+  myTeam = pkgs.lib.teams.${team};
+
+  isMaintainedByTeam =
+    pkg:
+    let
+      result = builtins.tryEval (builtins.elem myTeam (pkg.meta.teams or [ ]));
+    in
+    if result.success then result.value else false;
+
+  isDerivationRobust =
+    pkg:
+    let
+      result = builtins.tryEval (isDerivation pkg);
+    in
+    if result.success then result.value else false;
+
+  brokenFilter =
+    pkg:
+    let
+      isBroken = pkg.meta.broken or false;
+    in
+    if showBroken then
+      true
+    else if isBroken == false then
+      true
+    else
+      false;
+
+  isPkgSet =
+    pkg:
+    let
+      result = builtins.tryEval ((isAttrs pkg) && (pkg.recurseForDerivations or false));
+    in
+    if result.success then result.value else false;
+
+  recursePackageSet =
+    pkgSetName: pkgs:
+    concatMap (
+      name:
+      let
+        pkg = pkgs.${name};
+        fullName = if pkgSetName != null then pkgSetName + "." + name else name;
+      in
+      if isDerivationRobust pkg then
+        if isMaintainedByTeam pkg && brokenFilter pkg then [ fullName ] else [ ]
+      else if isPkgSet pkg then
+        recursePackageSet fullName pkg
+      else
+        [ ]
+    ) (attrNames pkgs);
+
+in
+{
+  packages = recursePackageSet null pkgs;
+}


### PR DESCRIPTION
Regularly check build status of NGI maintained packages. See [geospatial packages](https://github.com/imincik/nix-utils/actions/runs/29477940537) doing the same. 

This will allow us to respond faster and get more [insights](https://hydra.nixos.org/job/nixpkgs/unstable/arpa2-leaf.x86_64-linux/all) when something breaks in nixpkgs (like it happen during the previous week). 


## Test manually

```
nix eval --json --file maintainers/list-nixpkgs.nix packages --arg showBroken false > packages.json
nix run github:imincik/nix-utils#hydra-build-status -- --platforms x86_64-linux --file packages.json
```

```
### PLATFORM: x86_64-linux

| PACKAGE                                            | STATUS               | URL                                                                              |
| --------------------                               | -------------------- | --------------------                                                             |
| aerogramme                                         | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/aerogramme.x86_64-linux/all            |
| agorakit                                           | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/agorakit.x86_64-linux/all              |
| alive2                                             | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/alive2.x86_64-linux/all                |
| alps                                               | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/alps.x86_64-linux/all                  |
| arcan                                              | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/arcan.x86_64-linux/all                 |
| arpa2-leaf                                         | Dependency failed    | https://hydra.nixos.org/job/nixpkgs/trunk/arpa2-leaf.x86_64-linux/all            |
| arpa2cm                                            | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/arpa2cm.x86_64-linux/all               |
| arwen                                              | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/arwen.x86_64-linux/all                 |
| beam27Packages.livebook                            | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/beam27Packages.livebook.x86_64-linux/all |
| beam28Packages.livebook                            | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/beam28Packages.livebook.x86_64-linux/all |
| beam29Packages.livebook                            | Succeeded            | https://hydra.nixos.org/job/nixpkgs/trunk/beam29Packages.livebook.x86_64-linux/all |

...
```