### PR TITLE
Docs: Add discussion on re-exporting packages and make scopes clearer.

### DIFF
--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -53,12 +53,16 @@ Start the recipe with the following content:
       echo "with syntax highlighting"
       ```
     '';
-  };
 
-  # More configuration to be added here.
-  # ...
+    # More configuration to be added here.
+    # ...
+  };
 }
 ````
+
+::: {important}
+Ensure that the remainder of the application recipe is done within the `apps.app-name` block to avoid nasty infinite recursion errors.
+:::
 
 ### Links
 

--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -567,6 +567,24 @@ nix build .#apps.<app-name>.test-services-container --print-build-logs
 nix build .#apps.<app-name>.test-services-nixos --print-build-logs
 ```
 
+## Re-exporting packages
+
+If exposing a package already in nixpkgs, consider re-exporting the package using the new [`build.identityBuilder`](https://ngi.nixos.org/recipe/options?p=apps&p=pkgs&q=identi#pkgs.%3Cname%3E.build.identityBuilder.enable). This will allow the application to be accessed under the `pkgs` attribute path (i.e. `pkgs.<app-name>`). To do this, outside of the `apps.<app-name>` attribute set, add the following block:
+
+```nix
+pkgs.<app-name> = {
+  build.identityBuilder = {
+    enable = true;
+    derivation = pkgs.pkgsOriginal.<app-name>;
+  };
+};
+```
+
+::: {note}
+`pkgs.pkgsOriginal` will always provide packages from the original source of the `pkgs` attribute set (nixpkgs in almost in all cases).
+This is to clearly differentiate between packages provided in the forge (in `recipes/pkgs`), and packages from the original `pkgs`.
+:::
+
 ## Examples
 
 Browse the

--- a/docs/manuals/contributor/how_to/package_recipe.md
+++ b/docs/manuals/contributor/how_to/package_recipe.md
@@ -82,12 +82,16 @@ Start the package recipe with the following content:
     homePage = "https://project-website.org";
     mainProgram = "executable-name";
     license = lib.licenses.gpl3Only;
-  };
 
-  # More configuration to be added here.
-  # ...
+    # More configuration to be added here.
+    # ...
+  };
 }
 ```
+
+::: {important}
+Ensure that the remainder of the package recipe is done within the `pkgs.package-name` block to avoid nasty infinite recursion errors.
+:::
 
 ::: {note}
 Use the following command to get the list of all available licenses:


### PR DESCRIPTION
I fell into this trap more than once when not focused so felt it worthy to clarify (and the error messages are quite scary for beginners).

Credit to idea on re-exporting packages goes to @panchoh. 