### PR TITLE
fix build errors when `build.debug` is enabled

### DIFF
--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -134,7 +134,7 @@
                   };
                 }
                 // lib.optionalAttrs config.build.debug {
-                  shellHook = "source ${forge-inputs.inputs.nix-utils}/nix-develop-interactive.bash";
+                  shellHook = "source ${forge-inputs.nix-utils}/nix-develop-interactive.bash";
                 }
                 //
                   # Warning(co-existence): `extraAttrs` is overridden by the builder's options.


### PR DESCRIPTION
Closes https://github.com/ngi-nix/forge/issues/847