### PR TITLE
fix(ci): don't allow non-derivations in checks

### DIFF
--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -12,6 +12,14 @@
     }:
 
     let
+      # Some derivations aren't acutally real (e.g. the toplevel "apps" and "pkgs"),
+      # which we don't want to include in the checks.
+      isRealDrv = v: lib.isDerivation v && v ? drvPath;
+
+      nonBrokenPackages = lib.filterAttrs (
+        n: v: (isRealDrv v && !(v.passthru.forge.broken or false))
+      ) config.packages;
+
       # Helper function to extract passthru attribute, ensuring it is a valid derivation
       passthruAttr =
         attr:
@@ -22,13 +30,13 @@
               lib.nameValuePair "${name}-${attr}" package.${attr}
             else
               lib.nameValuePair name null
-          ) config.packages
+          ) nonBrokenPackages
         );
     in
 
     {
       checks =
-        config.packages
+        nonBrokenPackages
 
         # All packages passthru attributes
         // (passthruAttr "env")


### PR DESCRIPTION
else they'll pollute the check list.

For example, let's imagine that `pkgs.bang` is broken and is filtered out from checks. Currently, the toplevel `pkgs` is allowed in checks (being a fake derivation) and since it includes all packages, it introduces its own `pkgs.bang`, which isn't what we want.

**Note**: this was implemented as part of https://github.com/ngi-nix/forge/pull/781, thus the attribute being called `nonBrokenPackages`, but it's fine since we have defaults for it.

Closes: https://github.com/ngi-nix/forge/issues/777