### PR TITLE
docs: add more info about Nixpkgs maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,12 @@ We package and maintain some NGI software in
 [Nixpkgs](https://github.com/NixOS/nixpkgs) and re-use it in the Forge
 application recipes.
 
-- Get a list of packages maintained in Nixpkgs
+Get a list of packages maintained in Nixpkgs
 
 ```bash
 nix eval --json -f maintainers/list-nixpkgs.nix packages
 ```
-
-- [![Nixpkgs build status](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml/badge.svg)](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml)
+[![Nixpkgs build status](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml/badge.svg)](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Nixpkgs build status](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml/badge.svg)](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml)
-
 # NGI Forge
 
 This software is in active development. Expect backwards incompatible changes.
@@ -67,6 +65,20 @@ nix flake init --template github:ngi-nix/forge#provider
 - Add all new files to git
 
 - Start creating recipes in `recipes` directory
+
+## Nixpkgs repository
+
+We package and maintain some NGI software in
+[Nixpkgs](https://github.com/NixOS/nixpkgs) and re-use it in the Forge
+application recipes.
+
+- Get a list of packages maintained in Nixpkgs
+
+```bash
+nix eval --json -f maintainers/list-nixpkgs.nix packages
+```
+
+- [![Nixpkgs build status](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml/badge.svg)](https://github.com/ngi-nix/forge/actions/workflows/nixpkgs-build-status.yml)
 
 ## Credits
 


### PR DESCRIPTION
Add some more context to the `Nixpkgs build status` badge and move it lower in the `README` file to avoid impression that we have constantly broken something.