### PR TITLE
feat: add broken option to packages; skip broken in CI

### DIFF
--- a/forge/modules/apps/app.nix
+++ b/forge/modules/apps/app.nix
@@ -141,5 +141,11 @@
         default = self: "nixos-vm-config";
       };
     };
+
+    broken = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether the app is broken.";
+    };
   };
 }

--- a/forge/modules/apps/default.nix
+++ b/forge/modules/apps/default.nix
@@ -77,6 +77,7 @@
         in
         lib.fix (self: {
           config = app;
+          forge.broken = app.broken;
         })
         // lib.optionalAttrs app.programs.runtimes.program.enable {
           program = app.programs.mainPackage;

--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -118,6 +118,10 @@
                       packages = config.develop.packages;
                       shellHook = config.develop.shellHook;
                     };
+
+                    forge = {
+                      broken = config.broken;
+                    };
                   };
 
                   meta = {

--- a/forge/modules/pkgs/pkg.nix
+++ b/forge/modules/pkgs/pkg.nix
@@ -85,6 +85,11 @@
       '';
       example = lib.literalExpression "with lib.maintainers; [ ngi-nix ]";
     };
+    broken = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether the package is broken.";
+    };
 
     # Source configuration
     source = {

--- a/forge/packages.nix
+++ b/forge/packages.nix
@@ -46,10 +46,15 @@ let
     )}
   '';
 
+  forgeConfig = config.forge // {
+    pkgs = lib.filterAttrs (_: pkg: !pkg.broken) config.forge.pkgs;
+    apps = lib.filterAttrs (_: app: !app.broken) config.forge.apps;
+  };
+
   _forge = {
     config = pkgs.writeTextFile {
       name = "forge-config.json";
-      text = lib.toJSON (forge-lib.scrubNixContext config.forge);
+      text = lib.toJSON (forge-lib.scrubNixContext forgeConfig);
     };
 
     options = pkgs.runCommand "options.json" { } ''


### PR DESCRIPTION
Closes: https://github.com/ngi-nix/forge/issues/784

**Note:** I'm introducing our own broken attr path (`passthru.forge.broken`), which Nixpkgs tooling won't process. This is because setting `meta.broken` makes evaluations fail and because we're using the module system, this makes it all the time.