### PR TITLE
fix: support operating from Git linked worktrees

### DIFF
--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -133,7 +133,12 @@ def main():
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        _ = shutil.copytree(git_root, temp_dir, dirs_exist_ok=True)
+        _ = shutil.copytree(
+            git_root,
+            temp_dir,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(".git"),
+        )
 
         mock_recipes_root = temp_path / "recipes"
         if mock_recipes_root.exists():


### PR DESCRIPTION
Under _linked worktrees_, the top level `.git` is not a directory, but a file containing the absolute path to the _main worktree_.

The rest of the script assumes that the copied tree can be acted upon with little consequence, but that’s not the case if the `.git` pointer file is copied over, since then the disruptive commands will affect the _main worktree_ instead.

Fixed by not copying any `.git` entries to the temporary directory, which is fine, since a `git init` is performed on the tree anyway.

See https://docs.python.org/3/library/shutil.html#shutil.ignore_patterns

Fixes: #821