### PR TITLE
+packager@compatibility(forge): init `identityBuilder` to provide an external derivation

### DIFF
--- a/forge/modules/builders/identity-builder/default.nix
+++ b/forge/modules/builders/identity-builder/default.nix
@@ -1,0 +1,38 @@
+{
+  packageBuilderModule,
+  ...
+}:
+{
+  imports = [
+    (packageBuilderModule {
+      name = "identityBuilder";
+      imports = ./options.nix;
+      mkDerivation = mk: (mk { }).derivation;
+      attrs = builder: finalAttrs: previousAttrs: {
+        derivation = builder.derivation;
+      };
+    })
+    (
+      {
+        config,
+        lib,
+        ...
+      }:
+      {
+        config =
+          let
+            builder = config.build.identityBuilder;
+            drv = builder.derivation;
+          in
+          lib.mkIf builder.enable {
+            homePage = drv.meta.homepage;
+            description = lib.removeSuffix "." drv.meta.description + ".";
+            inherit (drv) version;
+            inherit (drv.meta)
+              license
+              ;
+          };
+      }
+    )
+  ];
+}

--- a/forge/modules/builders/identity-builder/options.nix
+++ b/forge/modules/builders/identity-builder/options.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options = {
+    enable = lib.mkEnableOption ''
+      Identity builder to provide a derivation directly
+      (eg. from Nixpkgs using `pkgs.pkgsOriginal`).
+    '';
+    derivation = lib.mkOption {
+      type = lib.types.package;
+      description = "Resulting package derivation.";
+    };
+  };
+  config = {
+    # `flake-parts-lib.mkPerSystemOption` does not provide `specialArgs.system`
+    # inside `options`, hence use `pkgs` in `config` to set a `default`.
+    # Setting a `default` is required for `_forge.config`.
+    derivation = lib.mkOptionDefault pkgs.emptyDirectory;
+  };
+}

--- a/forge/modules/pkgs.nix
+++ b/forge/modules/pkgs.nix
@@ -67,7 +67,7 @@
       warnings = lib.flatten (
         map (pkg: [
           {
-            condition = pkg.source.hash == "" && pkg.source.path == null;
+            condition = pkg.source.hash == "" && pkg.source.path == null && !pkg.build.identityBuilder.enable;
             message = ''
               Package '${pkg.pname}': source.hash is empty.
               Correct hash will be printed in the error message when package is built.
@@ -97,7 +97,13 @@
           in
           [
             {
-              condition = !(pkg.source.git == null && pkg.source.url == null && pkg.source.path == null);
+              condition =
+                !(
+                  pkg.source.git == null
+                  && pkg.source.url == null
+                  && pkg.source.path == null
+                  && !pkg.build.identityBuilder.enable
+                );
               message = ''
                 Package '${pkg.pname}': one of sources options must be defined.
                 Available options: source.git, source.url, or source.path.

--- a/forge/modules/pkgs/pkg.nix
+++ b/forge/modules/pkgs/pkg.nix
@@ -6,6 +6,7 @@
 }:
 {
   imports = [
+    ../builders/identity-builder
     ../builders/standard-builder
     ../builders/go-builder
     ../builders/npm-package-builder

--- a/recipes/apps/arwen/recipe.nix
+++ b/recipes/apps/arwen/recipe.nix
@@ -2,8 +2,13 @@
   pkgs,
   ...
 }:
-
 {
+  pkgs.arwen = {
+    build.identityBuilder = {
+      enable = true;
+      derivation = pkgs.pkgsOriginal.arwen;
+    };
+  };
   apps.arwen = {
     displayName = "Arwen";
     description = "Cross-platform patching of shared libraries (ELF and Mach-O).";

--- a/templates/consumer/flake.nix
+++ b/templates/consumer/flake.nix
@@ -23,6 +23,9 @@
       perSystem =
         { system, pkgs, ... }:
         {
+          # nix fmt
+          formatter = pkgs.nixfmt-tree;
+
           forge = {
             # NOTE: update the repository url to your forge. e.g. "github:username/forge-repo"
             repositoryUrl = "github:ngi-nix/forge";


### PR DESCRIPTION
Closes https://github.com/ngi-nix/forge/issues/772