### PR TITLE
docs: fix license listing expression

### DIFF
--- a/docs/manuals/contributor/how_to/package_recipe.md
+++ b/docs/manuals/contributor/how_to/package_recipe.md
@@ -93,7 +93,7 @@ Start the package recipe with the following content:
 Use the following command to get the list of all available licenses:
 
 ```bash
-nix eval nixpkgs#lib.licenses --json | jq
+nix repl nixpkgs <<<':p lib.licenses'
 ```
 
 :::


### PR DESCRIPTION
Current `nixpkgs#lib.licenses` contains functions (`AND`, `OR`, `PLUS`, `WITH`) that prevent it to be serialized to JSON.

Provide an alternative way to obtain the list.

Fixes: #832 