### PR TITLE
flake: update to the latest nixos-unstable version + modular services fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,16 +152,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
-        "owner": "NixOS",
+        "lastModified": 1784553897,
+        "narHash": "sha256-szGR07E/UiAxen8/dXg/HuStmkx3gkTIQK4FEYlXJLs=",
+        "owner": "imincik",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "ed97170327d872d25e348a4ada885bf7983493f3",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "owner": "imincik",
+        "ref": "nixos-unstable+pr-540857",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,12 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Rervert nixpkgs URL back to the official repo once
+    # https://github.com/NixOS/nixpkgs/pull/540857
+    # is merged and is present in nixos-unstable branch.
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:imincik/nixpkgs/nixos-unstable+pr-540857";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
     import-tree.url = "github:vic/import-tree";
 

--- a/recipes/apps/pijul/recipe.nix
+++ b/recipes/apps/pijul/recipe.nix
@@ -61,7 +61,7 @@
     programs = {
       packages = [
         pkgs.pijul
-        pkgs.expect
+        pkgs.openssh
       ];
 
       runtimes.shell = {
@@ -83,24 +83,11 @@
 
       pijul add src --recursive
 
-      cat << 'EOF' > pijul_expect.exp
-      spawn pijul rec -m "initial commit"
-      expect "Unique identity name"
-      send "\r"
-      expect "Display name"
-      send "Test User\r"
-      expect "Email"
-      send "test@example.com\r"
-      expect "change the encryption"
-      send "n\r"
-      expect "key to expire"
-      send "n\r"
-      expect "link this identity to a remote"
-      send "n\r"
-      expect eof
-      EOF
-
-      expect pijul_expect.exp
+      ssh-keygen -t ed25519 -f id_ed25519 -N ""
+      eval $(ssh-agent -s)
+      ssh-add id_ed25519
+      pijul identity new tester --no-link --display-name "Test User" --email "test@example.com"
+      pijul rec -m "initial commit"
 
       pijul log | grep -q initial
     '';

--- a/recipes/pkgs/bang/recipe.nix
+++ b/recipes/pkgs/bang/recipe.nix
@@ -83,6 +83,17 @@ in
         # pytest is incorrectly listed in install_requires upstream
         substituteInPlace setup.cfg \
           --replace-fail $'\tpytest\n' ""
+
+        # Python 3.14 switched the default multiprocessing start method on
+        # Linux from "fork" to "forkserver". Under "forkserver", arguments
+        # passed to Process() must be picklable, but bang's scan pipeline
+        # (built from nested closures like pipe_or/pipe_seq in scan_job.py)
+        # is not. Force "fork" explicitly to keep the existing behavior.
+        # https://github.com/armijnhemel/binaryanalysis-ng/issues/388
+        substituteInPlace src/bang/cli.py \
+          --replace-fail \
+          "multiprocessing.Process(target = process_jobs, args = (scan_pipeline, scan_environment,))" \
+          "multiprocessing.get_context('fork').Process(target = process_jobs, args = (scan_pipeline, scan_environment,))"
       '';
 
       preBuild = ''


### PR DESCRIPTION
PR is using temporary [nixpkgs-unstable fork](https://github.com/imincik/nixpkgs/tree/nixos-unstable%2Bpr-540857 ) containing [fix](https://github.com/NixOS/nixpkgs/pull/540857) for non-compatible change in modular services. 


- **flake: update to the latest nixos-unstable version + modular services fix**
- **pijul: fix tests for 1.0.0-beta.18**
- **recipes(bang): fix support for python 3.14**
