### PR TITLE
+dev@clarity(forge): move `scrubConfig` to `lib.scrubNixContext`

### DIFF
--- a/forge/modules/lib.nix
+++ b/forge/modules/lib.nix
@@ -3,9 +3,9 @@
   ...
 }:
 {
-  flake.lib = {
+  flake.lib = rec {
     # Helper to support namespacing with dot (`.`) in `flake.packages`
-    # (eg.`nix build .#pkgs.${packageName}`).
+    # (eg. `nix build .#pkgs.${packageName}`).
     # This relies on the Nix completion not quoting attrset keys containing
     # a dot.
     flakePackagesWithNamespace =
@@ -43,5 +43,21 @@
     # Get the Nix store hash of a derivation's output path
     # (eg. `/nix/store/<hash>-name` -> `<hash>`).
     nixStoreHash = drv: lib.unsafeDiscardStringContext (lib.substring 0 32 (baseNameOf drv.outPath));
+
+    # Recursively remove Nix context used to track dependencies.
+    # Useful to avoid building the derivations contained in a `config`
+    # when serializing it (eg. with `builtins.toJSON`).
+    scrubNixContext =
+      x:
+      if lib.isString x || lib.isDerivation x then
+        lib.unsafeDiscardStringContext x
+      else if lib.isFunction x then
+        null
+      else if lib.isList x then
+        map scrubNixContext x
+      else if lib.isAttrs x then
+        lib.mapAttrs (n: v: if n == "__toString" then v else scrubNixContext v) x
+      else
+        x;
   };
 }

--- a/forge/modules/lib.nix
+++ b/forge/modules/lib.nix
@@ -1,9 +1,10 @@
 {
   lib,
+  config,
   ...
 }:
 {
-  flake.lib = rec {
+  flake.lib = {
     # Helper to support namespacing with dot (`.`) in `flake.packages`
     # (eg. `nix build .#pkgs.${packageName}`).
     # This relies on the Nix completion not quoting attrset keys containing
@@ -54,9 +55,9 @@
       else if lib.isFunction x then
         null
       else if lib.isList x then
-        map scrubNixContext x
+        map config.flake.lib.scrubNixContext x
       else if lib.isAttrs x then
-        lib.mapAttrs (n: v: if n == "__toString" then v else scrubNixContext v) x
+        lib.mapAttrs (n: v: if n == "__toString" then v else config.flake.lib.scrubNixContext v) x
       else
         x;
   };

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -49,20 +49,7 @@ let
   _forge = {
     config = pkgs.writeTextFile {
       name = "forge-config.json";
-      text =
-        let
-          scrubConfig =
-            x:
-            if lib.isString x || lib.isDerivation x then
-              lib.unsafeDiscardStringContext x
-            else if lib.isList x then
-              map scrubConfig x
-            else if lib.isAttrs x then
-              lib.mapAttrs (n: v: scrubConfig v) x
-            else
-              x;
-        in
-        builtins.toJSON (scrubConfig config.forge);
+      text = builtins.toJSON (forge-lib.scrubNixContext config.forge);
     };
 
     options = pkgs.runCommand "options.json" { } ''

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -49,7 +49,7 @@ let
   _forge = {
     config = pkgs.writeTextFile {
       name = "forge-config.json";
-      text = builtins.toJSON (forge-lib.scrubNixContext config.forge);
+      text = lib.toJSON (forge-lib.scrubNixContext config.forge);
     };
 
     options = pkgs.runCommand "options.json" { } ''


### PR DESCRIPTION
Cherry-picked from: https://github.com/ngi-nix/forge/pull/694
With fix to not use `rec` in `forge/modules/lib.nix`.