### PR TITLE
recipes(pkgs.vivliostyle): init from nixpkgs derivation 

### DIFF
--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -13,6 +13,7 @@
         attrs,
       }:
       {
+        forgeConfig,
         config,
         pkgs,
         lib,
@@ -84,6 +85,8 @@
               mkSharedAttrs =
                 finalAttrs:
                 {
+                  _origin = forgeConfig.forge.repositoryUrl;
+
                   inherit (config)
                     pname
                     version

--- a/forge/modules/forge.nix
+++ b/forge/modules/forge.nix
@@ -19,19 +19,26 @@
         inputs = self-inputs;
         inherit forge-inputs;
         inherit forge-lib;
-        pkgs = pkgs.extend (
-          finalPkgs: previousPkgs:
-          # Extend `pkgs` with the packages from the forge.
-          lib.mapAttrs (packageName: package: package.result.derivation) config.forge.pkgs
-          // {
-            # `pkgs.pkgsOriginal` provides packages from the original `pkgs` (usually from Nixpkgs)
-            # Eg. `pkgs.pkgsOriginal.offen` (Nixpkgs) and `pkgs.offen` (ngi-forge).
-            # Note that as a consequence, all dependencies of those packages
-            # remain those coming from the original `pkgs`,
-            # even when they happen to also be packaged in the forge.
-            pkgsOriginal = previousPkgs;
-          }
-        );
+        nixpkgs = pkgs;
+        pkgs =
+          let
+            pkgFromNixpkgs = pkg: !pkg ? _origin;
+          in
+          pkgs.extend (
+            finalPkgs: previousPkgs:
+            # Extend `pkgs` with the packages from the forge.
+            lib.mapAttrs (
+              packageName: package: if pkgFromNixpkgs package then package else package.result.derivation
+            ) config.forge.pkgs
+            // {
+              # `pkgs.pkgsOriginal` provides packages from the original `pkgs` (usually from Nixpkgs)
+              # Eg. `pkgs.pkgsOriginal.offen` (Nixpkgs) and `pkgs.offen` (ngi-forge).
+              # Note that as a consequence, all dependencies of those packages
+              # remain those coming from the original `pkgs`,
+              # even when they happen to also be packaged in the forge.
+              pkgsOriginal = previousPkgs;
+            }
+          );
         lib = lib // {
           maintainers =
             (import "${forge-inputs.nixpkgs}/maintainers/maintainer-list.nix")

--- a/forge/modules/pkgs.nix
+++ b/forge/modules/pkgs.nix
@@ -26,17 +26,21 @@
                 Each package uses one of the available builders.
                 Only one builder can be enabled per package by setting build.<builder>.enable = true.
               '';
-              type = lib.types.attrsOf (
-                lib.types.submoduleWith {
-                  specialArgs = specialArgs // {
-                    forgeOptions = forgeArgs.options;
-                    inherit packageBuilderModule;
+              type =
+                let
+                  pkgRecipe = lib.types.submoduleWith {
+                    specialArgs = specialArgs // {
+                      forgeOptions = forgeArgs.options;
+                      inherit packageBuilderModule;
+                    };
+                    modules = [
+                      pkgs/pkg.nix
+                    ];
                   };
-                  modules = [
-                    pkgs/pkg.nix
-                  ];
-                }
-              );
+
+                  nixpkgsDrv = lib.types.package;
+                in
+                lib.types.attrsOf (lib.types.either nixpkgsDrv pkgRecipe);
             };
           }
         )
@@ -55,9 +59,16 @@
       failedAssertions = lib.filter (x: !x.condition) config.assertions;
       assertionMessages = lib.concatMapStringsSep "\n" (x: "- ${x.message}") failedAssertions;
 
+      pkgFromNixpkgs = pkg: !pkg ? _origin;
+
+      # don't check warnings if package are coming from Nixpkgs
+      forgePkgs = lib.filter (v: !(pkgFromNixpkgs v)) (lib.attrValues config.forge.pkgs);
+
       packagesWithNamespace = pkgs.callPackage (forge-lib.flakePackagesWithNamespace {
         namespace = "pkgs";
-        derivations = lib.mapAttrs (packageName: package: package.result.derivation) config.forge.pkgs;
+        derivations = lib.mapAttrs (
+          packageName: package: if pkgFromNixpkgs package then package else package.result.derivation
+        ) config.forge.pkgs;
       }) { };
     in
     {
@@ -79,7 +90,7 @@
               Package '${pkg.pname}': license is empty.
             '';
           }
-        ]) (lib.attrValues config.forge.pkgs)
+        ]) forgePkgs
       );
 
       # Collect assertions from forge.pkgs
@@ -118,7 +129,7 @@
               '';
             }
           ]
-        ) (lib.attrValues config.forge.pkgs)
+        ) forgePkgs
       );
 
       # Evaluation check: show warnings first, then throw on failed assertions

--- a/forge/modules/pkgs/pkg.nix
+++ b/forge/modules/pkgs/pkg.nix
@@ -2,6 +2,7 @@
   lib,
   name,
   specialArgs,
+  forgeConfig,
   ...
 }:
 {
@@ -298,6 +299,13 @@
         internal = true;
         description = "Resulting derivation of the package.";
       };
+    };
+
+    _origin = lib.mkOption {
+      type = lib.types.str;
+      internal = true;
+      default = forgeConfig.forge.repositoryUrl;
+      description = "Origin of forge packages.";
     };
   };
 }

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -46,10 +46,17 @@ let
     )}
   '';
 
+  pkgFromNixpkgs = pkg: !pkg ? _origin;
+
+  forgeConfig = config.forge // {
+    # TODO: show nixpkgs packages in the UI
+    pkgs = lib.filterAttrs (_: pkg: !(pkgFromNixpkgs pkg)) config.forge.pkgs;
+  };
+
   _forge = {
     config = pkgs.writeTextFile {
       name = "forge-config.json";
-      text = lib.toJSON (forge-lib.scrubNixContext config.forge);
+      text = lib.toJSON (forge-lib.scrubNixContext forgeConfig);
     };
 
     options = pkgs.runCommand "options.json" { } ''

--- a/recipes/apps/arwen/recipe.nix
+++ b/recipes/apps/arwen/recipe.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  nixpkgs,
   ...
 }:
 
@@ -81,4 +82,6 @@
       };
     };
   };
+
+  pkgs.arwen = nixpkgs.arwen;
 }

--- a/recipes/pkgs/vivliostyle/0001-allow-specifying-browser-path-via-env-var.patch
+++ b/recipes/pkgs/vivliostyle/0001-allow-specifying-browser-path-via-env-var.patch
@@ -1,0 +1,20 @@
+---
+ src/browser.ts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/browser.ts b/src/browser.ts
+index 8e653e2..ae57d2f 100644
+--- a/src/browser.ts
++++ b/src/browser.ts
+@@ -355,6 +355,8 @@ export async function getExecutableBrowserPath({
+   type,
+   tag,
+ }: ResolvedTaskConfig['browser']): Promise<string> {
++  const envPath = process.env.VIVLIOSTYLE_BROWSER_PATH;
++  if (envPath && fs.existsSync(envPath)) return envPath;
+   const browsers = await importNodeModule('@puppeteer/browsers');
+   const buildId = await resolveBuildId({ type, tag, browsers });
+   return browsers.computeExecutablePath({
+-- 
+2.54.0
+

--- a/recipes/pkgs/vivliostyle/_nixpkgs.nix
+++ b/recipes/pkgs/vivliostyle/_nixpkgs.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nix-update-script,
+
+  # build-time
+  makeBinaryWrapper,
+  nodejs,
+  pnpmBuildHook,
+  pnpmConfigHook,
+  pnpm_10,
+
+  chromium,
+  defaultBrowser ? chromium,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vivliostyle";
+  version = "11.1.0";
+
+  src = fetchFromGitHub {
+    owner = "vivliostyle";
+    repo = "vivliostyle-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rbb/av3amlLit7OjTc+S/pf1SrxEnsENQOArgnc7k3s=";
+  };
+
+  patches = [
+    ./0001-allow-specifying-browser-path-via-env-var.patch
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-WPTCLAEWmD1TY84281TJCzp+mcjMFM5Xwf02s7U+M4U=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    pnpm
+    pnpmBuildHook
+    pnpmConfigHook
+  ];
+
+  pnpmBuildFlags = [
+    "--mode"
+    "production"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    mv {node_modules,dist,examples,packages,package.json} $out/lib
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    chmod +x $out/lib/dist/cli.js
+    patchShebangs $out/usr/lib/dist/cli.js
+
+    makeWrapper $out/lib/dist/cli.js $out/bin/vivliostyle \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --set VIVLIOSTYLE_BROWSER_PATH ${lib.getExe defaultBrowser}
+
+    ln -s $out/bin/vivliostyle $out/bin/vs
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "CLI tool for typesetting HTML and Markdown documents";
+    longDescription = ''
+      Vivliostyle is a CSS typesetting ecosystem for creating beautifully
+      formatted documents using web technologies.
+    '';
+    homepage = "https://github.com/vivliostyle/vivliostyle-cli";
+    changelog = "https://github.com/vivliostyle/vivliostyle-cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    mainProgram = "vivliostyle";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/recipes/pkgs/vivliostyle/recipe.nix
+++ b/recipes/pkgs/vivliostyle/recipe.nix
@@ -1,0 +1,9 @@
+{
+  nixpkgs,
+  ...
+}:
+{
+  # TODO: replace with Nixpkgs derivation when this PR propagates to the forge:
+  # https://github.com/NixOS/nixpkgs/pull/544599
+  pkgs.vivliostyle = nixpkgs.callPackage ./_nixpkgs.nix { };
+}


### PR DESCRIPTION
Uses https://github.com/ngi-nix/forge/pull/773, but could also work with https://github.com/ngi-nix/forge/pull/774.

The idea here is to add packages that have been merged in Nixpkgs but are yet to reach the forge by calling their exact derivation, which is cheaper than converting it to a forge recipe.

Note that we could automate the cleanup of such recipes once the derivations do propagate back.