### PR TITLE
flake: update all inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769795883,
-        "narHash": "sha256-JfLxMbns2wzu681/HwVcMqijP6dvdGkc6Efqq/UBQoA=",
+        "lastModified": 1782731936,
+        "narHash": "sha256-fv+DN/pN5V6jeMIOuxjM9/jvbE7MLZPHUIMiIH903x0=",
         "owner": "dwayne",
         "repo": "elm2nix",
-        "rev": "e84ab8872f1660f5576df19adeb9e1a682402bb4",
+        "rev": "c31bb4c3c6ad2a6b6b328c2975126cfb6140c052",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1773693634,
-        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "lastModified": 1784254960,
+        "narHash": "sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "rev": "4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     "nix-utils": {
       "flake": false,
       "locked": {
-        "lastModified": 1759611167,
-        "narHash": "sha256-opywuWZGKtRDb5uLQlxQvG8iuihHt8gM3lLkePCmwlY=",
+        "lastModified": 1784817241,
+        "narHash": "sha256-x5ATngDfJ+mUiV7Cu0m+AEINiz8BBPXkIzptKvXS78M=",
         "owner": "imincik",
         "repo": "nix-utils",
-        "rev": "f0e102cc767951364949cbb9965d2d7120ea4fa7",
+        "rev": "9e5e8eca66cedc055332c954992160bd87b02767",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782892141,
-        "narHash": "sha256-hjLR3sKILmg4ragMOiVBAK4XVOTGy9TvkU0Hryob+68=",
+        "lastModified": 1785081136,
+        "narHash": "sha256-+Ntkg+CR1XjPnSznADCknYwj/4HDI+2hexHx/EZcQ1A=",
         "owner": "ngi-nix",
         "repo": "nimi",
-        "rev": "52e275234fe472cebc81fa266aad3018e4369094",
+        "rev": "4973113dc4092824ac5a1c6d08c2714a44ea6201",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
NOTE: no bump of nixpkgs.

`nix flake update --commit-lock-file --refresh`

Includes https://github.com/ngi-nix/nimi/pull/9
